### PR TITLE
Fix read the docs build and ci sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
 
   code-quality:
-    name: "🔍 Code Quality & Security"
+    name: "Code Quality"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -76,24 +76,7 @@ jobs:
               repo: context.repo.repo,
               sha,
               state: 'success',
-              context: '🔍 Code Quality & Security',
-              description: 'Checks passed',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-      - name: Report required status (success - plain)
-        if: ${{ success() }}
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
-            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha,
-              state: 'success',
-              context: 'Code Quality & Security',
+              context: 'Code Quality',
               description: 'Checks passed',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
@@ -111,30 +94,13 @@ jobs:
               repo: context.repo.repo,
               sha,
               state: 'failure',
-              context: '🔍 Code Quality & Security',
-              description: 'Checks failed',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-      - name: Report required status (failure - plain)
-        if: ${{ failure() }}
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
-            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha,
-              state: 'failure',
-              context: 'Code Quality & Security',
+              context: 'Code Quality',
               description: 'Checks failed',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
 
   unit-tests:
-    name: "🧪 Unit Tests (${{ matrix.python-version }})"
+    name: "Unit Tests (${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -205,27 +171,7 @@ jobs:
               repo: context.repo.repo,
               sha,
               state: 'success',
-              context: `🧪 Unit Tests (${ver})`,
-              description: 'Tests passed',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-        env:
-          PYV: ${{ matrix.python-version }}
-      - name: Report required status (success - plain)
-        if: ${{ success() }}
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
-            const ver = process.env.PYV || '${{ matrix.python-version }}';
-            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha,
-              state: 'success',
-              context: `Unit Tests (${ver})`,
+              context: `${ver}`,
               description: 'Tests passed',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
@@ -246,27 +192,7 @@ jobs:
               repo: context.repo.repo,
               sha,
               state: 'failure',
-              context: `🧪 Unit Tests (${ver})`,
-              description: 'Tests failed',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-        env:
-          PYV: ${{ matrix.python-version }}
-      - name: Report required status (failure - plain)
-        if: ${{ failure() }}
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
-            const ver = process.env.PYV || '${{ matrix.python-version }}';
-            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha,
-              state: 'failure',
-              context: `Unit Tests (${ver})`,
+              context: `${ver}`,
               description: 'Tests failed',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });

--- a/docs/api/services.github_service.rst
+++ b/docs/api/services.github_service.rst
@@ -5,3 +5,4 @@ services.github\_service module
    :members:
    :show-inheritance:
    :undoc-members:
+   :noindex:

--- a/docs/api/services.google_drive_service.rst
+++ b/docs/api/services.google_drive_service.rst
@@ -5,3 +5,4 @@ services.google\_drive\_service module
    :members:
    :show-inheritance:
    :undoc-members:
+   :noindex:

--- a/docs/api/services.rst
+++ b/docs/api/services.rst
@@ -5,6 +5,7 @@ services package
    :members:
    :show-inheritance:
    :undoc-members:
+   :noindex:
 
 Submodules
 ----------

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -10,6 +10,7 @@ File Management
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 GitHub Integration
 ------------------
@@ -18,11 +19,13 @@ GitHub Integration
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 .. automodule:: github_upload_fix
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Backup System
 -------------
@@ -31,6 +34,7 @@ Backup System
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Code Processing
 ---------------
@@ -39,11 +43,13 @@ Code Processing
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 .. automodule:: code_preview
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Search Engine
 -------------
@@ -52,6 +58,7 @@ Search Engine
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Repository Analysis
 -------------------
@@ -60,6 +67,7 @@ Repository Analysis
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Batch Processing
 ----------------
@@ -68,11 +76,13 @@ Batch Processing
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 .. automodule:: batch_commands
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Large Files Handling
 --------------------
@@ -81,6 +91,7 @@ Large Files Handling
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Cache Management
 ----------------
@@ -89,11 +100,13 @@ Cache Management
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 .. automodule:: cache_commands
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 User Statistics
 ---------------
@@ -102,6 +115,7 @@ User Statistics
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Activity Reporting
 ------------------
@@ -110,6 +124,7 @@ Activity Reporting
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Utilities
 ---------
@@ -118,6 +133,7 @@ Utilities
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Lazy Loading
 ------------
@@ -126,6 +142,7 @@ Lazy Loading
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Integrations
 ------------
@@ -134,6 +151,7 @@ Integrations
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Terminal Commands
 -----------------
@@ -142,6 +160,7 @@ Terminal Commands
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Autocomplete Manager
 --------------------
@@ -150,3 +169,4 @@ Autocomplete Manager
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:

--- a/docs/services/google_drive_service.rst
+++ b/docs/services/google_drive_service.rst
@@ -21,4 +21,5 @@ API (autodoc)
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -10,6 +10,7 @@ Code Service
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 GitHub Service
 --------------
@@ -18,6 +19,7 @@ GitHub Service
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Backup Service
 --------------
@@ -26,6 +28,7 @@ Backup Service
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Google Drive Service
 --------------------


### PR DESCRIPTION
Add `:noindex:` to Sphinx automodule directives and simplify CI status contexts to resolve RTD build warnings and improve PR status readability.

The "duplicate object description" warnings occurred because modules were being documented in multiple places. Adding `:noindex:` to the secondary documentation sources prevents Sphinx from indexing them twice. The CI status contexts were adjusted to remove emojis and redundant text, making them more concise and consistent with GitHub's status display.

---
<a href="https://cursor.com/background-agent?bcId=bc-57535d86-0c99-483b-8add-f255cef05133">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57535d86-0c99-483b-8add-f255cef05133">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

