### PR TITLE
Fix list command key error

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ class CodeKeeperBot:
             description = file_data.get('description', '')
             
             response += f"**{i}. {file_data['file_name']}**\n"
-            response += f"🔤 שפה: {file_data['language']}\n"
+            response += f"🔤 שפה: {file_data['programming_language']}\n"
             
             if description:
                 response += f"📝 תיאור: {description}\n"


### PR DESCRIPTION
Fix `KeyError` in `list` command by updating the key from `language` to `programming_language`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbc0cb7e-b2c6-4542-a88e-6fbc1c62c7a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbc0cb7e-b2c6-4542-a88e-6fbc1c62c7a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

