### PR TITLE
Add delay to fix image not found

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,9 @@ jobs:
           cache-to: type=gha,mode=max
           target: production
       
+      - name: ⏳ Wait for image to be available in registry
+        run: sleep 15
+      
       - name: 🛡️ Run Security Scan
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
Add a 15-second delay in CI/CD to resolve 'Image Not Found' errors during Trivy security scans.

The Trivy security scan step was failing due to a race condition where it attempted to pull the Docker image immediately after it was pushed to the registry, before it was fully available. This resulted in `MANIFEST_UNKNOWN` errors and subsequent failures in the pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-2235b33e-bbbd-48d3-ae89-e69b2410c3b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2235b33e-bbbd-48d3-ae89-e69b2410c3b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

