### PR TITLE
Investigate repository selection bug

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -1842,9 +1842,15 @@ class GitHubMenuHandler:
                     f"בחר ריפוזיטורי (עמוד {page+1} מתוך {total_pages}):", reply_markup=reply_markup
                 )
             else:
-                await update.callback_query.edit_message_text(
-                    f"בחר ריפוזיטורי (עמוד {page+1} מתוך {total_pages}):", reply_markup=reply_markup
-                )
+                try:
+                    await update.callback_query.edit_message_text(
+                        f"בחר ריפוזיטורי (עמוד {page+1} מתוך {total_pages}):", reply_markup=reply_markup
+                    )
+                except Exception:
+                    await update.message.reply_text(
+                        f"בחר ריפוזיטורי (עמוד {page+1} מתוך {total_pages}):",
+                        reply_markup=reply_markup,
+                    )
 
         except Exception as e:
             error_msg = str(e)
@@ -1858,45 +1864,11 @@ class GitHubMenuHandler:
             if query:
                 await query.answer(error_msg, show_alert=True)
             else:
-                await update.callback_query.answer(error_msg, show_alert=True)
-
-    # הוסר: upload_saved_files — זרימה זו מאוחדת למסך "העלה קובץ חדש"
-
-        if not session.get("selected_repo"):
-            await update.callback_query.answer("❌ נא לבחור ריפו קודם")
-            return
-
-        try:
-            # כאן תצטרך להתחבר למסד הנתונים שלך
-            # לדוגמה:
-            from database import db
-
-            files = db.get_user_files(user_id)
-
-            if not files:
-                await update.callback_query.answer("❌ אין לך קבצים שמורים", show_alert=True)
-                return
-
-            keyboard = []
-            for file in files[:10]:  # מציג עד 10 קבצים
-                keyboard.append(
-                    [
-                        InlineKeyboardButton(
-                            f"📄 {file['file_name']}", callback_data=f"upload_saved_{file['_id']}"
-                        )
-                    ]
-                )
-
-            keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="back_to_menu")])
-
-            reply_markup = InlineKeyboardMarkup(keyboard)
-
-            await update.callback_query.edit_message_text(
-                "בחר קובץ להעלאה:", reply_markup=reply_markup
-            )
-
-        except Exception as e:
-            await update.callback_query.answer(f"❌ שגיאה: {str(e)}", show_alert=True)
+                try:
+                    await update.callback_query.answer(error_msg, show_alert=True)
+                except Exception:
+                    await update.message.reply_text(error_msg)
+ 
 
     async def show_upload_other_files(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מציג רק קבצים שאינם מתויגים repo: ואינם קבצים גדולים"""


### PR DESCRIPTION
Remove stray saved-files display logic from `show_repos` and harden error handling to fix incorrect navigation and `AttributeError`.

The "Next" button in the repository selection flow (`repos_page_X`) was incorrectly redirecting users to a "saved files" view. This was caused by a remnant code block from a previously removed "upload saved files" feature that was mistakenly left embedded within the `show_repos` function. Additionally, an `AttributeError` occurred when `update` was a `Message` object during error handling, which is now addressed by falling back to `update.message.reply_text`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccefeabe-9e89-4ca0-8cdb-d420c92a826a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccefeabe-9e89-4ca0-8cdb-d420c92a826a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

