### PR TITLE
Remove syntax highlighting from show command

### DIFF
--- a/bot_handlers.py
+++ b/bot_handlers.py
@@ -84,16 +84,21 @@ class AdvancedBotHandlers:
             )
             return
         
-        # קריאה נכונה לפונקציית ההדגשה עם שם השדה המעודכן
-        highlighted_code = code_processor.highlight_code(
+        # קבל את הקוד המקורי (הפונקציה highlight_code תחזיר אותו כפי שהוא)
+        original_code = code_processor.highlight_code(
             file_data['code'],
-            file_data['programming_language'], 
+            file_data['programming_language'],
             'html'
         )
 
-        # בניית התגובה עם הימלטות (escape) לשם הקובץ למניעת שגיאות
+        # בצע הימלטות לתוכן הקוד כדי למנוע שגיאות
+        escaped_code = html.escape(original_code)
+
+        # עטוף את הקוד הנקי בתגיות <pre><code> שטלגרם תומך בהן
         response_text = f"""<b>File:</b> <code>{html.escape(file_data['file_name'])}</code>
-{highlighted_code}
+<b>Language:</b> {file_data['programming_language']}
+
+<pre><code>{escaped_code}</code></pre>
 """
         
         # יצירת כפתורי פעולה

--- a/code_processor.py
+++ b/code_processor.py
@@ -325,41 +325,8 @@ class CodeProcessor:
         return 'text'
     
     def highlight_code(self, code: str, programming_language: str, output_format: str = 'html') -> str:
-        """הדגשת תחביר של קוד"""
-        
-        try:
-            # קבלת הלקסר המתאים
-            if programming_language == 'text':
-                lexer = get_lexer_by_name('text', stripnl=False)
-            else:
-                try:
-                    lexer = get_lexer_by_name(programming_language, stripnl=False)
-                except ClassNotFound:
-                    lexer = get_lexer_by_name('text', stripnl=False)
-            
-            # בחירת פורמטר
-            if output_format == 'html':
-                formatter = HtmlFormatter(
-                    style=config.HIGHLIGHT_THEME,
-                    linenos=True,
-                    cssclass="highlight",
-                    noclasses=True,
-                    nowrap=True
-                )
-            elif output_format == 'terminal':
-                formatter = TerminalFormatter()
-            else:
-                formatter = HtmlFormatter(style=config.HIGHLIGHT_THEME, nowrap=True)
-            
-            # יצירת הקוד המודגש
-            highlighted = highlight(code, lexer, formatter)
-            
-            logger.info(f"הודגש קוד בשפה {programming_language} בפורמט {output_format}")
-            return highlighted
-            
-        except Exception as e:
-            logger.error(f"שגיאה בהדגשת קוד: {e}")
-            return f"<pre><code>{code}</code></pre>"
+        """Placeholder function. No longer performs highlighting to avoid Telegram API errors. Returns the original code unchanged."""
+        return code
     
     def create_code_image(self, code: str, programming_language: str, 
                          width: int = 800, font_size: int = 12) -> bytes:


### PR DESCRIPTION
Remove syntax highlighting to fix `/show` command failures caused by Telegram API's lack of support for `pygments` generated HTML tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-613ad679-adb6-449c-8919-eb092ae3cde2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-613ad679-adb6-449c-8919-eb092ae3cde2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

