### PR TITLE
Fix analyze repo button functionality

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -151,6 +151,7 @@ class GitHubMenuHandler:
     async def handle_menu_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle menu button clicks"""
         query = update.callback_query
+        logger.info(f"📱 GitHub handler received callback: {query.data} from user {query.from_user.id}")
         await query.answer()
         
         user_id = query.from_user.id
@@ -208,15 +209,18 @@ class GitHubMenuHandler:
             await query.answer()  # לא עושה כלום, רק לכפתור התצוגה
                 
         elif query.data == 'analyze_repo':
+            logger.info(f"🔍 User {query.from_user.id} clicked 'analyze_repo' button")
             await self.show_analyze_repo_menu(update, context)
         
         elif query.data == 'analyze_current_repo':
             # נתח את הריפו הנבחר
+            logger.info(f"📊 User {query.from_user.id} analyzing current repo")
             session = self.get_user_session(query.from_user.id)
             repo_url = f"https://github.com/{session['selected_repo']}"
             await self.analyze_repository(update, context, repo_url)
         
         elif query.data == 'analyze_other_repo':
+            logger.info(f"🔄 User {query.from_user.id} wants to analyze another repo")
             await self.request_repo_url(update, context)
         
         elif query.data == 'show_suggestions':
@@ -792,11 +796,14 @@ class GitHubMenuHandler:
         user_id = update.message.from_user.id
         session = self.get_user_session(user_id)
         text = update.message.text
+        logger.info(f"📝 GitHub text input handler: user={user_id}, waiting_for_repo={context.user_data.get('waiting_for_repo_url')}")
         
         # בדוק אם מחכים ל-URL לניתוח
         if context.user_data.get('waiting_for_repo_url'):
+            logger.info("🔗 Handling repo URL input...")
             handled = await self.handle_repo_url_input(update, context)
             if handled:
+                logger.info("✅ Repo URL handled successfully")
                 return ConversationHandler.END
         
         if text.startswith('ghp_') or text.startswith('github_pat_'):
@@ -846,9 +853,11 @@ class GitHubMenuHandler:
 
     async def show_analyze_repo_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מציג תפריט לניתוח ריפו"""
+        logger.info("📋 Starting show_analyze_repo_menu function")
         query = update.callback_query
         user_id = query.from_user.id
         session = self.get_user_session(user_id)
+        logger.info(f"📊 Session data: selected_repo={session.get('selected_repo')}, has_token={bool(session.get('github_token'))}")
         
         # בדוק אם יש ריפו נבחר
         if session.get('selected_repo'):
@@ -871,6 +880,7 @@ class GitHubMenuHandler:
     
     async def request_repo_url(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מבקש URL של ריפו לניתוח"""
+        logger.info("📝 Requesting repository URL from user")
         query = update.callback_query if update.callback_query else None
         
         keyboard = [
@@ -902,9 +912,11 @@ class GitHubMenuHandler:
     
     async def analyze_repository(self, update: Update, context: ContextTypes.DEFAULT_TYPE, repo_url: str):
         """מנתח ריפוזיטורי ומציג תוצאות"""
+        logger.info(f"🎯 Starting repository analysis for URL: {repo_url}")
         query = update.callback_query if update.callback_query else None
         user_id = update.effective_user.id
         session = self.get_user_session(user_id)
+        logger.info(f"👤 User {user_id} analyzing repo: {repo_url}")
         
         # הצג הודעת המתנה
         status_message = await self._send_or_edit_message(
@@ -1252,10 +1264,12 @@ class GitHubMenuHandler:
     
     async def handle_repo_url_input(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מטפל בקלט של URL לניתוח"""
+        logger.info(f"🔗 Handling repo URL input: waiting={context.user_data.get('waiting_for_repo_url')}")
         if not context.user_data.get('waiting_for_repo_url'):
             return False
         
         text = update.message.text
+        logger.info(f"📌 Received URL: {text}")
         context.user_data['waiting_for_repo_url'] = False
         
         # בדוק אם זה URL של GitHub

--- a/main.py
+++ b/main.py
@@ -163,6 +163,7 @@ class CodeKeeperBot:
 
         # --- GitHub handlers - חייבים להיות לפני ה-handler הגלובלי! ---
         github_handler = GitHubMenuHandler()
+        logger.info("✅ GitHubMenuHandler instance created successfully")
         
         # הוסף פקודת github
         self.application.add_handler(CommandHandler("github", github_handler.github_menu_command))
@@ -170,7 +171,7 @@ class CodeKeeperBot:
         # הוסף את ה-callbacks של GitHub - חשוב! לפני ה-handler הגלובלי
         self.application.add_handler(
             CallbackQueryHandler(github_handler.handle_menu_callback, 
-                               pattern='^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop)')
+                               pattern='^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop|analyze_repo|analyze_current_repo|analyze_other_repo|show_suggestions|show_full_analysis|download_analysis_json)')
         )
         
         # הגדר conversation handler להעלאת קבצים
@@ -194,6 +195,20 @@ class CodeKeeperBot:
         )
         
         self.application.add_handler(upload_conv_handler)
+        
+        # הוסף handler כללי לטיפול בקלט טקסט של GitHub (כולל URL לניתוח)
+        async def handle_github_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            # בדוק אם מחכים ל-URL לניתוח
+            if context.user_data.get('waiting_for_repo_url'):
+                logger.info(f"🔗 Detected repo URL input from user {update.effective_user.id}")
+                return await github_handler.handle_text_input(update, context)
+            return False
+        
+        # הוסף את ה-handler עם עדיפות גבוהה
+        self.application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, handle_github_text),
+            group=-1  # עדיפות גבוהה מאוד
+        )
         
         logger.info("✅ GitHub handler נוסף בהצלחה")
         

--- a/repo_analyzer.py
+++ b/repo_analyzer.py
@@ -62,8 +62,10 @@ class RepoAnalyzer:
     
     async def fetch_and_analyze_repo(self, repo_url: str) -> Dict[str, Any]:
         """שולף ומנתח ריפוזיטורי מ-GitHub"""
+        logger.info(f"🔍 Starting analysis of repository: {repo_url}")
         try:
             owner, repo_name = self.parse_github_url(repo_url)
+            logger.info(f"📦 Parsed repo: owner={owner}, name={repo_name}")
             
             if not self.github_client:
                 raise ValueError("נדרש GitHub token לניתוח ריפוזיטורי")


### PR DESCRIPTION
Fixes the "Analyze Repo" button by adding missing callback patterns and a global handler for repository URL input.

The "Analyze Repo" button and its subsequent actions (like analyzing current/other repo, showing suggestions, etc.) were not triggering the correct handlers due to missing `callback_data` patterns in the main `CallbackQueryHandler`. Additionally, the bot was not properly capturing user-provided repository URLs because the `handle_text_input` was not globally registered to catch these messages when `waiting_for_repo_url` was set. Debugging logs were also added to improve traceability.

---
<a href="https://cursor.com/background-agent?bcId=bc-39c72969-7a77-47c0-8c6f-0b5ea4f51372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39c72969-7a77-47c0-8c6f-0b5ea4f51372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

