### PR TITLE
Fix file upload logic for github

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -76,6 +76,9 @@ class GitHubMenuHandler:
         """מציג תפריט GitHub"""
         user_id = update.effective_user.id
         
+        # סמן שאנחנו בתפריט GitHub
+        context.user_data['in_github_menu'] = True
+        
         if user_id not in self.user_sessions:
             self.user_sessions[user_id] = {}
         
@@ -162,12 +165,20 @@ class GitHubMenuHandler:
                 )
             else:
                 folder_display = session.get('selected_folder') or 'root'
+                
+                # הוסף כפתור לבחירת קובץ
+                keyboard = [
+                    [InlineKeyboardButton("📎 בחר קובץ מהמכשיר", switch_inline_query_current_chat="")],
+                    [InlineKeyboardButton("❌ ביטול", callback_data="github_menu")]
+                ]
+                
                 await query.edit_message_text(
                     f"📤 *העלאת קובץ לריפו:*\n"
                     f"`{session['selected_repo']}`\n"
                     f"📂 תיקייה: `{folder_display}`\n\n"
-                    f"שלח לי קובץ להעלאה:",
-                    parse_mode='Markdown'
+                    f"שלח לי קובץ להעלאה או לחץ לבחירה:",
+                    parse_mode='Markdown',
+                    reply_markup=InlineKeyboardMarkup(keyboard)
                 )
                 return FILE_UPLOAD
         
@@ -182,7 +193,7 @@ class GitHubMenuHandler:
             file_id = query.data.split("_")[2]
             await self.handle_saved_file_upload(update, context, file_id)
             
-        elif query.data == "back_to_menu":
+        elif query.data == "back_to_menu" or query.data == "github_menu":
             await self.github_menu_command(update, context)
             
         elif query.data == "noop":
@@ -243,6 +254,8 @@ class GitHubMenuHandler:
                 await query.edit_message_text(f"✅ תיקייה עודכנה ל: `{session['selected_folder']}`", parse_mode='Markdown')
                 
         elif query.data == 'close_menu':
+            # סמן שיצאנו מתפריט GitHub
+            context.user_data['in_github_menu'] = False
             await query.edit_message_text("👋 התפריט נסגר")
             
         elif query.data.startswith('repo_'):

--- a/main.py
+++ b/main.py
@@ -232,8 +232,17 @@ class CodeKeeperBot:
         self.application.add_handler(CommandHandler("stats", self.stats_command))
         
         # --- שלב 3: רישום handler לקבצים ---
+        # Handler מותאם שבודק אם אנחנו בתפריט GitHub
+        async def smart_document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            if context.user_data.get('in_github_menu'):
+                # אנחנו בתפריט GitHub - העבר ל-handler של GitHub
+                await github_handler.handle_file_upload(update, context)
+            else:
+                # תפריט רגיל - שמור מקומית
+                await self.handle_document(update, context)
+        
         self.application.add_handler(
-            MessageHandler(filters.Document.ALL, self.handle_document)
+            MessageHandler(filters.Document.ALL, smart_document_handler)
         )
         
         # --- שלב 4: רישום המטפל הכללי בסוף ---
@@ -249,6 +258,9 @@ class CodeKeeperBot:
     
     async def help_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """פקודת עזרה מפורטת"""
+        # איפוס flag של תפריט GitHub
+        context.user_data['in_github_menu'] = False
+        
         reporter.report_activity(update.effective_user.id)
         response = """
 📚 <b>רשימת הפקודות המלאה:</b>
@@ -280,6 +292,9 @@ class CodeKeeperBot:
     
     async def save_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """פקודת שמירת קוד"""
+        # איפוס flag של תפריט GitHub
+        context.user_data['in_github_menu'] = False
+        
         reporter.report_activity(update.effective_user.id)
         user_id = update.effective_user.id
         
@@ -360,6 +375,9 @@ class CodeKeeperBot:
     
     async def search_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """חיפוש קטעי קוד"""
+        # איפוס flag של תפריט GitHub
+        context.user_data['in_github_menu'] = False
+        
         reporter.report_activity(update.effective_user.id)
         user_id = update.effective_user.id
         
@@ -415,6 +433,9 @@ class CodeKeeperBot:
     
     async def stats_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """הצגת סטטיסטיקות המשתמש"""
+        # איפוס flag של תפריט GitHub
+        context.user_data['in_github_menu'] = False
+        
         reporter.report_activity(update.effective_user.id)
         user_id = update.effective_user.id
         
@@ -452,6 +473,11 @@ class CodeKeeperBot:
     async def handle_document(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """טיפול בקבצים שנשלחים לבוט"""
         try:
+            # בדוק אם אנחנו בתפריט GitHub
+            if context.user_data.get('in_github_menu'):
+                # אנחנו בתפריט GitHub - תן ל-handler של GitHub לטפל בזה
+                return
+            
             document = update.message.document
             user_id = update.effective_user.id
             


### PR DESCRIPTION
Implement distinct file handling for local saves and GitHub uploads based on user context.

Previously, files uploaded from the GitHub menu were incorrectly saved locally instead of being uploaded to GitHub. This PR introduces an `in_github_menu` flag in `context.user_data` and a smart document handler to correctly route file uploads: files are now uploaded to GitHub when the flag is true, and saved locally otherwise. It also adds a "Choose file from device" button and ensures the flag is reset when exiting the GitHub menu or using other commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-8775f07b-4967-4b0d-9bc3-2f035f813d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8775f07b-4967-4b0d-9bc3-2f035f813d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

