### PR TITLE
Fix repository list after deletion

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -2286,6 +2286,9 @@ class GitHubMenuHandler:
                 await query.edit_message_text("❌ ניתן למחוק רק ריפו שאתה בעליו")
                 return
             repo.delete()
+            # נקה קאש ריפוזיטוריז כדי שהרשימה תרוענן ולא תציג פריטים שנמחקו
+            context.user_data.pop("repos", None)
+            context.user_data.pop("repos_cache_time", None)
             await query.edit_message_text(
                 f"✅ הריפו נמחק בהצלחה: <code>{repo_name}</code>", parse_mode="HTML"
             )
@@ -2295,6 +2298,9 @@ class GitHubMenuHandler:
             logger.error(f"Error deleting repository: {e}")
             await query.edit_message_text(f"❌ שגיאה במחיקת ריפו: {e}")
         finally:
+            # לאחר מחיקה, ודא שקאש הרשימות אינו משאיר את הריפו הישן
+            context.user_data.pop("repos", None)
+            context.user_data.pop("repos_cache_time", None)
             await self.github_menu_command(update, context)
 
     async def show_danger_delete_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
Invalidate cached repository list after deletion to prevent deleted repositories from reappearing in the bot's list.

---
<a href="https://cursor.com/background-agent?bcId=bc-53217db6-320a-4eea-bfd1-f4e93d4ad2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53217db6-320a-4eea-bfd1-f4e93d4ad2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

