### PR TITLE
Refactor: Pass query to safe_edit_message_text

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -826,6 +826,7 @@ async def handle_file_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"🎯 *מרכז בקרה מתקדם*\n\n"
             f"📄 **קובץ:** `{file_name}`\n"
             f"🧠 **שפה:** {language}{note_line}"
@@ -893,6 +894,7 @@ async def handle_view_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n" if note else "\n📝 הערה: —\n"
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}\n"
             f"```{language}\n{code_preview}\n```",
             reply_markup=reply_markup,
@@ -925,6 +927,7 @@ async def handle_edit_code(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         file_name = file_data.get('file_name', 'קובץ')
         
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"✏️ *עריכת קוד מתקדמת*\n\n"
             f"📄 **קובץ:** `{file_name}`\n\n"
             f"📝 שלח את הקוד החדש והמעודכן:",

--- a/handlers/file_view.py
+++ b/handlers/file_view.py
@@ -105,6 +105,7 @@ async def handle_file_menu(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"🎯 *מרכז בקרה מתקדם*\n\n"
             f"📄 **קובץ:** `{file_name}`\n"
             f"🧠 **שפה:** {language}{note_line}"
@@ -162,6 +163,7 @@ async def handle_view_file(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n" if note else "\n📝 הערה: —\n"
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}\n"
             f"```{language}\n{code_preview}\n```",
             reply_markup=reply_markup,
@@ -187,6 +189,7 @@ async def handle_edit_code(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         context.user_data['editing_file_data'] = file_data
         file_name = file_data.get('file_name', 'קובץ')
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"✏️ *עריכת קוד מתקדמת*\n\n"
             f"📄 **קובץ:** `{file_name}`\n\n"
             f"📝 שלח את הקוד החדש והמעודכן:",
@@ -359,6 +362,7 @@ async def handle_edit_name(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         context.user_data['editing_file_data'] = file_data
         current_name = file_data.get('file_name', 'קובץ')
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"📝 *עריכת שם קובץ*\n\n"
             f"📄 **שם נוכחי:** `{current_name}`\n\n"
             f"✏️ שלח שם חדש לקובץ:",
@@ -386,6 +390,7 @@ async def handle_edit_note(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         current_note = file_data.get('description', '') or '—'
         context.user_data['editing_note_file'] = file_name
         await TelegramUtils.safe_edit_message_text(
+            query,
             f"📝 *עריכת הערה לקובץ*\n\n"
             f"📄 **שם:** `{file_name}`\n"
             f"🔎 **הערה נוכחית:** {html_escape(current_note)}\n\n"


### PR DESCRIPTION
This change ensures that the query object is correctly passed to the safe_edit_message_text function, allowing for proper message editing.

<html> <h3>What</h3> <ul> <li>Pass <code>query</code> explicitly to <code>TelegramUtils.safe_edit_message_text</code> in file menus and views</li> <li>Adopt safe edit wrapper consistently to avoid “Message is not modified” noise</li> <li>Verify GitHub “📥 הורד קובץ מהריפו” hides delete controls in download mode</li> </ul> <h3>Why</h3> <ul> <li>Fix runtime error: <code>TelegramUtils.safe_edit_message_text() missing 1 required positional argument: 'text'</code></li> <li>Reduce log noise and UX glitches on fast clicks</li> <li>Align with Issue #507 and repo policy (download mode without delete)</li> </ul> <h3>Tests</h3> <ul> <li>Manual: navigate “שאר קבצים” + “לפי ריפו”, open file menu, view, edit prompts</li> <li>Manual: GitHub menu → “📥 הורד קובץ מהריפו” shows no delete/multi-select/safe-delete</li> <li>Smoke: rapid navigation produces no “Message is not modified” errors</li> </ul> <h3>Risks / Rollback</h3> <ul> <li>Low – localized to message-edit helpers and keyboards</li> <li>Rollback: revert this PR or disable safe edit calls</li> </ul> <h3>Docs</h3> <ul> <li>References: Issue #507, policy on download-only mode</li> </ul> </html>