### PR TITLE
Fix github menu and status messages

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -42,7 +42,8 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         "🔹 חיפוש והצגה חכמה\n"
         "🔹 הורדה וניהול מלא\n"
         "🔹 העלאת קבצים ל-GitHub\n\n"
-        "בחר פעולה מהכפתורים החכמים למטה:"
+        "בחר פעולה מהתפריט למטה 👇\n\n"
+        "🔧 לכל תקלה בבוט נא לשלוח הודעה ל-@moominAmir"
     )
     
     keyboard = ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True)

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -90,12 +90,12 @@ class GitHubMenuHandler:
         # בנה הודעת סטטוס
         status_msg = "🔧 *GitHub Integration Menu*\n\n"
         
-        if 'github_token' in session:
+        if session.get('github_token'):
             status_msg += "✅ טוקן מוגדר\n"
         else:
             status_msg += "❌ טוקן לא מוגדר\n"
         
-        if 'selected_repo' in session:
+        if session.get('selected_repo'):
             status_msg += f"📁 ריפו: `{session['selected_repo']}`\n"
             folder_display = session.get('selected_folder') or 'root'
             status_msg += f"📂 תיקייה: `{folder_display}`\n"
@@ -105,14 +105,14 @@ class GitHubMenuHandler:
         keyboard = []
         
         # כפתור הגדרת טוקן
-        if 'github_token' not in session:
+        if not session.get('github_token'):
             keyboard.append([InlineKeyboardButton("🔑 הגדר טוקן GitHub", callback_data="set_token")])
         
         # כפתור בחירת ריפו
         keyboard.append([InlineKeyboardButton("📁 בחר ריפו", callback_data="select_repo")])
         
         # כפתורי העלאה - מוצגים רק אם יש ריפו נבחר
-        if 'selected_repo' in session:
+        if session.get('selected_repo'):
             keyboard.append([
                 InlineKeyboardButton("📚 העלה מהקבצים השמורים", callback_data="upload_saved")
             ])
@@ -205,13 +205,17 @@ class GitHubMenuHandler:
             current_folder = session.get('selected_folder') or 'root'
             has_token = "✅" if session.get('github_token') else "❌"
             
+            keyboard = [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+            reply_markup = InlineKeyboardMarkup(keyboard)
+            
             await query.edit_message_text(
                 f"📊 *הגדרות נוכחיות:*\n\n"
                 f"📁 ריפו: `{current_repo}`\n"
                 f"📂 תיקייה: `{current_folder}`\n"
                 f"🔑 טוקן מוגדר: {has_token}\n\n"
                 f"💡 טיפ: השתמש ב-'בחר תיקיית יעד' כדי לשנות את מיקום ההעלאה",
-                parse_mode='Markdown'
+                parse_mode='Markdown',
+                reply_markup=reply_markup
             )
             
         elif query.data == 'set_token':
@@ -230,7 +234,8 @@ class GitHubMenuHandler:
                 [InlineKeyboardButton("📂 docs", callback_data='folder_docs')],
                 [InlineKeyboardButton("📂 assets", callback_data='folder_assets')],
                 [InlineKeyboardButton("📂 images", callback_data='folder_images')],
-                [InlineKeyboardButton("✏️ אחר (הקלד ידנית)", callback_data='folder_custom')]
+                [InlineKeyboardButton("✏️ אחר (הקלד ידנית)", callback_data='folder_custom')],
+                [InlineKeyboardButton("🔙 חזור לתפריט", callback_data='github_menu')]
             ]
             reply_markup = InlineKeyboardMarkup(keyboard)
             
@@ -249,10 +254,22 @@ class GitHubMenuHandler:
                 return FOLDER_SELECT
             elif folder == 'root':
                 session['selected_folder'] = None
