### PR TITLE
Feat/repo zip tagging delete by repo

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -1930,28 +1930,83 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             action = data.split(":", 1)[1]
             return await execute_batch_on_current_selection(update, context, action)
         elif data.startswith("by_repo:"):
-            # הצגת קבצים לפי תגית ריפו
+            # הצגת קבצים לפי תגית ריפו + אפשרות מחיקה מרוכזת
             tag = data.split(":", 1)[1]
             # סימון מקור הרשימה: "לפי ריפו" עם התגית שנבחרה
             context.user_data['files_origin'] = { 'type': 'by_repo', 'tag': tag }
             from database import db
             user_id = update.effective_user.id
-            files = db.search_code(user_id, query="", tags=[tag], limit=200)
+            files = db.search_code(user_id, query="", tags=[tag], limit=10000)
             if not files:
                 await query.edit_message_text("ℹ️ אין קבצים עבור התגית הזו.")
                 return ConversationHandler.END
             keyboard = []
+            # שמירת קאש לכל הקבצים לשימוש בעימוד/פתיחה
+            context.user_data['files_cache'] = {}
             for i, f in enumerate(files[:20]):
                 name = f.get('file_name', 'ללא שם')
                 keyboard.append([InlineKeyboardButton(name, callback_data=f"file_{i}")])
-                # שמור קאש קל להצגה
-                context.user_data.setdefault('files_cache', {})[str(i)] = f
+                context.user_data['files_cache'][str(i)] = f
+            # פעולת מחיקה לריפו הנוכחי
+            keyboard.append([InlineKeyboardButton("🗑️ מחק את כל הריפו", callback_data=f"repo_delete_confirm:{tag}")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="back_to_repo_menu")])
             keyboard.append([InlineKeyboardButton("🏠 תפריט ראשי", callback_data="main")])
             await query.edit_message_text(
                 f"📂 קבצים עם {tag}:",
                 reply_markup=InlineKeyboardMarkup(keyboard)
             )
+        elif data.startswith("repo_delete_confirm:"):
+            # שלב אישור ראשון למחיקת כל הקבצים תחת תגית ריפו
+            tag = data.split(":", 1)[1]
+            from database import db
+            user_id = update.effective_user.id
+            files = db.search_code(user_id, query="", tags=[tag], limit=10000) or []
+            total = len(files)
+            warn_text = (
+                f"⚠️ עומד/ת למחוק <b>{total}</b> קבצים תחת התגית <code>{tag}</code>\n"
+                "פעולה זו תסמן את הקבצים כלא־פעילים ולא תימחק פיזית קבצי ZIP/גדולים.\n\n"
+                "אם זה בטעות, חזור אחורה."
+            )
+            kb = [
+                [InlineKeyboardButton("✅ אני מאשר/ת", callback_data=f"repo_delete_double_confirm:{tag}")],
+                [InlineKeyboardButton("🔙 חזרה", callback_data=f"by_repo:{tag}")],
+            ]
+            await query.edit_message_text(warn_text, reply_markup=InlineKeyboardMarkup(kb), parse_mode=ParseMode.HTML)
+        elif data.startswith("repo_delete_double_confirm:"):
+            # שלב אישור שני
+            tag = data.split(":", 1)[1]
+            text2 = (
+                "🧨 אישור סופי למחיקה\n"
+                f"כל הקבצים תחת <code>{tag}</code> יימחקו (יוגדרו כלא־פעילים).\n"
+                "הפעולה בלתי הפיכה."
+            )
+            kb = [
+                [InlineKeyboardButton("🧨 כן, מחק", callback_data=f"repo_delete_do:{tag}")],
+                [InlineKeyboardButton("🔙 בטל", callback_data=f"by_repo:{tag}")],
+            ]
+            await query.edit_message_text(text2, reply_markup=InlineKeyboardMarkup(kb), parse_mode=ParseMode.HTML)
+        elif data.startswith("repo_delete_do:"):
+            # ביצוע מחיקה בפועל: מחיקה לפי שם קובץ של כל הקבצים תחת התג הנבחר
+            tag = data.split(":", 1)[1]
+            from database import db
+            user_id = update.effective_user.id
+            files = db.search_code(user_id, query="", tags=[tag], limit=10000) or []
+            deleted = 0
+            for f in files:
+                name = f.get('file_name')
+                if not name:
+                    continue
+                try:
+                    if db.delete_file(user_id, name):
+                        deleted += 1
+                except Exception:
+                    continue
+            msg = f"✅ נמחקו {deleted} קבצים תחת <code>{tag}</code>."
+            kb = [
+                [InlineKeyboardButton("🔙 חזור לתפריט ריפו", callback_data="by_repo_menu")],
+                [InlineKeyboardButton("🏠 תפריט ראשי", callback_data="main")],
+            ]
+            await query.edit_message_text(msg, reply_markup=InlineKeyboardMarkup(kb), parse_mode=ParseMode.HTML)
         elif data.startswith("batch_zip_page_"):
             try:
                 p = int(data.split("_")[-1])

