### PR TITLE
Install wheel before other dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       - name: 📦 Install Dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install wheel
           pip install --no-build-isolation -r requirements.txt
           pip install flake8 black isort mypy bandit safety pytest pytest-asyncio pytest-cov
       
@@ -156,6 +157,7 @@ jobs:
       - name: 📦 Install Dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install wheel
           pip install --no-build-isolation -r requirements.txt
           pip install pytest pytest-asyncio pytest-cov pytest-mock
       


### PR DESCRIPTION
Install `wheel` package separately in CI/CD workflow to resolve `bdist_wheel` errors during dependency installation.

The `wheel` package is required for building certain Python packages from source. Installing it explicitly before `pip install -r requirements.txt` ensures it's available, preventing `error: invalid command 'bdist_wheel'` which occurs when `pip` attempts to build packages without `wheel` being present.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5c17399-474a-4a8a-b3ee-a414473cf31d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5c17399-474a-4a8a-b3ee-a414473cf31d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

