### PR TITLE
Fix/webapp other files count and dates

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -581,10 +581,9 @@ def files():
     
     # ספירת סך הכל (אם לא חושב כבר)
     if category_filter == 'other':
-        # ספירת קבצים ייחודיים לפי שם קובץ לאחר סינון (רק פעילים ובעלי תוכן)
+        # ספירת קבצים ייחודיים לפי שם קובץ לאחר סינון (תוכן >0), עם עקביות ל-query הכללי
         count_pipeline = [
             {'$match': query},
-            {'$match': {'is_active': True}},
             {'$addFields': {
                 'code_size': {
                     '$cond': {
@@ -614,12 +613,11 @@ def files():
     if category_filter not in ('large', 'other'):
         files_cursor = db.code_snippets.find(query).sort(sort_field, sort_order).skip((page - 1) * per_page).limit(per_page)
     elif category_filter == 'other':
-        # "שאר קבצים": רק קבצים פעילים ובעלי תוכן (>0 בתים), הצגת הגרסה האחרונה לכל file_name
+        # "שאר קבצים": בעלי תוכן (>0 בתים), מציגים גרסה אחרונה לכל file_name; עקבי עם ה-query הכללי
         sort_dir = -1 if sort_by.startswith('-') else 1
         sort_field_local = sort_by.lstrip('-')
         base_pipeline = [
             {'$match': query},
-            {'$match': {'is_active': True}},  # התאמה לבוט: רק פעילים
             {'$addFields': {
                 'code_size': {
                     '$cond': {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -971,6 +971,27 @@ def upload_file_web():
             raw_tags = (request.form.get('tags') or '').strip()
             tags = [t.strip() for t in re.split(r'[,#\n]+', raw_tags) if t.strip()] if raw_tags else []
 
+            # אם הועלה קובץ — נקרא ממנו ונשתמש בשמו אם אין שם קובץ בשדה
+            try:
+                uploaded = request.files.get('code_file')
+            except Exception:
+                uploaded = None
+            if uploaded and hasattr(uploaded, 'filename') and uploaded.filename:
+                # הגבלת גודל בסיסית (עד ~2MB)
+                data = uploaded.read()
+                if data and len(data) > 2 * 1024 * 1024:
+                    error = 'קובץ גדול מדי (עד 2MB)'
+                else:
+                    try:
+                        code = data.decode('utf-8')
+                    except Exception:
+                        try:
+                            code = data.decode('latin-1')
+                        except Exception:
+                            code = ''
+                    if not file_name:
+                        file_name = uploaded.filename or ''
+
             if not file_name:
                 error = 'יש להזין שם קובץ'
             elif not code:

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -99,7 +99,7 @@
             {% endif %}
         </div>
         <div>
-            <a href="https://t.me/{{ bot_username }}?start=add_file" target="_blank" class="btn btn-secondary btn-icon" style="padding: 0.5rem 1rem;">
+            <a href="/upload" class="btn btn-secondary btn-icon" style="padding: 0.5rem 1rem;">
                 <i class="fas fa-plus"></i>
                 הוסף קובץ חדש
             </a>

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -85,7 +85,7 @@
             | ריפו: {{ selected_repo }}
             {% endif %}
             {% elif category_filter == 'zip' %}
-            | קטגוריה: קבצי ZIP
+            | קטגוריה: קבצי ZIP (גיבויים שמורים בבוט)
             {% elif category_filter == 'large' %}
             | קטגוריה: קבצים גדולים (מעל 100KB)
             {% elif category_filter == 'other' %}
@@ -119,6 +119,29 @@
       </span>
       <span class="badge">{{ r.count }}</span>
     </a>
+    {% endfor %}
+  </div>
+</div>
+{% elif zip_backups %}
+<div class="glass-card">
+  <h2 class="section-title"><i class="fas fa-file-archive"></i> קבצי ZIP</h2>
+  <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+    {% for z in zip_backups %}
+    <div class="glass-card" style="padding: 1rem;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
+        <span><i class="fas fa-archive"></i> {{ z.backup_id }}</span>
+        <span class="badge">{{ z.file_count }} קבצים</span>
+      </div>
+      <div style="opacity: 0.8; display: flex; gap: 1rem; font-size: 0.9rem;">
+        <span><i class="fas fa-weight-hanging"></i> {{ z.total_size }}</span>
+        <span><i class="fas fa-calendar"></i> {{ z.created_at }}</span>
+      </div>
+      {% if z.repo %}
+      <div style="margin-top: 0.5rem; opacity: 0.8; font-size: 0.9rem;">
+        <i class="fab fa-github"></i> {{ z.repo }}{% if z.path %} / {{ z.path }}{% endif %}
+      </div>
+      {% endif %}
+    </div>
     {% endfor %}
   </div>
 </div>

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -34,6 +34,9 @@
         <form method="get" style="display: flex; gap: 1rem; flex-wrap: wrap; flex: 1;">
             {% if category_filter %}
             <input type="hidden" name="category" value="{{ category_filter }}">
+            {% if selected_repo %}
+            <input type="hidden" name="repo" value="{{ selected_repo }}">
+            {% endif %}
             {% endif %}
             <div style="flex: 1; min-width: 200px;">
                 <input type="text" name="q" value="{{ search_query }}" 
@@ -77,7 +80,10 @@
         <div>
             מציג {{ files|length }} מתוך {{ total_count }} קבצים
             {% if category_filter == 'repo' %}
-            | קטגוריה: קבצים מ-GitHub
+            | קטגוריה: לפי ריפו
+            {% if selected_repo %}
+            | ריפו: {{ selected_repo }}
+            {% endif %}
             {% elif category_filter == 'zip' %}
             | קטגוריה: קבצי ZIP
             {% elif category_filter == 'large' %}
@@ -101,7 +107,22 @@
     </div>
 </div>
 
-{% if files %}
+{% if repos %}
+<div class="glass-card">
+  <h2 class="section-title"><i class="fab fa-github"></i> ריפואים</h2>
+  <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+    {% for r in repos %}
+    <a class="glass-card" href="/files?category=repo&repo={{ r.name | urlencode }}" style="display: flex; align-items: center; justify-content: space-between; padding: 1rem; text-decoration: none; color: white;">
+      <span style="display: inline-flex; align-items: center; gap: 0.5rem;">
+        <i class="fab fa-github"></i>
+        {{ r.name }}
+      </span>
+      <span class="badge">{{ r.count }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% elif files %}
 <div class="files-grid" style="display: grid; gap: 1rem;">
     {% for file in files %}
     <div class="glass-card file-card" style="padding: 1.5rem;">

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -13,7 +13,7 @@
   <div class="alert alert-success">{{ success }}</div>
   {% endif %}
 
-  <form method="post" style="display: grid; gap: 1rem;">
+  <form method="post" enctype="multipart/form-data" style="display: grid; gap: 1rem;">
     <div>
       <label>שם קובץ</label>
       <input type="text" name="file_name" placeholder="example.py" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
@@ -38,6 +38,11 @@
     <div>
       <label>קוד</label>
       <textarea name="code" rows="14" placeholder="# הדבק כאן את הקוד" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; font-family: 'Fira Code', 'Consolas', monospace;"></textarea>
+    </div>
+    <div>
+      <label>או העלה קובץ</label>
+      <input type="file" name="code_file" accept=".txt,.py,.js,.ts,.java,.c,.cpp,.cs,.go,.rs,.rb,.php,.swift,.kt,.html,.css,.sql,.sh,.yaml,.yml,.json,.xml,.md" style="width: 100%;">
+      <small style="opacity:.8;">אם נבחר קובץ, התוכן יקרא ממנו וישתמש בשם הקובץ לזיהוי השפה.</small>
     </div>
     <div style="display: flex; gap: 1rem;">
       <button type="submit" class="btn btn-primary btn-icon"><i class="fas fa-upload"></i> שמור</button>

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}העלה קובץ חדש - Code Keeper Bot{% endblock %}
+
+{% block content %}
+<h1 class="page-title">העלה קובץ חדש</h1>
+
+<div class="glass-card">
+  {% if error %}
+  <div class="alert alert-error">{{ error }}</div>
+  {% endif %}
+  {% if success %}
+  <div class="alert alert-success">{{ success }}</div>
+  {% endif %}
+
+  <form method="post" style="display: grid; gap: 1rem;">
+    <div>
+      <label>שם קובץ</label>
+      <input type="text" name="file_name" placeholder="example.py" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
+    </div>
+    <div>
+      <label>שפה</label>
+      <select name="language" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
+        <option value="text">— זהה לפי סיומת —</option>
+        {% for lang in languages %}
+        <option value="{{ lang }}">{{ lang }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label>תיאור</label>
+      <input type="text" name="description" placeholder="תיאור קצר" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
+    </div>
+    <div>
+      <label>תגיות</label>
+      <input type="text" name="tags" placeholder="#utils, #repo:owner/name" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
+    </div>
+    <div>
+      <label>קוד</label>
+      <textarea name="code" rows="14" placeholder="# הדבק כאן את הקוד" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; font-family: 'Fira Code', 'Consolas', monospace;"></textarea>
+    </div>
+    <div style="display: flex; gap: 1rem;">
+      <button type="submit" class="btn btn-primary btn-icon"><i class="fas fa-upload"></i> שמור</button>
+      <a href="/files" class="btn btn-secondary btn-icon"><i class="fas fa-arrow-right"></i> ביטול</a>
+    </div>
+  </form>
+</div>
+{% endblock %}
+

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -14,6 +14,9 @@
     font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
     font-size: 14px;
     line-height: 1.6;
+    direction: ltr;
+    text-align: left;
+    width: 100%;
 }
 
 .source pre {
@@ -24,6 +27,25 @@
     margin-right: 1rem;
     user-select: none;
     opacity: 0.5;
+}
+
+/* פריסה טובה יותר ל-Pygments highlighttable (מספרי שורות + קוד) */
+.highlighttable {
+    width: 100% !important;
+    table-layout: fixed;
+}
+.highlighttable td.linenos {
+    width: 3.5rem;
+    vertical-align: top;
+}
+.highlighttable td.code {
+    width: auto;
+}
+
+/* מיכל הקוד יתפרס לרוחב מלא */
+.code-container {
+    width: 100%;
+    overflow: auto;
 }
 
 .file-header {


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>תיקון קטגוריית "שאר קבצים":
    <ul>
      <li>הצגת גרסה אחרונה בלבד לכל <code>file_name</code> (distinct latest).</li>
      <li>סינון קבצים ללא תוכן (רק <code>code_size &gt; 0</code>).</li>
      <li>יישור עקביות עם הסינון הכללי: מאפשרים גם מסמכים בלי <code>is_active</code> (לצד <code>is_active=true</code>).</li>
      <li>ספירת <code>total_count</code> באותה לוגיקה (distinct לפי שם קובץ).</li>
    </ul>
  </li>
  <li>תיקוני תצוגה/מטא:
    <ul>
      <li>תאריכים: אין יותר נפילה ל-Now אם חסר ערך; הוספת <code>format_datetime_display()</code>.</li>
      <li>ספירת שורות: שימוש ב-<code>splitlines()</code>; קוד ריק מוצג כ‑0 שורות.</li>
      <li>דף צפייה בקוד: פריסה LTR, פריסת <code>.highlighttable</code> ברוחב מלא, מניעת הצמדה לימין/כיווץ.</li>
    </ul>
  </li>
  <li>UX "לפי ריפו" כמו בבוט:
    <ul>
      <li>בלחיצה על "לפי ריפו" מוצגת רשימת ריפואים מחולצת מהתגיות <code>repo:*</code> עם ספירת פריטים.</li>
      <li>בחירת ריפו מובילה לרשימת הקבצים של אותו ריפו בלבד.</li>
      <li>שמירת פרמטר <code>repo</code> בטפסים/עמודיות והצגת שם הריפו הנבחר.</li>
    </ul>
  </li>
  <li>קטגוריית "קבצי ZIP":
    <ul>
      <li>מעבר להצגת קבצי ZIP אמיתיים ששמורים בבוט (Filesystem/GridFS) דרך <code>BackupManager.list_backups()</code>.</li>
      <li>UI ייעודי להצגה: מזהה גיבוי, תאריך, גודל כולל, וספירת פריטים.</li>
    </ul>
  </li>
  <li>הוספת העלאת קובץ מהווב:
    <ul>
      <li>מסלול חדש: <code>/upload</code> עם טופס: שם קובץ, שפה, תיאור, תגיות, קוד.</li>
      <li>תמיכה ב‑file upload (multipart): קריאת התוכן מהקובץ, זיהוי שפה לפי שם הקובץ אם צריך, שימוש בשם הקובץ כברירת מחדל.</li>
      <li>מגבלת גודל בסיסית: 2MB.</li>
      <li>כפתור "הוסף קובץ חדש" מוביל ל‑<code>/upload</code> במקום לפתוח את הבוט.</li>
    </ul>
  </li>
</ul>

<h2>Why</h2>
<ul>
  <li>"שאר קבצים" היה מנופח (ספירת גרסאות מרובות) וכלל קבצי רפאים; כעת תואם לבוט.</li>
  <li>תאריכים השתנו בכל ריענון (ברירת מחדל ל‑Now); תוקן.</li>
  <li>קבצים ריקים הופיעו עם "1 שורות קוד"; תוקן ל‑0.</li>
  <li>חוויית "לפי ריפו" התאימה להצגת רשימת ריפואים כמו בבוט.</li>
  <li>קטגוריית ZIP הציגה 0 משום שחיפשה ב‑<code>code_snippets</code> במקום בזיפי הגיבוי האמיתיים; כעת מוצגים הגיבויים בפועל.</li>
  <li>נדרש להוסיף יצירת קובץ גם מהווב, לא רק דרך הבוט.</li>
</ul>

<h2>Changes</h2>
<ul>
  <li><code>webapp/app.py</code>:
    <ul>
      <li><code>/files</code>: 
        <ul>
          <li><strong>other</strong>: aggregation לגרסה אחרונה, סינון תוכן &gt;0, ספירת distinct; עקביות עם <code>is_active</code>.</li>
          <li><strong>repo</strong>: תצוגת רשימת ריפואים כשאין <code>repo</code>; סינון לפי <code>repo</code> כשנבחר.</li>
          <li><strong>zip</strong>: הצגת גיבויים דרך <code>BackupManager</code> במקום סריקה ב‑DB.</li>
        </ul>
      </li>
      <li><code>/file/&lt;id&gt;</code>: תאריכים בטוחים, ספירת שורות מדויקת, הדגשה.</li>
      <li><code>/download/&lt;id&gt;</code>: ללא שינוי לוגי.</li>
      <li><code>/upload</code> (חדש): שמירה דרך שכבת ה‑DB הקיימת; זיהוי שפה לפי סיומת.</li>
      <li>פונקציה חדשה: <code>format_datetime_display()</code>.</li>
    </ul>
  </li>
  <li><code>webapp/templates/files.html</code>:
    <ul>
      <li>תמיכה ברשימת ריפואים ובתצוגת ZIP.</li>
      <li>כפתור "הוסף קובץ חדש" ל‑<code>/upload</code>.</li>
      <li>שימור <code>selected_repo</code> בטפסים.</li>
    </ul>
  </li>
  <li><code>webapp/templates/view_file.html</code>:
    <ul>
      <li>שיפורי פריסה לקוד (LTR, רוחב מלא, <code>.highlighttable</code> מותאם).</li>
    </ul>
  </li>
  <li><code>webapp/templates/upload.html</code> (חדש): טופס העלאה + תמיכה ב‑file upload.</li>
</ul>

<h2>Tests / QA</h2>
<ul>
  <li><strong>שאר קבצים</strong>: /files?category=other מציג ≈מספר תואם לבוט; אין קבצי 0 שורות; דפדוף וספירה תואמים.</li>
  <li><strong>תאריכים/שורות</strong>: תאריכים לא קופצים בריענון; קבצים ריקים = 0 שורות.</li>
  <li><strong>לפי ריפו</strong>: /files?category=repo מציג רשימת ריפואים; כניסה ל‑repo מציגה רק את קבציו.</li>
  <li><strong>ZIP</strong>: /files?category=zip מציג גיבויי ZIP שמורים (עם גודל/ספירה/תאריך).</li>
  <li><strong>צפייה בקוד</strong>: לחיצה על העין מציגה קוד באמצע/שמאל, לא מצטמצם בצד ימין.</li>
  <li><strong>העלאה</strong>: /upload שומר קובץ חדש גם מהדבקת קוד וגם מעליית קובץ (עד 2MB), מחזיר ל‑/files.</li>
  <li>CI צפוי: "🔍 Code Quality &amp; Security", "🧪 Unit Tests (3.11)", "🧪 Unit Tests (3.12)".</li>
</ul>

<h2>Risk &amp; Rollback</h2>
<ul>
  <li>סיכון נמוך-בינוני: שינויי aggregation ותצוגה בקטגוריות; הוספת מסלול העלאה.</li>
  <li>Rollback: <code>git revert</code> לקומיטים של הענף; ניתן לבודד שינויי קטגוריות/טופס בנפרד.</li>
</ul>

<h2>Security / Notes</h2>
<ul>
  <li>אין שינויי הרשאות; העלאת קובץ מוגבלת ל‑2MB, קריאה כטקסט בלבד.</li>
  <li>אין הרצת קוד; אין לוגים עם תוכן רגיש.</li>
</ul>

<h2>Links</h2>
<ul>
  <li><a href="https://github.com/amirbiron/CodeBot/compare/main...fix/webapp-other-files-count-and-dates?expand=1">פתיחת/צפייה ב‑PR</a></li>
  <li><a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a></li>
</ul>