### PR TITLE
Handle file save error due to unassigned variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -908,7 +908,6 @@ class CodeKeeperBot:
                 repo_full = repo.full_name
                 # שמור כריפו נבחר במסד ובסשן
                 try:
-                    from database import db
                     db.save_selected_repo(user_id, repo_full)
                     sess = github_handler.get_user_session(user_id)
                     sess['selected_repo'] = repo_full


### PR DESCRIPTION
Remove local import of `db` within `main.py` to resolve `UnboundLocalError` when saving selected repositories.

The `UnboundLocalError: cannot access local variable 'db' where it is not associated with a value` occurred because `from database import db` was imported inside a function, shadowing the module-level `db` and causing it to be uninitialized in that scope. Removing this local import ensures the already-initialized module-level `db` is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-faacd12b-0a17-414c-8cad-74344c2a1e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-faacd12b-0a17-414c-8cad-74344c2a1e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

