### PR TITLE
Improve file operations and ui

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -134,11 +134,13 @@ async def show_all_files(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def show_large_files_direct(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """הצגת קבצים גדולים ישירות מהתפריט הראשי"""
+    # נקה דגלים ישנים של GitHub כדי למנוע בלבול בקלט
+    context.user_data.pop('waiting_for_delete_file_path', None)
+    context.user_data.pop('waiting_for_download_file_path', None)
     # רישום פעילות למעקב סטטיסטיקות ב-MongoDB
     user_stats.log_user(update.effective_user.id, update.effective_user.username)
     from large_files_handler import large_files_handler
     await large_files_handler.show_large_files_menu(update, context)
-    reporter.report_activity(update.effective_user.id)
     return ConversationHandler.END
 
 async def show_github_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -308,12 +310,12 @@ async def show_regular_files_callback(update: Update, context: ContextTypes.DEFA
 
 async def start_save_flow(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """התחלת תהליך שמירה מתקדם"""
+    cancel_markup = InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="cancel")]])
     await update.message.reply_text(
         "✨ *מצוין!* בואו נצור קוד חדש!\n\n"
         "📝 שלח לי את קטע הקוד המבריק שלך.\n"
-        "💡 אני אזהה את השפה אוטומטית ואארגן הכל!\n\n"
-        "🚫 לביטול בכל שלב: `/cancel`",
-        reply_markup=ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True),
+        "💡 אני אזהה את השפה אוטומטית ואארגן הכל!",
+        reply_markup=cancel_markup,
         parse_mode='Markdown'
     )
     reporter.report_activity(update.effective_user.id)
@@ -605,8 +607,8 @@ async def handle_edit_code(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await query.edit_message_text(
             f"✏️ *עריכת קוד מתקדמת*\n\n"
             f"📄 **קובץ:** `{file_name}`\n\n"
-            f"📝 שלח את הקוד החדש והמעודכן:\n"
-            f"🚫 לביטול: `/cancel`",
+            f"📝 שלח את הקוד החדש והמעודכן:",
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="cancel")]]),
             parse_mode='Markdown'
         )
         
@@ -714,8 +716,7 @@ async def receive_new_code(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if not is_valid:
             await update.message.reply_text(
                 f"❌ שגיאה בקלט הקוד:\n{error_message}\n\n"
-                f"💡 אנא וודא שהקוד תקין ונסה שוב.\n"
-                f"🚫 לביטול: `/cancel`",
+                f"💡 אנא וודא שהקוד תקין ונסה שוב.",
                 reply_markup=ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True)
             )
             return EDIT_CODE  # חזרה למצב עריכה
@@ -833,6 +834,7 @@ async def handle_edit_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             f"📄 **שם נוכחי:** `{current_name}`\n\n"
             f"✏️ שלח שם חדש לקובץ:\n"
             f"🚫 לביטול: `/cancel`",
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="cancel")]]),
             parse_mode='Markdown'
         )
         
@@ -1281,8 +1283,8 @@ async def handle_edit_code_direct(update: Update, context: ContextTypes.DEFAULT_
         await query.edit_message_text(
             f"✏️ *עריכת קוד מתקדמת*\n\n"
             f"📄 **קובץ:** `{file_name}`\n\n"
-            f"📝 שלח את הקוד החדש והמעודכן:\n"
-            f"🚫 לביטול: `/cancel`",
+            f"📝 שלח את הקוד החדש והמעודכן:",
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="cancel")]]),
             parse_mode='Markdown'
         )
         
@@ -1318,6 +1320,7 @@ async def handle_edit_name_direct(update: Update, context: ContextTypes.DEFAULT_
             f"📄 **שם נוכחי:** `{file_name}`\n\n"
             f"✏️ שלח שם חדש לקובץ:\n"
             f"🚫 לביטול: `/cancel`",
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="cancel")]]),
             parse_mode='Markdown'
         )
         
@@ -1371,6 +1374,15 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             return await show_all_files_callback(update, context)
         elif data == "main":
             await query.edit_message_text("🏠 חוזר לבית החכם:")
