### PR TITLE
Fix pastebin-python install in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 📦 Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --no-build-isolation -r requirements.txt
           pip install flake8 black isort mypy bandit safety pytest pytest-asyncio pytest-cov
       
       - name: 🎨 Code Formatting (Black)
@@ -156,7 +156,7 @@ jobs:
       - name: 📦 Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --no-build-isolation -r requirements.txt
           pip install pytest pytest-asyncio pytest-cov pytest-mock
       
       - name: 🧪 Run Tests


### PR DESCRIPTION
Add `--no-build-isolation` flag to `pip install` to fix CI/CD dependency installation failures.

The `pastebin-python` package was failing to build during CI due to a `ModuleNotFoundError` in an isolated build environment. Adding `--no-build-isolation` instructs pip to use the existing environment for building, resolving this packaging issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-970e934b-ce80-4840-a4a5-1dc1723e4437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-970e934b-ce80-4840-a4a5-1dc1723e4437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

