### PR TITLE
Fix activity reporter initialization

### DIFF
--- a/activity_reporter.py
+++ b/activity_reporter.py
@@ -5,7 +5,7 @@ from pymongo import MongoClient
 from datetime import datetime, timezone
 
 class SimpleActivityReporter:
-    def init(self, mongodb_uri, service_id, service_name=None):
+    def __init__(self, mongodb_uri, service_id, service_name=None):
         """
         mongodb_uri: חיבור למונגו (אותו מהבוט המרכזי)
         service_id: מזהה השירות ב-Render


### PR DESCRIPTION
Rename `init` method to `__init__` to correctly initialize the `SimpleActivityReporter` class.

---
<a href="https://cursor.com/background-agent?bcId=bc-553c95ef-5cf7-444d-882b-7edd1a0fa658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-553c95ef-5cf7-444d-882b-7edd1a0fa658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

