### PR TITLE
Remove duplicate callback query handler import

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,7 +172,7 @@ class CodeKeeperBot:
         # --- רק אחרי כל ה-handlers של GitHub, הוסף את ה-handler הגלובלי ---
         # הוסף CallbackQueryHandler גלובלי לטיפול בכפתורים
         from conversation_handlers import handle_callback_query
-        from telegram.ext import CallbackQueryHandler
+        # CallbackQueryHandler כבר מיובא בתחילת הקובץ!
         self.application.add_handler(CallbackQueryHandler(handle_callback_query))
         logger.info("CallbackQueryHandler גלובלי נוסף")
 


### PR DESCRIPTION
Remove duplicate import of `CallbackQueryHandler` to resolve redundancy and ensure cleaner code.

---
<a href="https://cursor.com/background-agent?bcId=bc-a216369c-ceaf-4bd0-bf8d-dfe0d91e04b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a216369c-ceaf-4bd0-bf8d-dfe0d91e04b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

