### PR TITLE
Remove problematic telegram package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 
 # Core Telegram Bot
 python-telegram-bot==20.7
-telegram==0.0.1
 
 # Database
 pymongo==4.6.1


### PR DESCRIPTION
Remove `telegram==0.0.1` from `requirements.txt` to fix CI/CD dependency installation failures.

The `telegram==0.0.1` package was causing `error: invalid command 'bdist_wheel'` during CI/CD dependency installation. It is an old, unofficial package that is not needed and conflicts with `python-telegram-bot`, which is the correct dependency. Removing it resolves the build issue and avoids conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-5818cd71-29b4-4d6a-b3f9-71c49496eaa4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5818cd71-29b4-4d6a-b3f9-71c49496eaa4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