-                await query.edit_message_text("✅ תיקייה עודכנה ל: `root` (ראשי)", parse_mode='Markdown')
+                keyboard = [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+                reply_markup = InlineKeyboardMarkup(keyboard)
+                await query.edit_message_text(
+                    "✅ תיקייה עודכנה ל: `root` (ראשי)", 
+                    parse_mode='Markdown',
+                    reply_markup=reply_markup
+                )
             else:
                 session['selected_folder'] = folder.replace('_', '/')
-                await query.edit_message_text(f"✅ תיקייה עודכנה ל: `{session['selected_folder']}`", parse_mode='Markdown')
+                keyboard = [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+                reply_markup = InlineKeyboardMarkup(keyboard)
+                await query.edit_message_text(
+                    f"✅ תיקייה עודכנה ל: `{session['selected_folder']}`", 
+                    parse_mode='Markdown',
+                    reply_markup=reply_markup
+                )
                 
         elif query.data == 'github_menu':
             # חזרה לתפריט הראשי של GitHub
@@ -295,7 +312,7 @@ class GitHubMenuHandler:
             
         session = self.user_sessions.get(user_id, {})
         
-        if 'github_token' not in session:
+        if not session.get('github_token'):
             if query:
                 await query.answer("❌ נא להגדיר טוקן קודם")
             else:
@@ -437,7 +454,7 @@ class GitHubMenuHandler:
         user_id = update.effective_user.id
         session = self.user_sessions.get(user_id, {})
         
-        if 'selected_repo' not in session:
+        if not session.get('selected_repo'):
             await update.callback_query.answer("❌ נא לבחור ריפו קודם")
             return
         
@@ -477,7 +494,7 @@ class GitHubMenuHandler:
         user_id = update.effective_user.id
         session = self.user_sessions.get(user_id, {})
         
-        if 'selected_repo' not in session:
+        if not session.get('selected_repo'):
             await update.callback_query.answer("❌ נא לבחור ריפו קודם")
             return
         
@@ -764,16 +781,22 @@ class GitHubMenuHandler:
             # טיפול בהגדרת תיקייה
             if text.strip() in ['/', '']:
                 session['selected_folder'] = None
+                keyboard = [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+                reply_markup = InlineKeyboardMarkup(keyboard)
                 await update.message.reply_text(
                     "✅ תיקייה הוגדרה: `root` (ראשי)",
-                    parse_mode='Markdown'
+                    parse_mode='Markdown',
+                    reply_markup=reply_markup
                 )
             else:
                 # הסר / מיותרים
                 folder = text.strip().strip('/')
                 session['selected_folder'] = folder
+                keyboard = [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+                reply_markup = InlineKeyboardMarkup(keyboard)
                 await update.message.reply_text(
                     f"✅ תיקייה הוגדרה: `{folder}`",
-                    parse_mode='Markdown'
+                    parse_mode='Markdown',
+                    reply_markup=reply_markup
                 )
             return ConversationHandler.END

--- a/main.py
+++ b/main.py
@@ -271,23 +271,22 @@ class CodeKeeperBot:
 • <code>/list</code> - הצגת כל הקבצים שלך.
 • <code>/show &lt;filename&gt;</code> - הצגת קובץ עם הדגשת תחביר וכפתורי פעולה.
 • <code>/edit &lt;filename&gt;</code> - עריכת קוד של קובץ קיים.
-• <code>/delete &lt;filename&gt;</code> - מחיקת קובץ וכל הגרסאות שלו.
-
-<b>גרסאות וניתוח:</b>
-• <code>/versions &lt;filename&gt;</code> - הצגת כל הגרסאות של קובץ.
-• <code>/restore &lt;filename&gt; &lt;version&gt;</code> - שחזור גרסה ישנה.
-• <code>/analyze &lt;filename&gt;</code> - ניתוח סטטיסטי של קוד.
-• <code>/validate &lt;filename&gt;</code> - בדיקת תחביר בסיסית.
-
-<b>שיתוף וארגון:</b>
-• <code>/share &lt;filename&gt;</code> - קבלת אפשרויות שיתוף.
-• <code>/download &lt;filename&gt;</code> - הורדת הקובץ למחשב שלך.
+• <code>/delete &lt;filename&gt;</code> - מחיקת קובץ.
+• <code>/rename &lt;old&gt; &lt;new&gt;</code> - שינוי שם קובץ.
+• <code>/download &lt;filename&gt;</code> - הורדת קובץ כמסמך.
+• <code>/github</code> - תפריט העלאה ל-GitHub.
+    
+<b>חיפוש וסינון:</b>
+• <code>/recent</code> - הצגת קבצים שעודכנו לאחרונה.
+• <code>/stats</code> - סטטיסטיקות אישיות.
 • <code>/tags &lt;filename&gt; &lt;tag1&gt;,&lt;tag2&gt;</code> - הוספת תגיות לקובץ.
 • <code>/search &lt;query&gt;</code> - חיפוש טקסטואלי בקוד שלך.
     
 <b>מידע כללי:</b>
 • <code>/recent</code> - הצגת קבצים שעודכנו לאחרונה.
 • <code>/help</code> - הצגת הודעה זו.
+
+🔧 <b>לכל תקלה בבוט נא לשלוח הודעה ל-@moominAmir</b>
 """
         await update.message.reply_text(response, parse_mode=ParseMode.HTML)
     
@@ -829,11 +828,18 @@ def setup_handlers(application: Application, db_manager):  # noqa: D401
     async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):  # noqa: D401
         reporter.report_activity(update.effective_user.id)
         reply_markup = ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True)
-        await update.message.reply_text("👋 שלום! הבוט מוכן לשימוש.", reply_markup=reply_markup)
+        await update.message.reply_text(
+            "👋 שלום! הבוט מוכן לשימוש.\n\n"
+            "🔧 לכל תקלה בבוט נא לשלוח הודעה ל-@moominAmir", 
+            reply_markup=reply_markup
+        )
 
     async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):  # noqa: D401
         reporter.report_activity(update.effective_user.id)
-        await update.message.reply_text("ℹ️ השתמש ב/start כדי להתחיל.")
+        await update.message.reply_text(
+            "ℹ️ השתמש ב/start כדי להתחיל.\n\n"
+            "🔧 לכל תקלה בבוט נא לשלוח הודעה ל-@moominAmir"
+        )
 
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("help", help_command))


### PR DESCRIPTION
Enhance GitHub menu usability by ensuring automatic menu return and accurate token/repo status display.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6a157ff-13ed-499a-85b8-4409bab29711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6a157ff-13ed-499a-85b8-4409bab29711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

