### PR TITLE
Handle github restore zip upload issues

### DIFF
--- a/database.py
+++ b/database.py
@@ -735,3 +735,7 @@ class DatabaseManager:
 
 # יצירת אינסטנס גלובלי
 db = DatabaseManager()
+
+def init_database() -> DatabaseManager:
+    """תאימות לאחור: מחזיר את מופע מנהל מסד הנתונים הגלובלי."""
+    return db

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -4299,18 +4299,11 @@ class GitHubMenuHandler:
                 blob = repo.create_git_blob(b64, 'base64')
             elements.append(InputGitTreeElement(path=path, mode='100644', type='blob', sha=blob.sha))
         if purge_first:
-            # שלב א': קומיט ביניים לאיפוס מלא של העץ
-            empty_tree = repo.create_git_tree([])
-            purge_commit = repo.create_git_commit("Purge repository via bot (clear tree)", empty_tree, [base_commit])
-            base_ref.edit(purge_commit.sha)
-            logger.info(f"[restore_zip_from_backup] Performed hard purge commit: {purge_commit.sha}")
-            base_commit = purge_commit
-            base_tree = empty_tree
-            # שלב ב': עץ חדש מהקבצים שב-ZIP בלבד
+            # Soft purge: יצירת עץ חדש ללא בסיס (מוחק קבצים שאינם ב-ZIP)
             new_tree = repo.create_git_tree(elements)
         else:
             new_tree = repo.create_git_tree(elements, base_tree)
         commit_message = f"Restore from ZIP via bot: replace {'with purge' if purge_first else 'update only'}"
         new_commit = repo.create_git_commit(commit_message, new_tree, [base_commit])
         base_ref.edit(new_commit.sha)
-        logger.info(f"[restore_zip_from_backup] Final restore commit created: {new_commit.sha}, files_added={len(elements)}, purge={purge_first}")
+        logger.info(f"[restore_zip_from_backup] Restore commit created: {new_commit.sha}, files_added={len(elements)}, purge={purge_first}")

--- a/main.py
+++ b/main.py
@@ -744,12 +744,20 @@ class CodeKeeperBot:
                     return
                 # חלץ את ה-ZIP לזיכרון לרשימת קבצים
                 zf = zipfile.ZipFile(buf, 'r')
-                members = [n for n in zf.namelist() if not n.endswith('/')]
-                # נקה תיקיית root של GitHub zip אם קיימת
+                # סינון ערכי מערכת של macOS וכד'. נשמור רק קבצים אמיתיים
+                all_names = [n for n in zf.namelist() if not n.endswith('/')]
+                members = [n for n in all_names if not (n.startswith('__MACOSX/') or n.split('/')[-1].startswith('._'))]
+                # זיהוי תיקיית-שורש משותפת (אם כל הקבצים חולקים את אותו הסגמנט העליון)
+                top_levels = set()
+                for n in zf.namelist():
+                    if '/' in n and not n.startswith('__MACOSX/'):
+                        top_levels.add(n.split('/', 1)[0])
+                common_root = list(top_levels)[0] if len(top_levels) == 1 else None
+                logger.info(f"[restore_zip] Detected common_root={common_root!r}, files_in_zip={len(members)}")
+                # נקה תיקיית root של GitHub zip רק אם זוהתה תיקיית-שורש משותפת אחת
                 def strip_root(path: str) -> str:
-                    parts = path.split('/')
-                    if len(parts) > 1 and parts[0] and all('/' not in p for p in parts[:1]):
-                        return '/'.join(parts[1:])
+                    if common_root and path.startswith(common_root + '/'):
+                        return path[len(common_root) + 1:]
                     return path
                 files = []
                 for name in members:
@@ -804,12 +812,22 @@ class CodeKeeperBot:
                     elem = InputGitTreeElement(path=path, mode='100644', type='blob', sha=blob.sha)
                     new_tree_elements.append(elem)
                 if purge_first:
+                    # שלב א': קומיט ביניים שמרוקן את העץ לחלוטין (hard purge)
+                    empty_tree = repo.create_git_tree([])
+                    purge_commit = repo.create_git_commit("Purge repository via bot (clear tree)", empty_tree, [base_commit])
+                    base_ref.edit(purge_commit.sha)
+                    logger.info(f"[restore_zip] Performed hard purge commit: {purge_commit.sha}")
+                    # עדכן בסיס לקומיט הבא
+                    base_commit = purge_commit
+                    base_tree = empty_tree
+                    # שלב ב': צור עץ חדש מהקבצים שב-ZIP בלבד
                     new_tree = repo.create_git_tree(new_tree_elements)
                 else:
                     new_tree = repo.create_git_tree(new_tree_elements, base_tree)
                 commit_message = f"Restore from ZIP via bot: replace {'with purge' if purge_first else 'update only'}"
                 new_commit = repo.create_git_commit(commit_message, new_tree, [base_commit])
                 base_ref.edit(new_commit.sha)
+                logger.info(f"[restore_zip] Final restore commit created: {new_commit.sha}, files_added={len(new_tree_elements)}, purge={purge_first}")
                 await update.message.reply_text("✅ השחזור הועלה לריפו בהצלחה")
             except Exception as e:
                 logger.exception(f"GitHub restore-to-repo failed: {e}")


### PR DESCRIPTION
Enhance ZIP restore purge logic and resolve `init_database` import error.

The "full delete before upload" option for ZIP restores was not always completely removing all existing files. This PR introduces a "hard purge" mechanism by committing an empty tree before the ZIP content, ensuring all previous files are deleted. It also improves ZIP processing by intelligently handling root directories and filtering system files. Additionally, a compatibility function for `init_database` was added to resolve a runtime `ImportError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b8e7b6a-c5eb-4b6a-9cdf-000bd4c07a80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b8e7b6a-c5eb-4b6a-9cdf-000bd4c07a80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

