### PR TITLE
Add return to menu button after upload

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -205,19 +205,17 @@ class GitHubMenuHandler:
             current_folder = session.get('selected_folder') or 'root'
             has_token = "✅" if session.get('github_token') else "❌"
             
+            keyboard = [[InlineKeyboardButton("🔙 חזרה לתפריט", callback_data="github_menu")]]
+            
             await query.edit_message_text(
                 f"📊 *הגדרות נוכחיות:*\n\n"
                 f"📁 ריפו: `{current_repo}`\n"
                 f"📂 תיקייה: `{current_folder}`\n"
                 f"🔑 טוקן מוגדר: {has_token}\n\n"
-                f"💡 טיפ: השתמש ב-'בחר תיקיית יעד' כדי לשנות את מיקום ההעלאה\n\n"
-                f"⏳ חוזר לתפריט בעוד מספר שניות...",
-                parse_mode='Markdown'
+                f"💡 טיפ: השתמש ב-'בחר תיקיית יעד' כדי לשנות את מיקום ההעלאה",
+                parse_mode='Markdown',
+                reply_markup=InlineKeyboardMarkup(keyboard)
             )
-            
-            # המתן 3 שניות ואז הצג את התפריט
-            await asyncio.sleep(3)
-            await self.github_menu_command(update, context)
             
         elif query.data == 'set_token':
             await query.edit_message_text(

--- a/github_upload_fix.py
+++ b/github_upload_fix.py
@@ -182,7 +182,7 @@ async def upload_to_github_fixed(update, context, status_message):
         keyboard = [
             [InlineKeyboardButton("👁 צפה בקובץ", url=file_url)],
             [InlineKeyboardButton("📤 העלה עוד", callback_data="github_upload_new")],
-            [InlineKeyboardButton("🔙 תפריט GitHub", callback_data="github_menu")]
+            [InlineKeyboardButton("🔙 חזרה לתפריט", callback_data="github_menu")]
         ]
         
         await status_message.edit_text(


### PR DESCRIPTION
Adds "Back to Menu" buttons after GitHub upload and in current settings display for improved user control.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9149503-3c89-4023-ae14-e8f95c60587d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9149503-3c89-4023-ae14-e8f95c60587d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

