### PR TITLE
Add linux-headers to dockerfile for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,8 @@ RUN apk add --no-cache \
     fontconfig \
     ttf-dejavu \
     tzdata \
-    curl
+    curl \
+    linux-headers
 
 # יצירת משתמש
 RUN addgroup -g 1000 botuser && \


### PR DESCRIPTION
Add `linux-headers` to Dockerfile to fix `psutil` compilation errors on Render.

---
<a href="https://cursor.com/background-agent?bcId=bc-85e5b89f-84a6-4682-8050-4b114a7f4435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85e5b89f-84a6-4682-8050-4b114a7f4435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

