### PR TITLE
Fix cleanup job dependency and package name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -512,13 +512,14 @@ jobs:
     name: 🧹 Cleanup
     runs-on: ubuntu-latest
     # needs: [notify]
+    needs: [deploy-staging, deploy-production]
     if: always()
     
     steps:
       - name: 🗑️ Delete Old Images
         uses: actions/delete-package-versions@v4
         with:
-          package-name: ${{ env.IMAGE_NAME }}
+          package-name: 'codebot'
           package-type: 'container'
           min-versions-to-keep: 10
           delete-only-untagged-versions: true


### PR DESCRIPTION
Fix `cleanup` job in deploy workflow by updating its dependencies and correcting the package name to prevent failures.

The `cleanup` job was failing due to a broken dependency (`notify` job was removed) and an incorrect package name (using `IMAGE_NAME` which resolved to an incorrect case). This PR updates the `needs` to depend on `deploy-staging` and `deploy-production` and hardcodes the correct lowercase package name `codebot`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d140419e-8339-4b65-bb5f-5b38b29b959c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d140419e-8339-4b65-bb5f-5b38b29b959c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

