### PR TITLE
Fix bot file permissions and content access

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -483,7 +483,16 @@ class GitHubMenuHandler:
             logger.info(f"📄 מעלה קובץ שמור: {file_data['file_name']}")
             
             # קודד את התוכן ל-base64
-            content = file_data['content']
+            # בדוק כמה אפשרויות לשדה content
+            content = file_data.get('content') or \
+                     file_data.get('code') or \
+                     file_data.get('data') or \
+                     file_data.get('file_content', '')
+            
+            if not content:
+                await update.callback_query.edit_message_text("❌ תוכן הקובץ ריק או לא נמצא")
+                return
+                
             if isinstance(content, str):
                 # אם התוכן כבר מחרוזת, קודד אותו
                 encoded_content = base64.b64encode(content.encode('utf-8')).decode('utf-8')

--- a/main.py
+++ b/main.py
@@ -116,8 +116,13 @@ class CodeKeeperBot:
     """המחלקה הראשית של הבוט"""
     
     def __init__(self):
+        # יצירת תיקייה זמנית עם הרשאות כתיבה
+        DATA_DIR = "/tmp"
+        if not os.path.exists(DATA_DIR):
+            os.makedirs(DATA_DIR, exist_ok=True)
+            
         # יצירת persistence לשמירת נתונים בין הפעלות
-        persistence = PicklePersistence(filepath="bot_data.pickle")
+        persistence = PicklePersistence(filepath=f"{DATA_DIR}/bot_data.pickle")
         
         self.application = (
             Application.builder()


### PR DESCRIPTION
Resolves `PermissionError` for `bot_data.pickle` and `KeyError: 'content'` by adjusting file paths and content retrieval logic.

The `KeyError` occurred because the `file_data` dictionary sometimes used keys like 'code' or 'data' instead of 'content' for the file's actual content, leading to crashes. The `PermissionError` was due to the bot attempting to write its persistence file in a directory without sufficient permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7a48806-7af0-47ba-8231-f6112c56fca8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7a48806-7af0-47ba-8231-f6112c56fca8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

