### PR TITLE
Show follow-up menu after repo selection

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -277,11 +277,10 @@ class GitHubMenuHandler:
             else:
                 repo_name = query.data.replace('repo_', '')
                 session['selected_repo'] = repo_name
-                await query.edit_message_text(
-                    f"✅ ריפו נבחר: `{repo_name}`\n\n"
-                    f"כעת תוכל להעלות קבצים!",
-                    parse_mode='Markdown'
-                )
+                
+                # הצג את התפריט המלא אחרי בחירת הריפו
+                await self.github_menu_command(update, context)
+                return
     
     async def show_repo_selection(self, query, context: ContextTypes.DEFAULT_TYPE):
         """Show repository selection menu"""
@@ -756,10 +755,9 @@ class GitHubMenuHandler:
         
         elif '/' in text:
             session['selected_repo'] = text
-            await update.message.reply_text(
-                f"✅ ריפו הוגדר: `{text}`",
-                parse_mode='Markdown'
-            )
+            
+            # הצג את התפריט המלא אחרי הגדרת הריפו
+            await self.github_menu_command(update, context)
             return ConversationHandler.END
         
         else:


### PR DESCRIPTION
Display the GitHub menu immediately after a repository is selected to improve user flow.

Previously, after selecting a repository, the bot only sent a confirmation message. This required users to manually re-enter the `/github` command to access further options. This change streamlines the user experience by directly presenting the available actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4390e713-bcc9-49b8-aebe-2efb5b227e97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4390e713-bcc9-49b8-aebe-2efb5b227e97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

