### PR TITLE
Fix GitHub repo browser activity 20250909014103

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -35,14 +35,7 @@ BOT_USERNAME = os.getenv('BOT_USERNAME', 'my_code_keeper_bot')
 BOT_USERNAME_CLEAN = (BOT_USERNAME or '').lstrip('@')
 WEBAPP_URL = os.getenv('WEBAPP_URL', 'https://code-keeper-webapp.onrender.com')
 
-# Activity reporter (optional)
-REPORT_ACTIVITY = os.getenv('REPORT_ACTIVITY', 'true').lower() == 'true'
-SERVICE_ID = os.getenv('RENDER_SERVICE_ID') or os.getenv('SERVICE_ID') or 'webapp'
-try:
-    from activity_reporter import create_reporter as _create_reporter
-    _activity = _create_reporter(MONGODB_URL, SERVICE_ID, service_name='CodeKeeper WebApp') if (REPORT_ACTIVITY and MONGODB_URL) else None
-except Exception:
-    _activity = None
+ 
 
 # חיבור ל-MongoDB
 client = None
@@ -54,15 +47,7 @@ def inject_globals():
         'bot_username': BOT_USERNAME_CLEAN,
     }
 
-@app.before_request
-def _report_user_activity():
-    """דיווח פעילות לכל בקשה (ללא זיהוי משתמש אם אין סשן)."""
-    try:
-        if _activity is not None:
-            uid = session.get('user_id') or 0
-            _activity.report_activity(uid)
-    except Exception:
-        pass
+ 
 
 
 def get_db():
@@ -887,11 +872,6 @@ def health():
         health_data['status'] = 'unhealthy'
         health_data['error'] = str(e)
     
-    try:
-        if _activity is not None:
-            _activity.report_activity(0)
-    except Exception:
-        pass
     return jsonify(health_data)
 
 # --- Public share route ---


### PR DESCRIPTION
<h2>תיקוני Repo Browser + ניקוי WebApp activity_reporter</h2>

<ul>
  <li><b>חיפוש קבצים (Browse Repo)</b>: תוקן שימוש בשאילתא ל-GitHub Code Search כדי למנוע שגיאת 422. 
    <br/>כעת משתמשים ב-<code>in:path</code> בלבד ומנרמלים את מחרוזת החיפוש (כולל מחרוזות עם רווחים).</li>
  <li><b>כפתור שיתוף ברשימות</b>: הוסר כפתור "🔗 שתף קישור" מרשימת הקבצים. 
    <br/>כפתור השיתוף נשאר זמין <u>רק</u> במסך תצוגת הקובץ.</li>
  <li><b>Button_data_invalid</b>: נוספה שכבת אבטחה לכל ה-callbacks עם נתיבים ארוכים. 
    <br/>מיפוי אינדקסים ב-<code>context.user_data</code> מונע חריגה ממגבלת 64 בתים של Telegram.</li>
  <li><b>YAML Highlight</b>: במסך תצוגה לזיהוי <code>.yml/.yaml</code> יש הדגשה ייעודית, כך שהתצוגה צבעונית וקריאה.</li>
  <li><b>שאר הקבצים (GitHub > העלה קובץ חדש)</b>: הושווה ל"הצג את כל הקבצים שלי" – 
    <br/>עימוד ל-20 פריטים בעמוד + אימוג׳י לפי סוג קובץ, ניווט "הבא/הקודם".</li>
  <li><b>בחירת תיקיית יעד</b>: הוסר כפתור "📌 בחר כיעד". 
    <br/>בחירה נעשית ע״י כניסה לתיקייה ואז "✅ סיום בחירה".</li>
  <li><b>WebApp</b>: בוצעה הסרת בלוקי <code>activity_reporter</code> מ-<code>webapp/app.py</code> (אתחול, before_request, ping ב-health).</li>
</ul>

<h3>בדיקות</h3>
<ul>
  <li>חיפוש בשם קובץ עם ובלי רווחים – ללא 422.</li>
  <li>מעבר עמודים ("הבא") רציף – ללא Button_data_invalid.</li>
  <li>תצוגת <code>.yml/.yaml</code> צבעונית.</li>
  <li>"שאר הקבצים" – 20 פריטים לעמוד + אימוג׳י + עימוד.</li>
  <li>בחירת תיקיית יעד – ללא כפתור "📌", מאושרת עם "✅ סיום בחירה".</li>
</ul>

<h3>שיקולי בטיחות</h3>
<ul>
  <li>אין מחיקות מסוכנות; כל הניקיונות מתבצעים רק ב-<code>/tmp</code> (ככל שקיים).</li>
  <li>callbacks ארוכים עוברים דרך מיפוי בטוח, ללא הטמעה של נתיב מלא ב-<code>callback_data</code>.</li>
</ul>