### PR TITLE
Enable disk use for MongoDB aggregation

### DIFF
--- a/database/repository.py
+++ b/database/repository.py
@@ -131,7 +131,7 @@ class Repository:
                 {"$sort": {"updated_at": -1}},
                 {"$limit": limit},
             ]
-            return list(self.manager.collection.aggregate(pipeline))
+            return list(self.manager.collection.aggregate(pipeline, allowDiskUse=True))
         except Exception as e:
             logger.error(f"שגיאה בקבלת קבצי משתמש: {e}")
             return []
@@ -154,7 +154,7 @@ class Repository:
                 {"$sort": {"updated_at": -1}},
                 {"$limit": limit},
             ]
-            return list(self.manager.collection.aggregate(pipeline))
+            return list(self.manager.collection.aggregate(pipeline, allowDiskUse=True))
         except Exception as e:
             logger.error(f"שגיאה בחיפוש קוד: {e}")
             return []
@@ -206,7 +206,7 @@ class Repository:
                     "latest_activity": {"$max": "$latest_update"},
                 }},
             ]
-            result = list(self.manager.collection.aggregate(pipeline))
+            result = list(self.manager.collection.aggregate(pipeline, allowDiskUse=True))
             if result:
                 stats = result[0]
                 stats.pop('_id', None)


### PR DESCRIPTION
<div style="font-family:Segoe UI, Arial, sans-serif; line-height:1.5;">
  <h2 style="margin:0 0 8px;">fix(db): הוספת allowDiskUse ל‑Mongo aggregates כדי למנוע שגיאת Sort (292)</h2>

  <div style="margin:6px 0 14px;">
    <span style="background:#eaf5ff;color:#0550ae;padding:2px 8px;border-radius:12px;font-size:12px;">תיקון באג</span>
    <span style="background:#dafbe1;color:#055d20;padding:2px 8px;border-radius:12px;font-size:12px;">השפעה: נמוכה</span>
    <span style="background:#fff8c5;color:#4d2d00;padding:2px 8px;border-radius:12px;font-size:12px;">קבצים שנגעו: 1</span>
  </div>

  <p><strong>מה הבעיה?</strong> בשאילתות אגרגציה יש שני שלבי <code>$sort</code> ללא <code>allowDiskUse</code>, מה שהוביל לשגיאת Mongo:
    <code>QueryExceededMemoryLimitNoDiskUseAllowed (code 292)</code>. התוצאה: מסכי "שאר הקבצים" ו"לפי ריפו" חזרו ריקים.</p>

  <p><strong>מה השתנה?</strong></p>
  <ul style="margin-top:0;">
    <li>הוספת <code>allowDiskUse=True</code> לכל קריאות <code>aggregate</code> שממיינות:
      <code>Repository.get_user_files</code>, <code>Repository.search_code</code>, <code>Repository.get_user_stats</code>.
    </li>
    <li>קובץ מעודכן: <code>database/repository.py</code> בלבד. אין שינוי סכימה/מיגרציות.</li>
  </ul>

  <p><strong>למה זה פותר?</strong> מאפשר ל‑MongoDB לבצע external sort על דיסק במקום לחצות מגבלת זיכרון (32MB), כך שהשאילתות לא ייכשלו וה‑UI יציג תוצאות.</p>

  <details style="margin:10px 0;">
    <summary style="cursor:pointer;"><strong>אימות ידני</strong></summary>
    <ol>
      <li>ב‑Render: להריץ <em>Clear build cache &amp; deploy</em> לענף <code>fix/allowDiskUse-aggregates</code>.</li>
      <li>ב‑UI:
        <ul>
          <li>"📁 שאר הקבצים" מציג עד 50 פריטים (עם עימוד אם יש).</li>
          <li>"לפי ריפו" מציג תגיות <code>repo:owner/name</code> ותוכן תחת כל תגית.</li>
        </ul>
      </li>
      <li>בלוגים: אין יותר <code>Sort exceeded memory limit ... code 292</code>.</li>
    </ol>
  </details>

  <details>
    <summary style="cursor:pointer;"><strong>המלצת ביצועים (לא חובה לפרסום ה‑PR)</strong></summary>
    <p>להוסיף אינדקס ידידותי למיון הראשון כדי לצמצם שימוש ב‑external sort:</p>
    <pre style="background:#f6f8fa;padding:10px;border-radius:6px;margin:6px 0;">{ user_id: 1, is_active: 1, file_name: 1, version: -1 }</pre>
  </details>

  <p><strong>סיכונים ורולבאק</strong>: נמוך. שינוי פרמטר בלבד. במקרה צורך — Revert לקומיט והפריסה תחזור לקודם.</p>

  <p><strong>קישורים</strong>:
    <br/>ענף: <a href="https://github.com/amirbiron/CodeBot/tree/fix/allowDiskUse-aggregates">fix/allowDiskUse-aggregates</a>
    <br/>פתיחת PR: <a href="https://github.com/amirbiron/CodeBot/pull/new/fix/allowDiskUse-aggregates">Create Pull Request</a>
  </p>
</div>