### PR TITLE
Add db argument to get_save_conversation_handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -456,7 +456,7 @@ def main() -> None:
     bot = CodeKeeperBot()
 
     # מוסיף את ה-ConversationHandler עבור הכפתורים החדשים
-    conv_handler = get_save_conversation_handler()
+    conv_handler = get_save_conversation_handler(db)
     bot.application.add_handler(conv_handler)
 
     # מפעיל את הבוט


### PR DESCRIPTION
Pass the `db` object to `get_save_conversation_handler` to provide a missing required parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-892899e0-09d5-40e6-a980-7f276932507a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-892899e0-09d5-40e6-a980-7f276932507a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

