### PR TITLE
Investigate dependency installation failure after auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     directory: "/" # Location of package manifests (requirements.txt)
     schedule:
       interval: "weekly" # Check for updates once a week
+  - package-ecosystem: "pip"
+    directory: "/telegram_terminal_bot" # Monitor worker requirements
+    schedule:
+      interval: "weekly"
     # You can add reviewers or assignees automatically if you want
     # assignees:
     #   - "amirbiron"

--- a/docs/auto-updates-and-auto-merge.md
+++ b/docs/auto-updates-and-auto-merge.md
@@ -84,6 +84,18 @@
   - ודא ש־`DEPENDABOT_AUTOMERGE`=true כסוד ריפוזיטורי.
   - בדוק שכל הבדיקות ירוקות וכללי ההגנה מתקיימים.
 
+- תלות עודכנה אבל ה־Deploy ב‑Render לא התקין אותה:
+  - אם פרויקט מחולק לתת‑תיקיות עם `requirements.txt` נוספים (למשל `telegram_terminal_bot/requirements.txt`), ודא ש‑Render מתקין גם אותם בשלב ה‑build.
+  - בקובץ `render.yaml` בעבור worker, עדכן את `buildCommand` כך:
+    ```bash
+    pip install --upgrade pip
+    pip install -r requirements.txt
+    if [ -f telegram_terminal_bot/requirements.txt ]; then
+      pip install -r telegram_terminal_bot/requirements.txt
+    fi
+    ```
+  - הרחב את Dependabot כדי שינטר גם את התיקייה: הוסף ל־`.github/dependabot.yml` בלוק נוסף עם `directory: "/telegram_terminal_bot"`.
+
 ### צ'ק־ליסט מהיר
 - [ ] הגדרת כלל Branch protection ל־`main` עם "✅ Branch Protection Gate"
 - [ ] הפעלת "Allow auto‑merge" (Settings → General → Pull requests)

--- a/render.yaml
+++ b/render.yaml
@@ -95,6 +95,9 @@ services:
     buildCommand: |
       pip install --upgrade pip
       pip install -r requirements.txt
+      if [ -f telegram_terminal_bot/requirements.txt ]; then
+        pip install -r telegram_terminal_bot/requirements.txt
+      fi
 
     startCommand: python telegram_terminal_bot/bot.py
 


### PR DESCRIPTION
Ensure nested `requirements.txt` dependencies are installed during Render deployment and monitored by Dependabot.

Previously, Dependabot updates to `telegram_terminal_bot/requirements.txt` were not reflected in deployments because the Render worker's `buildCommand` only installed the root `requirements.txt`. This led to new dependencies not being installed.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eae2b5f-295d-4081-ae87-3fd77aac12e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6eae2b5f-295d-4081-ae87-3fd77aac12e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

