### PR TITLE
Fix drive menu zip selection and confirm button

### DIFF
--- a/handlers/drive/menu.py
+++ b/handlers/drive/menu.py
@@ -671,13 +671,16 @@ class GoogleDriveMenuHandler:
 
     def _compose_selection_header(self, user_id: int) -> str:
         sess = self._session(user_id)
+        # Prefer showing current selection (UI state) over last executed upload
+        selected = sess.get("selected_category")
         last_upload = sess.get("last_upload")
-        if last_upload == "zip":
+        category = selected or last_upload
+        if category == "zip":
             typ = "קבצי ZIP"
-        elif last_upload == "all":
+        elif category == "all":
             typ = "הכל"
-        elif isinstance(last_upload, str) and last_upload in {"by_repo", "large", "other"}:
-            typ = {"by_repo": "לפי ריפו", "large": "קבצים גדולים", "other": "שאר קבצים"}[last_upload]
+        elif isinstance(category, str) and category in {"by_repo", "large", "other"}:
+            typ = {"by_repo": "לפי ריפו", "large": "קבצים גדולים", "other": "שאר קבצים"}[category]
         else:
             typ = "—"
         folder = sess.get("target_folder_label") or "ברירת מחדל (גיבויי_קודלי)"

--- a/main.py
+++ b/main.py
@@ -395,7 +395,7 @@ class CodeKeeperBot:
         self.application.add_handler(
             CallbackQueryHandler(
                 drive_handler.handle_callback,
-                pattern=r'^(drive_menu|drive_auth|drive_poll_once|drive_cancel_auth|drive_backup_now|drive_sel_zip|drive_sel_all|drive_sel_adv|drive_advanced|drive_adv_by_repo|drive_adv_large|drive_adv_other|drive_choose_folder|drive_choose_folder_adv|drive_folder_default|drive_folder_auto|drive_folder_set|drive_folder_back|drive_folder_cancel|drive_schedule|drive_set_schedule:.*|drive_adv_multi_toggle|drive_adv_upload_selected|drive_logout)$'
+                pattern=r'^(drive_menu|drive_auth|drive_poll_once|drive_cancel_auth|drive_backup_now|drive_sel_zip|drive_sel_all|drive_sel_adv|drive_advanced|drive_adv_by_repo|drive_adv_large|drive_adv_other|drive_choose_folder|drive_choose_folder_adv|drive_folder_default|drive_folder_auto|drive_folder_set|drive_folder_back|drive_folder_cancel|drive_schedule|drive_set_schedule:.*|drive_adv_multi_toggle|drive_adv_upload_selected|drive_logout|drive_logout_do|drive_simple_confirm|drive_adv_confirm|drive_make_zip_now)$'
             )
         )
 


### PR DESCRIPTION
Update Drive menu V2 to correctly display the selected backup type and enable confirm actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-39ef21d4-8885-49d2-b9c7-e0aa7a4e1c3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39ef21d4-8885-49d2-b9c7-e0aa7a4e1c3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

