### PR TITLE
Fix zip file display and github menu error

### DIFF
--- a/backup_menu_handler.py
+++ b/backup_menu_handler.py
@@ -169,6 +169,7 @@ class BackupMenuHandler:
 		user_id = query.from_user.id
 		await query.answer()
 		backups = backup_manager.list_backups(user_id)
+		# ודא שתמיד מוצגים כל קבצי ה‑ZIP ללא סינון לפי משתמש
 		# יעד חזרה דינמי לפי מקור הכניסה ("📚" או GitHub)
 		zip_back_to = context.user_data.get('zip_back_to')
 		# אם מגיעים מתפריט "📚" או מזרימת "העלה קובץ חדש → קבצי ZIP" (github_upload), אל תסנן לפי ריפו

--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -2254,6 +2254,7 @@ async def show_batch_zips_menu(update: Update, context: ContextTypes.DEFAULT_TYP
     user_id = update.effective_user.id
     try:
         backups = backup_manager.list_backups(user_id)
+        # מציג את כל קבצי ה‑ZIP השמורים בבוט
         if not backups:
             keyboard = [[InlineKeyboardButton("🔙 חזור", callback_data="batch_menu")]]
             await query.edit_message_text(

--- a/file_manager.py
+++ b/file_manager.py
@@ -486,11 +486,11 @@ class BackupManager:
             return {"restored_files": 0, "errors": [str(e)]}
     
     def list_backups(self, user_id: int) -> List[BackupInfo]:
-        """רשימת כל קבצי ה‑ZIP הרלוונטיים למשתמש (לא רק כאלה בשם backup_*).
+        """רשימת כל קבצי ה‑ZIP השמורים בבוט (לא רק כאלה בשם backup_*), ללא סינון לפי user_id.
 
-        הכללה מתבצעת לפי אחד מהקריטריונים:
-        - metadata.json בתוך ה‑ZIP עם user_id תואם
-        - או שם קובץ המתאים לדפוס backup_{user_id}_*.zip (תמיכה לאחור)
+        הערות:
+        - אם קיים metadata.json, נשלוף ממנו נתונים (כולל user_id מקורי אם קיים) אך לא נסנן לפיו
+        - אם אין מטאדטה, נטפל בהם כ‑generic_zip עם נפילה לאחור
         """
 
         backups: List[BackupInfo] = []
@@ -516,21 +516,9 @@ class BackupManager:
                         except Exception:
                             metadata = None
 
-                        # החלט אם הקובץ רלוונטי לתצוגה עבור המשתמש הנוכחי
-                        # לוגיקה:
-                        # - אם יש מטאדטה עם user_id: הצג רק אם user_id תואם או חסר
-                        # - אם אין מטאדטה בכלל: הצג בכל מקרה (תמיכה מלאה לאחור)
-                        include: bool = False
-                        if metadata is not None:
-                            meta_uid = metadata.get("user_id")
-                            if meta_uid is None or meta_uid == user_id:
-                                include = True
-                        else:
-                            # ללא מטאדטה – נכליל תמיד כדי להציג "כל קבצי ה‑ZIP" השמורים בבוט
-                            include = True
-
-                        if not include:
-                            continue
+                        # הצגת כל קובצי ה‑ZIP שנשמרו בבוט, ללא תלות ב‑user_id
+                        # שמירת ה‑user_id המקורי (אם קיים) תיעשה בשדה המידע החוזר
+                        include: bool = True
 
                         # שלוף נתונים מהמטאדטה אם קיימת
                         if metadata is not None:


### PR DESCRIPTION
Fixes ZIP file listing to always show all stored files across all menus.

Previously, ZIP listings were incomplete or errored in "My Files", "Batch Processing", and GitHub upload menus due to incorrect filtering by user ID or repository association. This PR updates `file_manager.BackupManager.list_backups` to return all stored ZIPs, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9be586c-b820-4c7d-971b-40c018d3da94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9be586c-b820-4c7d-971b-40c018d3da94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

