### PR TITLE
Comment out missing command handlers

### DIFF
--- a/bot_handlers.py
+++ b/bot_handlers.py
@@ -40,22 +40,22 @@ class AdvancedBotHandlers:
         
         # פקודות גרסאות
         self.application.add_handler(CommandHandler("versions", self.versions_command))
-        self.application.add_handler(CommandHandler("restore", self.restore_command))
-        self.application.add_handler(CommandHandler("diff", self.diff_command))
+        # self.application.add_handler(CommandHandler("restore", self.restore_command))
+        # self.application.add_handler(CommandHandler("diff", self.diff_command))
         
         # פקודות שיתוף
         self.application.add_handler(CommandHandler("share", self.share_command))
-        self.application.add_handler(CommandHandler("export", self.export_command))
+        # self.application.add_handler(CommandHandler("export", self.export_command))
         self.application.add_handler(CommandHandler("download", self.download_command))
         
         # פקודות ניתוח
         self.application.add_handler(CommandHandler("analyze", self.analyze_command))
         self.application.add_handler(CommandHandler("validate", self.validate_command))
-        self.application.add_handler(CommandHandler("minify", self.minify_command))
+        # self.application.add_handler(CommandHandler("minify", self.minify_command))
         
         # פקודות ארגון
         self.application.add_handler(CommandHandler("tags", self.tags_command))
-        self.application.add_handler(CommandHandler("languages", self.languages_command))
+        # self.application.add_handler(CommandHandler("languages", self.languages_command))
         self.application.add_handler(CommandHandler("recent", self.recent_command))
         
         # Callback handlers לכפתורים


### PR DESCRIPTION
Disable unimplemented bot commands to prevent `AttributeError` crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc2ad16e-bd9d-416b-a6cf-5d0472e5fa25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc2ad16e-bd9d-416b-a6cf-5d0472e5fa25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

