### PR TITLE
Fix invalid GitHub workflow file

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -13,6 +13,9 @@ jobs:
       security-events: write
       contents: read
       issues: write
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -131,11 +134,11 @@ jobs:
             return mdBody;
 
       - name: "📨 Notify Telegram"
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        if: ${{ env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
         run: |
           MSG_HTML="${{ steps.scan_summary.outputs.html }}"
-          curl -sS -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
-            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
             -d "parse_mode=HTML" \
             -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG_HTML}"


### PR DESCRIPTION
Fix `Unrecognized named-value: 'secrets'` error in workflow by mapping secrets to environment variables.

GitHub Actions does not allow direct access to `secrets` within `if` conditions in the form `secrets.SOMETHING != ''`. This PR maps the `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets to job-level environment variables and updates the `if` condition and `curl` command to use these `env` variables instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-c99abc6f-8cae-45f2-9c54-02415c281c8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c99abc6f-8cae-45f2-9c54-02415c281c8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