--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -383,7 +383,7 @@ async def show_all_files(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         # - קבצים גדולים אינם מוחזרים כאן ממילא
         # - קבצי ZIP אינם חלק ממסד הקבצים
         # - קבצים עם תגית repo: יוצגו תחת "לפי ריפו" ולכן יוחרגו כאן
-        all_files = db.get_user_files(user_id)
+        all_files = db.get_user_files(user_id, limit=10000)
         files = [f for f in all_files if not any((t or '').startswith('repo:') for t in (f.get('tags') or []))]
         
         # מסך בחירה: 4 כפתורים
@@ -475,7 +475,7 @@ async def show_regular_files_callback(update: Update, context: ContextTypes.DEFA
     from database import db
     
     try:
-        all_files = db.get_user_files(user_id)
+        all_files = db.get_user_files(user_id, limit=10000)
         files = [f for f in all_files if not any((t or '').startswith('repo:') for t in (f.get('tags') or []))]
         
         if not files:
@@ -546,7 +546,7 @@ async def show_regular_files_page_callback(update: Update, context: ContextTypes
     from database import db
     try:
         # קרא את כל הקבצים כדי לחשב עימוד, אך הצג רק "שאר הקבצים"
-        all_files = db.get_user_files(user_id)
+        all_files = db.get_user_files(user_id, limit=10000)
         files = [f for f in all_files if not any((t or '').startswith('repo:') for t in (f.get('tags') or []))]
         if not files:
             # אם אין קבצים, הצג הודעה וכפתור חזרה לתת־התפריט של הקבצים

--- a/database/manager.py
+++ b/database/manager.py
@@ -218,8 +218,8 @@ class DatabaseManager:
     def save_code_snippet(self, snippet) -> bool:
         return self._get_repo().save_code_snippet(snippet)
 
-    def save_file(self, user_id: int, file_name: str, code: str, programming_language: str) -> bool:
-        return self._get_repo().save_file(user_id, file_name, code, programming_language)
+    def save_file(self, user_id: int, file_name: str, code: str, programming_language: str, extra_tags: List[str] = None) -> bool:
+        return self._get_repo().save_file(user_id, file_name, code, programming_language, extra_tags)
 
     def get_latest_version(self, user_id: int, file_name: str) -> Optional[Dict]:
         return self._get_repo().get_latest_version(user_id, file_name)

--- a/file_manager.py
+++ b/file_manager.py
@@ -404,7 +404,8 @@ class BackupManager:
                                 results["errors"].append(f"decode failed for {name}: {e}")
                                 continue
                         lang = detect_language_from_filename(name)
-                        ok = db.save_file(user_id=user_id, file_name=name, code=text, programming_language=lang)
+                        # העברת extra_tags כדי לתייג כל קובץ מיובא (למשל repo:owner/name)
+                        ok = db.save_file(user_id=user_id, file_name=name, code=text, programming_language=lang, extra_tags=(extra_tags or []))
                         if ok:
                             results["restored_files"] += 1
                         else:


### PR DESCRIPTION

<h2>📥 ייבוא ZIP לפי ריפו + 🗑️ מחיקה מרוכזת + 📄 תיקון עימוד</h2>

<p>
שחזור ההתנהגות הקודמת של ייבוא ZIP מריפו עם תיוג <code>repo:owner/name</code>, הוספת מחיקה מרוכזת לכל ריפו מתוך "לפי ריפו", ותיקון מגבלת התצוגה ב"שאר הקבצים".
</p>

<h3>✨ מה נכלל</h3>
<ul>
  <li>🔖 תיוג אוטומטי בייבוא ZIP: לכל קובץ מיובא מצורפת תגית <code>repo:owner/name</code>.
    <ul>
      <li>קריאה מ-<code>metadata.json</code> אם קיים</li>
      <li>זיהוי חכם מתיקיית השורש של ZIP מגיטהאב (למשל: <code>owner-repo-main/</code>)</li>
    </ul>
  </li>
  <li>🗂 "לפי ריפו": כפתור חדש למחיקת כל הקבצים של ריפו נבחר עם אישור כפול</li>
  <li>📁 "שאר הקבצים": טעינה עד 10,000 פריטים + עימוד מלא (לא מוגבל ל־50)</li>
  <li>🧭 אין כפילויות תוכן: ייבוא מחדש לאותו שם קובץ יוצר גרסה חדשה ונקי למחיקה מרוכזת</li>
</ul>

<h3>🤔 למה</h3>
<p>
נוסף בעבר פיצ'ר שחילץ ZIPים ישירות לקבצים רגילים ללא תיוג, מה ש"פירק" את ארגון ה"🗂 לפי ריפו". כאן אנחנו מחזירים את התיוג ואת חוויית הניהול לפי פרויקט, ומוסיפים מחיקה מרוכזת נוחה.
</p>

<h3>🧪 איך לבדוק</h3>
<ol>
  <li>ייבוא ZIP:
    <ol>
      <li>לחצו "📥 ייבוא ZIP מריפו" ושלחו ZIP מהגיטהאב (Code → Download ZIP)</li>
      <li>ודאו הודעה: <strong>✅ יובאו N קבצים</strong></li>
      <li>עברו ל-"🗂 לפי ריפו" ובדקו שמופיע <code>repo:owner/name (N)</code></li>
    </ol>
  </li>
  <li>מחיקה מרוכזת:
    <ol>
      <li>בחרו תגית ריפו → לחצו "🗑️ מחק את כל הריפו"</li>
      <li>אשרו פעמיים (התראות ברורות) → קבלו סיכום <strong>✅ נמחקו X</strong></li>
    </ol>
  </li>
  <li>"שאר הקבצים":
    <ol>
      <li>פתחו "📁 שאר הקבצים" → ודאו שהספירה והעימוד מכסים את כל הפריטים (עד 10,000)</li>
    </ol>
  </li>
</ol>

<h3>🧩 שינויי קוד מרכזיים</h3>
<ul>
  <li><code>main.py</code>:
    <ul>
      <li>זרימת "zip_import": קריאה ל-<code>metadata.json</code> + גזירת <code>owner/name</code> משורש ZIP/שם הקובץ</li>
      <li>מעבר של <code>extra_tags=[repo:owner/name]</code> לשחזור</li>
    </ul>
  </li>
  <li><code>file_manager.py</code>:
    <ul>
      <li><code>restore_from_backup(..., extra_tags)</code> – העברת תגיות לחיסכון במסד</li>
    </ul>
  </li>
  <li><code>database/repository.py</code> + <code>database/manager.py</code>:
    <ul>
      <li><code>save_file(..., extra_tags=None)</code> – מיזוג תגיות קיימות עם חדשות (ללא כפילויות)</li>
    </ul>
  </li>
  <li><code>conversation_handlers.py</code>:
    <ul>
      <li>🗂 תצוגת "לפי ריפו": כפתור "🗑️ מחק את כל הריפו" + 2 שלבי אישור + מחיקה רכה</li>
      <li>📁 "שאר הקבצים": טעינת עד 10,000 פריטים לצורך עימוד מלא</li>
    </ul>
  </li>
  <li><code>handlers/file_view.py</code>:
    <ul>
      <li>שמירת מקור ניווט נכון בין "שאר הקבצים" ל"לפי ריפו"</li>
    </ul>
  </li>
</ul>

<h3>🛡️ בטיחות ומדיניות</h3>
<ul>
  <li>מחיקה היא <strong>רכה</strong>: מסומן <code>is_active = false</code> במסד; אין מחיקה פיזית של ZIP/קבצים גדולים</li>
  <li>אין שינויי הרשאות/נתיבי דיסק; אין שימוש בפקודות מחיקה מסוכנות</li>
</ul>

<h3>⚙️ ביצועים</h3>
<ul>
  <li>הגדלת טעינה ל־10,000 ב"שאר הקבצים" נתמכת בעימוד UI; אין שאילתות כבדות לא סופרות</li>
</ul>

<h3>✅ בדיקות</h3>
<ul>
  <li>ייבוא ZIP עם <code>metadata.json</code> (כולל <code>repo</code>)</li>
  <li>ייבוא ZIP סטנדרטי מגיטהאב (ללא <code>metadata.json</code>) – זיהוי מתיקיית שורש</li>
  <li>מחיקה מרוכזת לריפו עם 10+ קבצים (אישור כפול)</li>
  <li>תצוגת "שאר הקבצים" מעל 50 פריטים עם ניווט בין עמודים</li>
</ul>

<h3>🧯 סיכוני Rollback</h3>
<ul>
  <li>נמוך. אפשר להחזיר את הענף; מחיקות הן רכות וניתן לשחזר גרסאות קיימות</li>
</ul>

<h3>🔗 מטא</h3>
<ul>
  <li>Base: <code>main</code></li>
  <li>Branch: <code>feat/repo-zip-tagging-delete-by-repo</code></li>
  <li>Docs: “📥 ייבוא ZIP מריפו” בהסברים למשתמש – תואם</li>
</ul>

<h3>📝 צ'קליסט</h3>
<ul>
  <li>[x] תיוג ZIP → <code>repo:owner/name</code></li>
  <li>[x] כפתור מחיקת ריפו עם אישור כפול</li>
  <li>[x] עימוד “שאר הקבצים” עד 10,000</li>
  <li>[x] בדיקות ידניות לזרימות העיקריות</li>
</ul>