### PR TITLE
Feat/telegram repo browser 00ec5c5

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -645,7 +645,7 @@ class GitHubMenuHandler:
             # העבר את "בחר תיקיית יעד" למעלה, ישירות אחרי "בחר ריפו"
             keyboard.append([InlineKeyboardButton("📂 בחר תיקיית יעד", callback_data="set_folder")])
             # ניווט בריפו
-            keyboard.append([InlineKeyboardButton("🧭 עיין בריפו", callback_data="browse_repo")])
+            keyboard.append([InlineKeyboardButton("🗃️ עיין בריפו", callback_data="browse_repo")])
             # כפתור העלאה
             keyboard.append([InlineKeyboardButton("📤 העלה קובץ חדש", callback_data="upload_file")])
             # פעולות נוספות בטוחות


### PR DESCRIPTION
<h3>עדכון לתיאור ה‑PR</h3> <ul> <li><strong>Markdown</strong>: הצגה נקייה של קבצי <code>.md</code>/<code>.markdown</code> כשמורים מעברי השורות (תצוגת <code>&lt;pre&gt;</code> ללא המרות שמשטחות טקסט).</li> <li><strong>הורדה נשארת בעץ</strong>: אחרי “⬇️ הורד” נשארים בדפדפן הריפו (רענון מקלדת בלבד), במקום לחזור לתפריט הראשי.</li> <li><strong>אימוג׳י ייחודי</strong>: כפתור “עיין בריפו” הוחלף ל‑“🗃️ עיין בריפו” כדי להבדיל מ‑“📂 בחר תיקיית יעד”.</li> </ul> <p>שאר השינויים כפי שתוארו: עץ תיקיות עם עימוד, breadcrumbs, תצוגת קובץ חלקית עם “הצג עוד ⤵️” והדגשת תחביר, חיפוש בשם קובץ, ובחירת ref (ענף/תג).</p>