### PR TITLE
Fix double-click errors on all buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from telegram import Update, ReplyKeyboardMarkup, InlineKeyboardButton, InlineKe
 from telegram.constants import ParseMode
 from telegram.ext import (Application, CommandHandler, ContextTypes,
                           MessageHandler, filters, Defaults, ConversationHandler, CallbackQueryHandler,
-                          PicklePersistence, InlineQueryHandler)
+                          PicklePersistence, InlineQueryHandler, ApplicationHandlerStop)
 
 from config import config
 from database import CodeSnippet, DatabaseManager, db
@@ -608,6 +608,30 @@ class CodeKeeperBot:
 
         # הוספת פקודות batch (עיבוד מרובה קבצים) לפני ההנדלר הגלובלי כדי שיתפוס את התבניות שלו
         setup_batch_handlers(self.application)
+        
+        # --- Guard גלובלי ללחיצות כפולות על CallbackQuery (קדימות גבוהה) ---
+        async def _global_callback_guard(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            try:
+                if getattr(update, 'callback_query', None):
+                    # בדיקת דופליקטים קצרה לכל הכפתורים
+                    try:
+                        from utils import CallbackQueryGuard
+                        if CallbackQueryGuard.should_block(update, context):
+                            try:
+                                await update.callback_query.answer("עובד…", show_alert=False)
+                            except Exception:
+                                pass
+                            # עצור עיבוד נוסף של ההודעה הנוכחית
+                            raise ApplicationHandlerStop()
+                    except Exception:
+                        pass
+            except ApplicationHandlerStop:
+                raise
+            except Exception:
+                pass
+
+        # הוסף את ה-guard בקבוצה בעלת עדיפות גבוהה מאוד, לפני כל ה-callback handlers הספציפיים
+        self.application.add_handler(CallbackQueryHandler(_global_callback_guard), group=-10)
         
         # --- רק אחרי כל ה-handlers הספציפיים, הוסף את ה-handler הגלובלי ---
         from conversation_handlers import handle_callback_query


### PR DESCRIPTION
Implement a global guard to prevent errors caused by rapid double-clicks on callback query buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-193149d1-cac3-4979-9b89-f0d344dff11c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-193149d1-cac3-4979-9b89-f0d344dff11c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

