### PR TITLE
Fix/webapp other files count and dates

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -581,10 +581,9 @@ def files():
     
     # ספירת סך הכל (אם לא חושב כבר)
     if category_filter == 'other':
-        # ספירת קבצים ייחודיים לפי שם קובץ לאחר סינון (רק פעילים ובעלי תוכן)
+        # ספירת קבצים ייחודיים לפי שם קובץ לאחר סינון (תוכן >0), עם עקביות ל-query הכללי
         count_pipeline = [
             {'$match': query},
-            {'$match': {'is_active': True}},
             {'$addFields': {
                 'code_size': {
                     '$cond': {
@@ -614,12 +613,11 @@ def files():
     if category_filter not in ('large', 'other'):
         files_cursor = db.code_snippets.find(query).sort(sort_field, sort_order).skip((page - 1) * per_page).limit(per_page)
     elif category_filter == 'other':
-        # "שאר קבצים": רק קבצים פעילים ובעלי תוכן (>0 בתים), הצגת הגרסה האחרונה לכל file_name
+        # "שאר קבצים": בעלי תוכן (>0 בתים), מציגים גרסה אחרונה לכל file_name; עקבי עם ה-query הכללי
         sort_dir = -1 if sort_by.startswith('-') else 1
         sort_field_local = sort_by.lstrip('-')
         base_pipeline = [
             {'$match': query},
-            {'$match': {'is_active': True}},  # התאמה לבוט: רק פעילים
             {'$addFields': {
                 'code_size': {
                     '$cond': {


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>יישור קטגוריית "שאר קבצים" לבוט: מציגים רק את הגרסה האחרונה לכל <code>file_name</code>.</li>
  <li>מסננים קבצים לא-פעילים (<code>is_active != true</code>) וקבצים ללא תוכן (רק <code>code_size &gt; 0</code>).</li>
  <li><code>total_count</code> מחושב באותה לוגיקה (distinct לפי <code>file_name</code>).</li>
  <li>תיקון הצגת תאריכים: אין ברירת מחדל של עכשיו כשאין ערך.</li>
  <li>תיקון ספירת שורות: שימוש ב-<code>splitlines()</code> — קוד ריק מוצג כ‑0 שורות.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>הווב אפפ הציג יותר פריטים מהבוט עקב ספירת גרסאות מרובות, הכללת קבצים לא-פעילים וקבצי רפאים ללא תוכן.</li>
  <li>תאריכים קפצו בכל ריענון כי הוצגה ברירת מחדל של עכשיו כשלא היה ערך.</li>
  <li>קבצים ריקים הופיעו עם "1 שורות קוד" במקום 0.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>בדיקה ידנית:
    <ul>
      <li>ב-<code>/files?category=other</code> המספר תואם לבוט (≈14).</li>
      <li>אין יותר קבצי רפאים עם 0 שורות.</li>
      <li>תאריכים יציבים ואינם משתנים על ריענון.</li>
    </ul>
  </li>
  <li>CI נדרש: "🔍 Code Quality &amp; Security", "🧪 Unit Tests (3.11)", "🧪 Unit Tests (3.12)".</li>
</ul>

<h2>Risk &amp; Rollback</h2>
<ul>
  <li>סיכון נמוך — שינויי אגרגציה וסינון בקטגוריית "שאר קבצים" והצגה בלבד.</li>
  <li>Rollback: <code>git revert</code> לקומיטים של הענף.</li>
</ul>

<h2>Files</h2>
<ul>
  <li><code>webapp/app.py</code> — אגרגציה ל-"other" (distinct גרסה אחרונה), סינון תוכן/פעיל, עיצוב תאריכים, וספירת שורות.</li>
</ul>

<h2>Links</h2>
<ul>
  <li><a href="https://github.com/amirbiron/CodeBot/compare/main...fix/webapp-other-files-count-and-dates?expand=1">פתיחת PR</a></li>
</ul>