### PR TITLE
Fix div tag issue in code highlighting

### DIFF
--- a/code_processor.py
+++ b/code_processor.py
@@ -343,12 +343,13 @@ class CodeProcessor:
                     style=config.HIGHLIGHT_THEME,
                     linenos=True,
                     cssclass="highlight",
-                    noclasses=True
+                    noclasses=True,
+                    nowrap=True
                 )
             elif output_format == 'terminal':
                 formatter = TerminalFormatter()
             else:
-                formatter = HtmlFormatter(style=config.HIGHLIGHT_THEME)
+                formatter = HtmlFormatter(style=config.HIGHLIGHT_THEME, nowrap=True)
             
             # יצירת הקוד המודגש
             highlighted = highlight(code, lexer, formatter)


### PR DESCRIPTION
Adds `nowrap=True` to `HtmlFormatter` to resolve `BadRequest` errors in Telegram caused by `pygments` generating unsupported `div` tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-484ebe6a-f560-46dc-a8d7-5e672cee9e94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-484ebe6a-f560-46dc-a8d7-5e672cee9e94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

