### PR TITLE
Fix database access in lock mechanism

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def cleanup_mongo_lock():
     Runs on exit to remove the lock document from MongoDB, allowing a new instance to start.
     """
     try:
-        db[LOCK_COLLECTION].delete_one({"_id": BOT_LOCK_ID})
+        db.db[LOCK_COLLECTION].delete_one({"_id": BOT_LOCK_ID})
         print("INFO: Bot instance lock released successfully.")
     except Exception as e:
         print(f"ERROR: Could not release bot instance lock on exit: {e}")
@@ -51,7 +51,7 @@ def manage_mongo_lock():
     try:
         # Attempt to insert the lock document. This is an atomic operation.
         # If a document with this _id already exists, it will raise DuplicateKeyError.
-        db[LOCK_COLLECTION].insert_one(lock_doc)
+        db.db[LOCK_COLLECTION].insert_one(lock_doc)
         print("INFO: Bot instance lock acquired successfully.")
         # Register the cleanup function to run when the script exits gracefully.
         atexit.register(cleanup_mongo_lock)


### PR DESCRIPTION
Fixes `TypeError: 'DatabaseManager' object is not subscriptable` by correcting database object access in MongoDB lock functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f4908eb-6c44-4a2e-b7a5-02c7b1b86d88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f4908eb-6c44-4a2e-b7a5-02c7b1b86d88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

