### PR TITLE
Investigate incorrect repository upload

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -416,6 +416,8 @@ class GitHubMenuHandler:
                     except Exception:
                         pass
                 return
+            # ודא שניקינו דגלים ישנים של העלאה רגילה כדי למנוע בלבול
+            context.user_data["waiting_for_github_upload"] = False
             context.user_data["upload_mode"] = "github_restore_zip_to_repo"
             kb = [
                 [InlineKeyboardButton("🧹 מחיקה מלאה לפני העלאה", callback_data="github_restore_zip_setpurge:1")],
@@ -441,6 +443,8 @@ class GitHubMenuHandler:
         elif query.data.startswith("github_restore_zip_setpurge:"):
             # טיפול בבחירת מצב מחיקה/עדכון לפני העלאה
             purge_flag = query.data.split(":", 1)[1] == "1"
+            # ודא שניקינו דגלים ישנים של העלאה רגילה כדי למנוע בלבול
+            context.user_data["waiting_for_github_upload"] = False
             context.user_data["upload_mode"] = "github_restore_zip_to_repo"
             context.user_data["github_restore_zip_purge"] = purge_flag
             await query.edit_message_text(
@@ -4159,6 +4163,8 @@ class GitHubMenuHandler:
             pass
         elif query.data.startswith("github_restore_zip_setpurge:"):
             purge_flag = query.data.split(":", 1)[1] == "1"
+            # ודא שניקינו דגלים ישנים של העלאה רגילה כדי למנוע בלבול
+            context.user_data["waiting_for_github_upload"] = False
             context.user_data["upload_mode"] = "github_restore_zip_to_repo"
             context.user_data["github_restore_zip_purge"] = purge_flag
             await query.edit_message_text(

--- a/main.py
+++ b/main.py
@@ -727,11 +727,6 @@ class CodeKeeperBot:
         logger.info(f"DEBUG: upload_mode = {context.user_data.get('upload_mode')}")
         logger.info(f"DEBUG: waiting_for_github_upload = {context.user_data.get('waiting_for_github_upload')}")
         
-        # בדוק אם אנחנו במצב העלאה לגיטהאב (תמיכה בשני המשתנים)
-        if context.user_data.get('waiting_for_github_upload') or context.user_data.get('upload_mode') == 'github':
-            # תן ל-GitHub handler לטפל בזה
-            return
-        
         # שחזור ZIP ישירות לריפו בגיטהאב (פריסה והחלפה)
         if context.user_data.get('upload_mode') == 'github_restore_zip_to_repo':
             try:
@@ -822,6 +817,11 @@ class CodeKeeperBot:
             finally:
                 context.user_data['upload_mode'] = None
                 context.user_data.pop('github_restore_zip_purge', None)
+            return
+        
+        # בדוק אם אנחנו במצב העלאה לגיטהאב (תמיכה בשני המשתנים)
+        if context.user_data.get('waiting_for_github_upload') or context.user_data.get('upload_mode') == 'github':
+            # תן ל-GitHub handler לטפל בזה
             return
         
         # שחזור מגיבוי מלא: קבלת ZIP


### PR DESCRIPTION
Prioritize GitHub ZIP restore flow and clear stale upload flags to ensure uploads go to the correct repository.

The bug occurred because stale `waiting_for_github_upload` flags or hardcoded default repository names could cause ZIP restores to be routed to the previous or an incorrect GitHub repository. This PR ensures the restore flow takes precedence and clears conflicting flags, preventing unintended uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-58ee9062-e673-4379-aea6-3255e3627ae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58ee9062-e673-4379-aea6-3255e3627ae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

