### PR TITLE
Feature/drive menu v2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Telegram](https://img.shields.io/badge/Telegram-Bot-blue.svg)](https://core.telegram.org/bots)
 [![MongoDB](https://img.shields.io/badge/MongoDB-Database-green.svg)](https://mongodb.com)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/Docs-Website-blueviolet.svg)](https://amirbiron.github.io/CodeBot/)
 
 <!-- CI/CD Badges -->
 [![CI](https://github.com/amirbiron/CodeBot/actions/workflows/ci.yml/badge.svg)](https://github.com/amirbiron/CodeBot/actions/workflows/ci.yml)

--- a/config.py
+++ b/config.py
@@ -45,6 +45,9 @@ class BotConfig:
     GOOGLE_CLIENT_SECRET: Optional[str] = None
     GOOGLE_OAUTH_SCOPES: str = "https://www.googleapis.com/auth/drive.file"
     GOOGLE_TOKEN_REFRESH_MARGIN_SECS: int = 120
+
+    # Feature flags
+    DRIVE_MENU_V2: bool = True
     
     def __post_init__(self):
         if self.SUPPORTED_LANGUAGES is None:
@@ -81,6 +84,7 @@ def load_config() -> BotConfig:
         GOOGLE_CLIENT_SECRET=os.getenv('GOOGLE_CLIENT_SECRET'),
         GOOGLE_OAUTH_SCOPES=os.getenv('GOOGLE_OAUTH_SCOPES', 'https://www.googleapis.com/auth/drive.file'),
         GOOGLE_TOKEN_REFRESH_MARGIN_SECS=int(os.getenv('GOOGLE_TOKEN_REFRESH_MARGIN_SECS', '120')),
+        DRIVE_MENU_V2=os.getenv('DRIVE_MENU_V2', 'true').lower() == 'true',
         MAINTENANCE_MODE=os.getenv('MAINTENANCE_MODE', 'false').lower() == 'true',
         MAINTENANCE_MESSAGE=os.getenv('MAINTENANCE_MESSAGE', "🚀 אנחנו מעלים עדכון חדש!\nהבוט יחזור לפעול ממש בקרוב (1 - 3 דקות)"),
         MAINTENANCE_AUTO_WARMUP_SECS=int(os.getenv('MAINTENANCE_AUTO_WARMUP_SECS', '180')),

--- a/config.py
+++ b/config.py
@@ -48,6 +48,7 @@ class BotConfig:
 
     # Feature flags
     DRIVE_MENU_V2: bool = True
+    DOCUMENTATION_URL: str = "https://amirbiron.github.io/CodeBot/"
     
     def __post_init__(self):
         if self.SUPPORTED_LANGUAGES is None:
@@ -85,6 +86,7 @@ def load_config() -> BotConfig:
         GOOGLE_OAUTH_SCOPES=os.getenv('GOOGLE_OAUTH_SCOPES', 'https://www.googleapis.com/auth/drive.file'),
         GOOGLE_TOKEN_REFRESH_MARGIN_SECS=int(os.getenv('GOOGLE_TOKEN_REFRESH_MARGIN_SECS', '120')),
         DRIVE_MENU_V2=os.getenv('DRIVE_MENU_V2', 'true').lower() == 'true',
+        DOCUMENTATION_URL=os.getenv('DOCUMENTATION_URL', 'https://amirbiron.github.io/CodeBot/'),
         MAINTENANCE_MODE=os.getenv('MAINTENANCE_MODE', 'false').lower() == 'true',
         MAINTENANCE_MESSAGE=os.getenv('MAINTENANCE_MESSAGE', "🚀 אנחנו מעלים עדכון חדש!\nהבוט יחזור לפעול ממש בקרוב (1 - 3 דקות)"),
         MAINTENANCE_AUTO_WARMUP_SECS=int(os.getenv('MAINTENANCE_AUTO_WARMUP_SECS', '180')),

--- a/handlers/drive/menu.py
+++ b/handlers/drive/menu.py
@@ -129,17 +129,6 @@ class GoogleDriveMenuHandler:
                 await query.answer("עדיין ממתינים לאישור…", show_alert=False)
                 return
             if isinstance(tokens, dict) and tokens.get("error"):
-                # Show descriptive error to the user and keep polling active
-                err = tokens.get("error")
-                desc = tokens.get("error_description") or "בקשה נדחתה. נא לאשר בדפדפן ולנסות שוב."
-                await query.answer(f"שגיאה: {err}\n{desc}"[:190], show_alert=True)
-                return
-            gdrive.save_tokens(user_id, tokens)
-            tokens = gdrive.poll_device_token(dc)
-            if not tokens:
-                await query.answer("עדיין ממתינים לאישור…", show_alert=False)
-                return
-            if isinstance(tokens, dict) and tokens.get("error"):
                 err = tokens.get("error")
                 desc = tokens.get("error_description") or "בקשה נדחתה. נא לאשר בדפדפן ולנסות שוב."
                 await query.answer(f"שגיאה: {err}\n{desc}"[:190], show_alert=True)

--- a/handlers/drive/menu.py
+++ b/handlers/drive/menu.py
@@ -174,7 +174,10 @@ class GoogleDriveMenuHandler:
         if data == "drive_sel_zip":
             # Pre-check Drive availability
             if gdrive.get_drive_service(user_id) is None:
-                kb = [[InlineKeyboardButton("🔙 חזרה", callback_data="drive_backup_now")]]
+                kb = [
+                    [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                    [InlineKeyboardButton("🔙 חזרה", callback_data="drive_backup_now")],
+                ]
                 await query.edit_message_text("❌ לא ניתן לגשת ל‑Drive כרגע. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
                 return
             # Check if there are any saved ZIP backups
@@ -202,6 +205,14 @@ class GoogleDriveMenuHandler:
             await self._render_simple_selection(update, context, header_prefix=f"✅ הועלו {count} גיבויי ZIP ל‑Drive\n\n")
             return
         if data == "drive_sel_all":
+            # Pre-check Drive availability
+            if gdrive.get_drive_service(user_id) is None:
+                kb = [
+                    [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                    [InlineKeyboardButton("🔙 חזרה", callback_data="drive_backup_now")],
+                ]
+                await query.edit_message_text("❌ לא ניתן לגשת ל‑Drive כרגע. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
+                return
             fn, data_bytes = gdrive.create_full_backup_zip_bytes(user_id, category="all")
             # Friendly name + subpath
             friendly = gdrive.compute_friendly_name(user_id, "all", "CodeBot")
@@ -213,7 +224,11 @@ class GoogleDriveMenuHandler:
                 sess["last_upload"] = "all"
                 await self._render_simple_selection(update, context, header_prefix="✅ גיבוי מלא הועלה ל‑Drive\n\n")
             else:
-                await query.edit_message_text("❌ כשל בהעלאה")
+                kb = [
+                    [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                    [InlineKeyboardButton("🔙 חזרה", callback_data="drive_backup_now")],
+                ]
+                await query.edit_message_text("❌ כשל בהעלאה. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
             return
         if data == "drive_sel_adv":
             await self._render_advanced_menu(update, context)
@@ -221,7 +236,11 @@ class GoogleDriveMenuHandler:
         if data in {"drive_adv_by_repo", "drive_adv_large", "drive_adv_other"}:
             # Ensure Drive service ready
             if gdrive.get_drive_service(user_id) is None:
-                await query.edit_message_text("❌ לא ניתן לגשת ל‑Drive כרגע. נסה להתחבר מחדש או לבדוק הרשאות.")
+                kb = [
+                    [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                    [InlineKeyboardButton("🔙 חזרה", callback_data="drive_sel_adv")],
+                ]
+                await query.edit_message_text("❌ לא ניתן לגשת ל‑Drive כרגע. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
                 return
             category = {
                 "drive_adv_by_repo": "by_repo",
@@ -246,7 +265,14 @@ class GoogleDriveMenuHandler:
                         sub_path = gdrive.compute_subpath("by_repo", repo_name)
                         fid = gdrive.upload_bytes(user_id, friendly, data_bytes, sub_path=sub_path)
                         ok_any = ok_any or bool(fid)
-                    await query.edit_message_text("✅ הועלו גיבויי ריפו לפי תיקיות" if ok_any else "❌ כשל בהעלאה")
+                    if ok_any:
+                        await query.edit_message_text("✅ הועלו גיבויי ריפו לפי תיקיות")
+                    else:
+                        kb = [
+                            [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                            [InlineKeyboardButton("🔙 חזרה", callback_data="drive_sel_adv")],
+                        ]
+                        await query.edit_message_text("❌ כשל בהעלאה. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
                 else:
                     # Pre-check category has files
                     try:
@@ -273,7 +299,14 @@ class GoogleDriveMenuHandler:
                     friendly = gdrive.compute_friendly_name(user_id, category, "CodeBot")
                     sub_path = gdrive.compute_subpath(category)
                     fid = gdrive.upload_bytes(user_id, friendly, data_bytes, sub_path=sub_path)
-                    await query.edit_message_text("✅ גיבוי הועלה ל‑Drive" if fid else "❌ כשל בהעלאה")
+                    if fid:
+                        await query.edit_message_text("✅ גיבוי הועלה ל‑Drive")
+                    else:
+                        kb = [
+                            [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                            [InlineKeyboardButton("🔙 חזרה", callback_data="drive_sel_adv")],
+                        ]
+                        await query.edit_message_text("❌ כשל בהעלאה. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
             return
         if data == "drive_adv_multi_toggle":
             sess = self._session(user_id)
@@ -311,7 +344,14 @@ class GoogleDriveMenuHandler:
                     fid = gdrive.upload_bytes(user_id, friendly, data_bytes, sub_path=sub_path)
                     uploaded_any = uploaded_any or bool(fid)
             sess["adv_selected"] = set()
-            await query.edit_message_text("✅ הועלו הגיבויים שנבחרו" if uploaded_any else "❌ כשל בהעלאה")
+            if uploaded_any:
+                await query.edit_message_text("✅ הועלו הגיבויים שנבחרו")
+            else:
+                kb = [
+                    [InlineKeyboardButton("🔐 התחבר ל‑Drive", callback_data="drive_auth")],
+                    [InlineKeyboardButton("🔙 חזרה", callback_data="drive_sel_adv")],
+                ]
+                await query.edit_message_text("❌ כשל בהעלאה. נסה להתחבר מחדש או לבדוק הרשאות.", reply_markup=InlineKeyboardMarkup(kb))
             return
         if data == "drive_choose_folder":
             # Remember current simple menu context
@@ -535,6 +575,22 @@ class GoogleDriveMenuHandler:
         }
         return mapping.get(key) or "🗓 זמני גיבוי"
 
+    def _compose_selection_header(self, user_id: int) -> str:
+        sess = self._session(user_id)
+        last_upload = sess.get("last_upload")
+        if last_upload == "zip":
+            typ = "קבצי ZIP"
+        elif last_upload == "all":
+            typ = "הכל"
+        elif isinstance(last_upload, str) and last_upload in {"by_repo", "large", "other"}:
+            typ = {"by_repo": "לפי ריפו", "large": "קבצים גדולים", "other": "שאר קבצים"}[last_upload]
+        else:
+            typ = "—"
+        folder = sess.get("target_folder_label") or "ברירת מחדל (גיבויי_קודלי)"
+        sched = self._schedule_button_label(user_id)
+        sched_text = sched.replace("🕑 ", "") if sched != "🗓 זמני גיבוי" else "לא נקבע"
+        return f"פרטים: סוג: {typ} | תיקייה: {folder} | תזמון: {sched_text}\n"
+
     def _folder_button_label(self, user_id: int) -> str:
         sess = self._session(user_id)
         label = sess.get("target_folder_label")
@@ -564,7 +620,8 @@ class GoogleDriveMenuHandler:
             [InlineKeyboardButton("⚙️ מתקדם", callback_data="drive_sel_adv")],
             [InlineKeyboardButton("🚪 התנתק", callback_data="drive_logout")],
         ]
-        await send(header_prefix + "בחר מה לגבות:", reply_markup=InlineKeyboardMarkup(kb))
+        header = header_prefix + self._compose_selection_header(user_id)
+        await send(header + "בחר מה לגבות:", reply_markup=InlineKeyboardMarkup(kb))
 
     async def _render_after_folder_selection(self, update: Update, context: ContextTypes.DEFAULT_TYPE, success: bool):
         query = update.callback_query
@@ -596,7 +653,8 @@ class GoogleDriveMenuHandler:
             [InlineKeyboardButton("🔙 חזרה", callback_data="drive_backup_now")],
             [InlineKeyboardButton("🚪 התנתק", callback_data="drive_logout")],
         ]
-        await query.edit_message_text(header_prefix + "בחר קטגוריה מתקדמת:", reply_markup=InlineKeyboardMarkup(kb))
+        header = header_prefix + self._compose_selection_header(user_id)
+        await query.edit_message_text(header + "בחר קטגוריה מתקדמת:", reply_markup=InlineKeyboardMarkup(kb))
 
     async def _render_simple_summary(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query

--- a/main.py
+++ b/main.py
@@ -395,7 +395,7 @@ class CodeKeeperBot:
         self.application.add_handler(
             CallbackQueryHandler(
                 drive_handler.handle_callback,
-                pattern=r'^(drive_menu|drive_auth|drive_poll_once|drive_cancel_auth|drive_backup_now|drive_sel_zip|drive_sel_all|drive_sel_adv|drive_advanced|drive_adv_by_repo|drive_adv_large|drive_adv_other|drive_choose_folder|drive_folder_default|drive_folder_set|drive_schedule|drive_set_schedule:.*|drive_adv_multi_toggle|drive_adv_upload_selected|drive_logout)$'
+                pattern=r'^(drive_menu|drive_auth|drive_poll_once|drive_cancel_auth|drive_backup_now|drive_sel_zip|drive_sel_all|drive_sel_adv|drive_advanced|drive_adv_by_repo|drive_adv_large|drive_adv_other|drive_choose_folder|drive_choose_folder_adv|drive_folder_default|drive_folder_auto|drive_folder_set|drive_folder_back|drive_folder_cancel|drive_schedule|drive_set_schedule:.*|drive_adv_multi_toggle|drive_adv_upload_selected|drive_logout)$'
             )
         )
 

--- a/main.py
+++ b/main.py
@@ -590,6 +590,11 @@ class CodeKeeperBot:
         # פקודה /drive
         self.application.add_handler(CommandHandler("drive", show_drive_menu))
         # כפתור חדש לתפריט גיבוי/שחזור
+
+        # פקודה /docs – שליחת קישור לתיעוד
+        async def show_docs(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            await update.message.reply_text(f"📚 תיעוד: {config.DOCUMENTATION_URL}")
+        self.application.add_handler(CommandHandler("docs", show_docs))
         # הוסר: כפתורי גיבוי/שחזור מהמקלדת הראשית. כעת תחת /github -> 🧰 גיבוי ושחזור
         # self.application.add_handler(MessageHandler(
         #     filters.Regex("^(📦 גיבוי מלא|♻️ שחזור מגיבוי|🧰 גיבוי/שחזור)$"),

--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - optional dependency
 from config import config
 from database import db
 from file_manager import backup_manager
+import logging
 
 
 DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
@@ -91,11 +92,13 @@ def poll_device_token(device_code: str) -> Optional[Dict[str, Any]]:
             err, desc = None, None
         # Pending/slowdown are not errors for the UI
         if err in {"authorization_pending", "slow_down"}:
+            logging.getLogger(__name__).debug("Drive auth pending/slow_down")
             return None
         # Access denied / expired / invalid_grant are user-facing errors
         if err in {"access_denied", "expired_token", "invalid_grant", "invalid_request", "invalid_client"}:
             return {"error": err or "bad_request", "error_description": desc}
         # Unknown 400 – return a generic error record
+        logging.getLogger(__name__).warning(f"Drive auth error: {err} {desc}")
         return {"error": err or f"http_{resp.status_code}", "error_description": desc or "token endpoint error"}
     # Success
     tokens = resp.json()
@@ -137,6 +140,7 @@ def _credentials_from_tokens(tokens: Dict[str, Any]) -> Credentials:
 def _ensure_valid_credentials(user_id: int) -> Optional[Credentials]:
     tokens = _load_tokens(user_id)
     if not tokens:
+        logging.getLogger(__name__).warning("Drive creds missing for user; need login")
         return None
     try:
         creds = _credentials_from_tokens(tokens)
@@ -158,6 +162,7 @@ def _ensure_valid_credentials(user_id: int) -> Optional[Credentials]:
             }
             save_tokens(user_id, updated)
         except Exception:
+            logging.getLogger(__name__).exception("Drive token refresh failed")
             return None
     return creds
 


### PR DESCRIPTION
שיפורי אמינות וחוויית משתמש בתפריט Google Drive:

שימור refresh_token והסרת פול כפול למניעת ניתוקים
טיפול שגיאות עם כפתור “התחבר ל‑Drive” במקום כשל כללי
תיקון כפתור “אוטומטי” שלא הגיב (callback חסר)
שורת פרטים עקבית בראש התפריט (סוג, תיקייה, תזמון)
דגל פיצ’ר DRIVE_MENU_V2 לכיבוי/הדלקה מהירים
Breadcrumbs ללוגים לזיהוי כשלי OAuth/רענון
שינויים עיקריים
config.py
הוספת DRIVE_MENU_V2 (ברירת מחדל true, קריאה מ־env)
handlers/drive/menu.py
בדיקת דגל בתחילת התפריט (כיבוי מהיר)
הוספת callbacks חסרים: drive_folder_auto, drive_choose_folder_adv, drive_folder_back, drive_folder_cancel
בדיקות חיבור לפני ZIP/הכל והודעות עם כפתור “התחבר ל‑Drive”
שורת פרטים בראש התפריטים (פשוט/מתקדם)
Breadcrumbs ללוגים: התחלה/סיום התחברות, Logout
services/google_drive_service.py
שמירת טוקנים תוך שימור refresh_token אם לא מוחזר
לוגים על pending/slow_down, שגיאות OAuth, וכשל רענון
main.py
הרחבת תבנית ה‑CallbackQueryHandler לכל ה‑callbacks החדשים
איך מפעילים
ברירת מחדל: DRIVE_MENU_V2=true (מוצג התפריט החדש)
לכיבוי זמני: DRIVE_MENU_V2=false והפעלת הבוט מחדש
בדיקות
Smoke ידני:
התחברות ל‑Drive ולאחריה העלאת “הכל” ו־“קבצי ZIP”
כפתור “אוטומטי” מעדכן יעד
הודעת שגיאה עם כפתור “התחבר ל‑Drive” בעת חוסר הרשאות/ניתוק
שורת פרטים מוצגת עקבית בפשוט/מתקדם
יחידות (ללא ריצה ב‑CI כאן): הוגדרו נקודות הזרקה ללוגים ובדיקת לוגיקת שמירת טוקנים
סיכונים/רולבק
סיכון נמוך: השינויים ממוקדים בתפריט ה‑Drive ושכבת הטוקנים
רולבק: כיבוי מהיר עם DRIVE_MENU_V2=false; לחלופין revert לענף
נספח: תועלות למשתמש
פחות ניתוקים לא מוסברים
הנחיה מיידית להתחברות מחדש בעת צורך
שקיפות מצב (סוג/תיקייה/תזמון

### 📚 Documentation
- https://amirbiron.github.io/CodeBot/