### PR TITLE
Fix f-string backslash errors

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -636,12 +636,13 @@ async def receive_new_code(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 keyboard = [[InlineKeyboardButton("📚 חזרה לקבצים גדולים", callback_data="show_large_files")]]
                 reply_markup = InlineKeyboardMarkup(keyboard)
                 
+                lines_count = len(new_code.split('\n'))
                 await update.message.reply_text(
                     f"✅ **הקובץ הגדול עודכן בהצלחה!**\n\n"
                     f"📄 **קובץ:** `{file_name}`\n"
                     f"{emoji} **שפה:** {language}\n"
                     f"💾 **גודל חדש:** {len(new_code):,} תווים\n"
-                    f"📏 **שורות:** {len(new_code.split('\n')):,}",
+                    f"📏 **שורות:** {lines_count:,}",
                     reply_markup=reply_markup,
                     parse_mode='Markdown'
                 )

--- a/main.py
+++ b/main.py
@@ -496,12 +496,13 @@ class CodeKeeperBot:
                     ]
                     reply_markup = InlineKeyboardMarkup(keyboard)
                     
+                    lines_count = len(content.split('\n'))
                     await update.message.reply_text(
                         f"✅ **הקובץ נשמר בהצלחה!**\n\n"
                         f"📄 **שם:** `{file_name}`\n"
                         f"{emoji} **שפה:** {language}\n"
                         f"💾 **גודל:** {len(content):,} תווים\n"
-                        f"📏 **שורות:** {len(content.split('\n')):,}\n\n"
+                        f"📏 **שורות:** {lines_count:,}\n\n"
                         "💡 הקובץ נשמר במערכת הקבצים הגדולים",
                         reply_markup=reply_markup,
                         parse_mode='Markdown'


### PR DESCRIPTION
Refactor f-strings to avoid `flake8 E999` errors by extracting expressions with backslashes into variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-01814b91-99b8-44a1-b153-503cc83bd1c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01814b91-99b8-44a1-b153-503cc83bd1c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

