### PR TITLE
Fix edit save bug and add github logout

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -1378,6 +1378,8 @@ def get_save_conversation_handler(db: DatabaseManager) -> ConversationHandler:
             MessageHandler(filters.Regex("^📚 הצג את כל הקבצים שלי$"), show_all_files),
             MessageHandler(filters.Regex("^📂 קבצים גדולים$"), show_large_files_direct),
             MessageHandler(filters.Regex("^🔧 GitHub$"), show_github_menu),
+            # כניסה לעריכת קוד/שם גם דרך כפתורי callback כדי שמצב השיחה ייקבע כראוי
+            CallbackQueryHandler(handle_callback_query, pattern=r'^(edit_code_|edit_name_|lf_edit_)')
         ],
         states={
             GET_CODE: [

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -175,6 +175,8 @@ class GitHubMenuHandler:
         # כפתור ניתוח ריפו - תמיד מוצג אם יש טוקן
         if token:
             keyboard.append([InlineKeyboardButton("🔍 נתח ריפו", callback_data="analyze_repo")])
+            # כפתור יציאה (מחיקת טוקן) כאשר יש טוקן
+            keyboard.append([InlineKeyboardButton("🚪 התנתק מגיטהאב", callback_data="logout_github")])
         
         # כפתור הצגת הגדרות
         keyboard.append([InlineKeyboardButton("📋 הצג הגדרות נוכחיות", callback_data="show_current")])
@@ -256,7 +258,23 @@ class GitHubMenuHandler:
             
         elif query.data == "noop":
             await query.answer()  # לא עושה כלום, רק לכפתור התצוגה
-                
+        
+        # --- New: logout GitHub token from menu ---
+        elif query.data == "logout_github":
+            from database import db
+            removed = db.delete_github_token(user_id)
+            try:
+                session["github_token"] = None
+            except Exception:
+                pass
+            if removed:
+                await query.edit_message_text("🔐 הטוקן נמחק.⏳ מרענן תפריט...")
+            else:
+                await query.edit_message_text("ℹ️ לא נמצא טוקן או שאירעה שגיאה.⏳ מרענן תפריט...")
+            # refresh the menu after logout
+            await self.github_menu_command(update, context)
+            return
+        
         elif query.data == 'analyze_repo':
             logger.info(f"🔍 User {query.from_user.id} clicked 'analyze_repo' button")
             await self.show_analyze_repo_menu(update, context)

--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ class CodeKeeperBot:
         # הוסף את ה-callbacks של GitHub - חשוב! לפני ה-handler הגלובלי
         self.application.add_handler(
             CallbackQueryHandler(github_handler.handle_menu_callback, 
-                               pattern=r'^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop|analyze_repo|analyze_current_repo|analyze_other_repo|show_suggestions|show_full_analysis|download_analysis_json|back_to_analysis|back_to_analysis_menu|back_to_summary|choose_my_repo|enter_repo_url|suggestion_\d+|github_menu)')
+                               pattern=r'^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop|analyze_repo|analyze_current_repo|analyze_other_repo|show_suggestions|show_full_analysis|download_analysis_json|back_to_analysis|back_to_analysis_menu|back_to_summary|choose_my_repo|enter_repo_url|suggestion_\d+|github_menu|logout_github)')
         )
         
         # הגדר conversation handler להעלאת קבצים


### PR DESCRIPTION
Fixes "Edit" button not saving new code and adds a GitHub logout option to the menu.

The "Edit" button's save issue was due to the conversation state not being correctly set when the edit callback was triggered. This PR adds `CallbackQueryHandler` for edit patterns to the conversation's `entry_points`, ensuring the correct state is entered and new code is saved.

---
<a href="https://cursor.com/background-agent?bcId=bc-a21b6ffd-bf0b-40e3-a685-a9eff3e3f559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a21b6ffd-bf0b-40e3-a685-a9eff3e3f559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

