### PR TITLE
Fix none values in files page languages

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -372,6 +372,8 @@ def files():
     
     # רשימת שפות לפילטר
     languages = db.code_snippets.distinct('programming_language', {'user_id': user_id})
+    # סינון None וערכים ריקים ומיון
+    languages = sorted([lang for lang in languages if lang]) if languages else []
     
     # חישוב עמודים
     total_pages = (total_count + per_page - 1) // per_page
@@ -380,7 +382,7 @@ def files():
                          user=session['user_data'],
                          files=files_list,
                          total_count=total_count,
-                         languages=sorted(languages) if languages else [],
+                         languages=languages,
                          search_query=search_query,
                          language_filter=language_filter,
                          sort_by=sort_by,


### PR DESCRIPTION
Filter `None` and empty strings from the language list to prevent a `TypeError` on the 'My Files' page.

---
<a href="https://cursor.com/background-agent?bcId=bc-caea3f38-a01d-49c0-9f62-2a107cb9f9eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-caea3f38-a01d-49c0-9f62-2a107cb9f9eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

