### PR TITLE
Add handler for github token

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,6 +168,28 @@ class CodeKeeperBot:
         self.application.add_handler(upload_conv_handler)
         
         logger.info("✅ GitHub handler נוסף בהצלחה")
+        
+        # Handler נפרד לטיפול בטוקן GitHub
+        async def handle_github_token(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            text = update.message.text
+            if text.startswith('ghp_') or text.startswith('github_pat_'):
+                user_id = update.message.from_user.id
+                if user_id not in github_handler.user_sessions:
+                    github_handler.user_sessions[user_id] = {}
+                github_handler.user_sessions[user_id]['github_token'] = text
+                await update.message.reply_text(
+                    "✅ טוקן נשמר בהצלחה!\n"
+                    "כעת תוכל לגשת לריפוזיטוריז הפרטיים שלך.\n\n"
+                    "שלח /github כדי לחזור לתפריט."
+                )
+                return
+        
+        # הוסף את ה-handler
+        self.application.add_handler(
+            MessageHandler(filters.Regex('^(ghp_|github_pat_)'), handle_github_token),
+            group=0  # עדיפות גבוהה
+        )
+        logger.info("✅ GitHub token handler נוסף בהצלחה")
 
         # --- רק אחרי כל ה-handlers של GitHub, הוסף את ה-handler הגלובלי ---
         # הוסף CallbackQueryHandler גלובלי לטיפול בכפתורים


### PR DESCRIPTION
Add a new handler to correctly process and save GitHub tokens sent as plain text messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fbeca43-9ca6-4449-a390-69cf399ee6b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fbeca43-9ca6-4449-a390-69cf399ee6b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

