### PR TITLE
Restore zip import by repository organization

### DIFF
--- a/database/manager.py
+++ b/database/manager.py
@@ -218,8 +218,8 @@ class DatabaseManager:
     def save_code_snippet(self, snippet) -> bool:
         return self._get_repo().save_code_snippet(snippet)
 
-    def save_file(self, user_id: int, file_name: str, code: str, programming_language: str) -> bool:
-        return self._get_repo().save_file(user_id, file_name, code, programming_language)
+    def save_file(self, user_id: int, file_name: str, code: str, programming_language: str, extra_tags: List[str] = None) -> bool:
+        return self._get_repo().save_file(user_id, file_name, code, programming_language, extra_tags)
 
     def get_latest_version(self, user_id: int, file_name: str) -> Optional[Dict]:
         return self._get_repo().get_latest_version(user_id, file_name)

--- a/file_manager.py
+++ b/file_manager.py
@@ -404,7 +404,8 @@ class BackupManager:
                                 results["errors"].append(f"decode failed for {name}: {e}")
                                 continue
                         lang = detect_language_from_filename(name)
-                        ok = db.save_file(user_id=user_id, file_name=name, code=text, programming_language=lang)
+                        # העברת extra_tags כדי לתייג כל קובץ מיובא (למשל repo:owner/name)
+                        ok = db.save_file(user_id=user_id, file_name=name, code=text, programming_language=lang, extra_tags=(extra_tags or []))
                         if ok:
                             results["restored_files"] += 1
                         else:


### PR DESCRIPTION
Restore automatic `repo:owner/name` tagging for ZIP imports to organize files under "By Repo".

Previously, importing a ZIP from a repository would tag all files with `repo:owner/name`, making them appear under the "By Repo" section. This functionality was lost, causing files to be treated as untagged and appear under "Other Files". This PR reintroduces the tagging logic, including inferring the repository name from the ZIP structure or filename if `metadata.json` is not present. This ensures that imported repository ZIPs are correctly categorized and displayed as `repo:owner/name (count)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1709656e-c5c4-4661-8c03-a45f81ebf448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1709656e-c5c4-4661-8c03-a45f81ebf448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

