### PR TITLE
Fix read the docs build configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,3 @@ python:
 
 formats:
   - htmlzip
-
-environment:
-  variables:
-    READTHEDOCS: "True"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_autodoc_typehints',
     'sphinx_rtd_theme',
-    'sphinx_multiversion',
 ]
 
 # Napoleon settings for Google and NumPy style docstrings
@@ -80,22 +79,7 @@ html_theme_options = {
     'display_version': True,
     'prev_next_buttons_location': 'both',
 }
-# -- sphinx-multiversion -------------------------------------------------------
-# Build latest main and all tags like v*/
-smv_tag_whitelist = r'^v.*$'
-smv_branch_whitelist = r'^(main|master)$'
-smv_remote_whitelist = r'^origin$'
-smv_released_pattern = r'^tags/.+$'
-smv_latest_version = 'main'
-
-# Include PR branch in multiversion build when running on pull_request
-_event = os.getenv('GITHUB_EVENT_NAME', '')
-_pr_branch = os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME')
-try:
-    if _event == 'pull_request' and _pr_branch:
-        smv_branch_whitelist = rf'^(main|master|{re.escape(_pr_branch)})$'
-except Exception:
-    pass
+ 
 
 # Static files
 html_static_path = ['_static']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,17 +1,13 @@
-sphinx==7.3.7
-sphinx-rtd-theme==3.0.1
-sphinx-autodoc-typehints==2.2.3
-sphinx-multiversion==0.2.4
 # Documentation Requirements
 # =========================
 # Dependencies needed for building the documentation
 
 # Core Sphinx
 sphinx==7.4.7  # Last version supporting Python 3.9
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==3.0.1
 
 # Sphinx Extensions
-sphinx-autodoc-typehints==1.25.3  # Last version compatible with Sphinx 7.x
+sphinx-autodoc-typehints==2.2.3  # Compatible with Sphinx 7.x
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-mermaid==0.9.2
 
@@ -26,4 +22,4 @@ pydocstyle==6.3.0  # Docstring style checker
 doc8==1.1.2  # RST style checker
 
 # Optional: for generating API docs from source
-sphinx-apidoc==0.3.2
+# sphinx-apidoc is included with Sphinx; no separate package needed


### PR DESCRIPTION
Fix Read the Docs build failure by removing invalid configuration and incompatible `sphinx_multiversion` settings.

The `environment.variables.READTHEDOCS` key is not supported by Read the Docs and caused a build error. Additionally, `sphinx_multiversion` and its related configurations were removed from `docs/conf.py` and `docs/requirements.txt` as they were causing build failures and are not needed for the current documentation setup. Dependencies in `docs/requirements.txt` were also aligned for compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-0636cebf-d26a-43e7-95e3-73ad3c6fe125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0636cebf-d26a-43e7-95e3-73ad3c6fe125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