+            await query.message.reply_text(
+                "🎮 בחר פעולה מתקדמת:",
+                reply_markup=ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True)
+            )
+            return ConversationHandler.END
+        elif data == "cancel":
+            # ביטול כללי דרך כפתור
+            context.user_data.clear()
+            await query.edit_message_text("🚫 התהליך בוטל בהצלחה!")
             await query.message.reply_text(
                 "🎮 בחר פעולה מתקדמת:",
                 reply_markup=ReplyKeyboardMarkup(MAIN_KEYBOARD, resize_keyboard=True)

--- a/database.py
+++ b/database.py
@@ -431,13 +431,13 @@ class DatabaseManager:
     def delete_large_file(self, user_id: int, file_name: str) -> bool:
         """מוחק קובץ גדול"""
         try:
-            result = self.large_files_collection.update_one(
-                {"user_id": user_id, "file_name": file_name},
+            result = self.large_files_collection.update_many(
+                {"user_id": user_id, "file_name": file_name, "is_active": True},
                 {"$set": {"is_active": False, "updated_at": datetime.now()}}
             )
             
             if result.modified_count > 0:
-                logger.info(f"קובץ גדול נמחק: {file_name}")
+                logger.info(f"קובץ גדול נמחק: {file_name} ({result.modified_count} מסמכים עודכנו)")
                 return True
             
             return False

--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ class CodeKeeperBot:
         # הוסף את ה-callbacks של GitHub - חשוב! לפני ה-handler הגלובלי
         self.application.add_handler(
             CallbackQueryHandler(github_handler.handle_menu_callback, 
-                               pattern=r'^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop|analyze_repo|analyze_current_repo|analyze_other_repo|show_suggestions|show_full_analysis|download_analysis_json|back_to_analysis|back_to_analysis_menu|back_to_summary|choose_my_repo|enter_repo_url|suggestion_\d+|github_menu|logout_github|delete_file_menu|delete_repo_menu|confirm_delete_repo|confirm_delete_file|danger_delete_menu|download_file_menu)')
+                               pattern=r'^(select_repo|upload_file|upload_saved|show_current|set_token|set_folder|close_menu|folder_|repo_|repos_page_|upload_saved_|back_to_menu|repo_manual|noop|analyze_repo|analyze_current_repo|analyze_other_repo|show_suggestions|show_full_analysis|download_analysis_json|back_to_analysis|back_to_analysis_menu|back_to_summary|choose_my_repo|enter_repo_url|suggestion_\d+|github_menu|logout_github|delete_file_menu|delete_repo_menu|confirm_delete_repo|confirm_delete_repo_step1|confirm_delete_file|danger_delete_menu|download_file_menu|browse_open:.*|browse_select_download:.*|browse_select_delete:.*)')
         )
         
         # הגדר conversation handler להעלאת קבצים
@@ -201,6 +201,14 @@ class CodeKeeperBot:
         # הוסף handler כללי לטיפול בקלט טקסט של GitHub (כולל URL לניתוח)
         async def handle_github_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
             # העבר כל קלט רלוונטי למנהל GitHub לפי דגלים ב-user_data
+            text = (update.message.text or '').strip()
+            main_menu_texts = {"➕ הוסף קוד חדש", "📚 הצג את כל הקבצים שלי", "📂 קבצים גדולים", "🔧 GitHub"}
+            if text in main_menu_texts:
+                # נקה דגלים כדי למנוע טריגר שגוי
+                context.user_data.pop('waiting_for_repo_url', None)
+                context.user_data.pop('waiting_for_delete_file_path', None)
+                context.user_data.pop('waiting_for_download_file_path', None)
+                return False
             if context.user_data.get('waiting_for_repo_url') or \
                context.user_data.get('waiting_for_delete_file_path') or \
                context.user_data.get('waiting_for_download_file_path'):


### PR DESCRIPTION
Improve user experience by replacing text commands with inline buttons and file browsers, and fix several deletion-related bugs.

The user requested a more intuitive interface, leading to the replacement of `/cancel` text with inline buttons and manual path inputs for GitHub file operations with a button-based file browser. Additionally, a double-confirmation step was added for full repository deletion to prevent accidental data loss. Bug fixes include preventing an incorrect delete confirmation prompt after selecting "large files" and ensuring large files are correctly deactivated upon deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5311c20-5114-43e7-9d5f-ea5a908cac83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5311c20-5114-43e7-9d5f-ea5a908cac83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

