### PR TITLE
Fix: Handle "message is not modified" errors and improve browse state

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -569,11 +569,15 @@ async def show_regular_files_callback(update: Update, context: ContextTypes.DEFA
                 "✨ לחץ על קובץ לחוויה מלאה של עריכה וניהול:"
             )
 
-            await query.edit_message_text(
-                header_text,
-                reply_markup=reply_markup,
-                parse_mode=ParseMode.HTML
-            )
+            try:
+                await query.edit_message_text(
+                    header_text,
+                    reply_markup=reply_markup,
+                    parse_mode=ParseMode.HTML
+                )
+            except telegram.error.BadRequest as br:
+                if "message is not modified" not in str(br).lower():
+                    raise
             
         reporter.report_activity(user_id)
         
@@ -664,11 +668,15 @@ async def show_regular_files_page_callback(update: Update, context: ContextTypes
             "✨ לחץ על קובץ לחוויה מלאה של עריכה וניהול:"
         )
 
-        await query.edit_message_text(
-            header_text,
-            reply_markup=reply_markup,
-            parse_mode=ParseMode.HTML
-        )
+        try:
+            await query.edit_message_text(
+                header_text,
+                reply_markup=reply_markup,
+                parse_mode=ParseMode.HTML
+            )
+        except telegram.error.BadRequest as br:
+            if "message is not modified" not in str(br).lower():
+                raise
     except Exception as e:
         logger.error(f"Error in show_regular_files_page_callback: {e}")
         await query.edit_message_text("❌ שגיאה בטעינת עמוד הקבצים")


### PR DESCRIPTION
<html> <h3>What</h3> <ul> <li>Regular files: swallow “message is not modified” on rapid back clicks</li> <li>GitHub download: keep <code>browse_action=download</code> after file download; no delete controls</li> </ul> <h3>Why</h3> <ul> <li>Fix double-click edge causing noisy error on pagination</li> <li>Enforce download-only UI per policy</li> </ul> <h3>Tests</h3> <ul> <li>Double-click “חזרה” under “שאר קבצים” → no error logs</li> <li>Download a file under “📥 הורד קובץ מהריפו” → list stays in download mode</li> </ul> </html>