### PR TITLE
Add build tools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,9 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # התקנת תלויות Alpine
 RUN apk add --no-cache \
+    gcc \
+    python3-dev \
+    musl-dev \
     cairo \
     pango \
     gdk-pixbuf \


### PR DESCRIPTION
Add `gcc` and Python development libraries to `Dockerfile` to fix build failures for packages requiring compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-eccd2210-ef3f-4bb1-82a5-1e3dcde1e7e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eccd2210-ef3f-4bb1-82a5-1e3dcde1e7e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

