### PR TITLE
Fix telegram entity parsing for zip creation

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -329,7 +329,7 @@ class GitHubMenuHandler:
                 "1) ניתן להקליד שם לריפו (ללא רווחים)\n"
                 "2) שלח עכשיו קובץ ZIP עם כל הקבצים\n\n"
                 "אם לא תוקלד שם, ננסה לחלץ שם מתיקיית-הבסיס ב‑ZIP או משם הקובץ.\n"
-                "ברירת מחדל: <code>repo-<timestamp></code>\n\n"
+                "ברירת מחדל: <code>repo-&lt;timestamp&gt;</code>\n\n"
                 "לאחר השליחה, ניצור ריפו פרטי ונפרוס את התוכן ב-commit אחד."
             )
             await query.edit_message_text(help_txt, parse_mode="HTML", reply_markup=InlineKeyboardMarkup(kb))


### PR DESCRIPTION
Escape `<timestamp>` in the "create repo from ZIP" help text to fix `BadRequest` HTML parsing errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-296c12fc-2b2e-403d-83d4-75e6e62740d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-296c12fc-2b2e-403d-83d4-75e6e62740d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

