### PR TITLE
Fix missing dataclasses import in test_full_bot

### DIFF
--- a/test_full_bot.py
+++ b/test_full_bot.py
@@ -24,6 +24,7 @@ import os
 import sys
 import tempfile
 import time
+from dataclasses import asdict
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path


### PR DESCRIPTION
Add missing `asdict` import to `test_full_bot.py` to resolve import errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa97801c-9eb2-4c7f-a08c-76099ae3b52a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa97801c-9eb2-4c7f-a08c-76099ae3b52a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

