### PR TITLE
Fix git save point creation failure

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -3055,9 +3055,9 @@ class GitHubMenuHandler:
             import datetime
             g = Github(login_or_token=token)
             repo = g.get_repo(repo_full)
-            default_branch = repo.get_branch(repo.default_branch).name
-            ref = repo.get_git_ref("heads/" + default_branch)
-            sha = ref.object.sha
+            branch_obj = repo.get_branch(repo.default_branch)
+            default_branch = branch_obj.name
+            sha = branch_obj.commit.sha
             ts = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
             prefix = (config.GIT_CHECKPOINT_PREFIX or "checkpoint").strip()
             # שמור על תווים חוקיים לשמות refs בסיסיים


### PR DESCRIPTION
Adds pre-merge checks for PRs and fixes a 404 error during Git checkpoint creation.

The 404 error was caused by `get_git_ref` failing, now resolved by fetching SHA from `repo.get_branch().commit.sha`. Pre-merge checks provide better visibility into PR readiness (permissions, mergeable state, statuses, draft status, review requests) before merging.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d824e02-0be7-437c-bee4-aadd09a2b4f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d824e02-0be7-437c-bee4-aadd09a2b4f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

