### PR TITLE
Adjust code block display for responsive design

### DIFF
--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -390,8 +390,14 @@ document.addEventListener('keydown', function(e) {
         e.preventDefault();
         copyCode();
     }
-    // Escape לחזרה לרשימה
+    // Escape: אם במסך מלא – לצאת ממנו; אחרת – חזרה לרשימה
     if (e.key === 'Escape') {
+        const codeCard = document.getElementById('codeCard');
+        if (document.fullscreenElement && document.fullscreenElement === codeCard) {
+            e.preventDefault();
+            try { document.exitFullscreen(); } catch (err) { /* ignore */ }
+            return;
+        }
         window.location.href = '/files';
     }
 });

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -169,6 +169,20 @@
     }
     .highlighttable td.linenos { width: 2.8rem; }
     .main-content > .container { padding-left: 10px; padding-right: 10px; }
+    /* שבירת שורות בקוד במסכים צרים */
+    pre, code {
+        white-space: pre-wrap;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+}
+
+@media (min-width: 769px) {
+    pre, code {
+        white-space: pre;
+        overflow-x: auto;
+        width: 100%;
+    }
 }
 
 /* Mini WebApp: שיפורים כאשר נטען בתוך טלגרם */

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -60,6 +60,20 @@
     overflow: auto;
 }
 
+/* כותרת מקטע עם כפתור פעולה (למסך מלא) */
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+/* כאשר הכרטיס במסך מלא – הקוד יתפוס כמעט את כל הגובה */
+#codeCard:fullscreen .code-container {
+    height: calc(100vh - 120px);
+    overflow: auto;
+}
+
 .file-header {
     display: flex;
     justify-content: space-between;
@@ -169,21 +183,8 @@
     }
     .highlighttable td.linenos { width: 2.8rem; }
     .main-content > .container { padding-left: 10px; padding-right: 10px; }
-    /* שבירת שורות בקוד במסכים צרים */
-    pre, code {
-        white-space: pre-wrap;
-        word-break: break-word;
-        overflow-wrap: anywhere;
-    }
 }
 
-@media (min-width: 769px) {
-    pre, code {
-        white-space: pre;
-        overflow-x: auto;
-        width: 100%;
-    }
-}
 
 /* Mini WebApp: שיפורים כאשר נטען בתוך טלגרם */
 body.telegram-mini-app .source { font-size: 12px !important; padding: 0.75rem !important; }
@@ -256,11 +257,17 @@ body.telegram-mini-app .main-content > .container { padding-left: 10px !importan
     </div>
 </div>
 
-<div class="glass-card">
-    <h2 class="section-title">
-        <i class="fas fa-code"></i>
-        קוד מקור
-    </h2>
+<div class="glass-card" id="codeCard">
+    <div class="section-header">
+        <h2 class="section-title" style="margin: 0;">
+            <i class="fas fa-code"></i>
+            קוד מקור
+        </h2>
+        <button id="fullscreenBtn" class="btn btn-secondary btn-icon" title="מסך מלא">
+            <i class="fas fa-expand"></i>
+            מסך מלא
+        </button>
+    </div>
     <div class="code-container">
         {{ highlighted_code|safe }}
     </div>
@@ -388,5 +395,40 @@ document.addEventListener('keydown', function(e) {
         window.location.href = '/files';
     }
 });
+
+// מסך מלא עבור מיכל הקוד
+(function(){
+    const btn = document.getElementById('fullscreenBtn');
+    const card = document.getElementById('codeCard');
+    if (!btn || !card) return;
+
+    function isFullscreen(){
+        return document.fullscreenElement === card;
+    }
+
+    function updateButton(){
+        const icon = btn.querySelector('i');
+        if (isFullscreen()) {
+            btn.innerHTML = '<i class="fas fa-compress"></i> יציאה ממסך מלא';
+        } else {
+            btn.innerHTML = '<i class="fas fa-expand"></i> מסך מלא';
+        }
+    }
+
+    btn.addEventListener('click', async function(){
+        try {
+            if (!isFullscreen()) {
+                await card.requestFullscreen();
+            } else {
+                await document.exitFullscreen();
+            }
+        } catch (e) {
+            console.error('fullscreen error', e);
+        }
+    });
+
+    document.addEventListener('fullscreenchange', updateButton);
+    updateButton();
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
<h2>feat(webapp): כפתור מסך מלא לתצוגת הקוד</h2>

<h3>What</h3>
<ul>
  <li>הוסר עיצוב שבירת שורות/מילים שנוסף בטעות.</li>
  <li>נוסף כפתור “מסך מלא” למקטע הקוד בעמוד הצפייה בקובץ.</li>
  <li>מימוש עם Fullscreen API, כולל החלפת אייקון/טקסט במצב פעיל.</li>
  <li>במסך מלא: קופסת הקוד תופסת את גובה ה‑viewport עם גלילה פנימית.</li>
  <li>קובץ מעודכן: <code>webapp/templates/view_file.html</code></li>
</ul>

<h3>Why</h3>
<p>
שיפור חוויית הקריאה של קוד במובייל/טאבלט/דסקטופ בלי לפגוע בפורמט המקורי,
ומתן אפשרות להתמקד בקוד במסך מלא.
</p>

<h3>Tests</h3>
<ol>
  <li>פתחו עמוד צפייה בקובץ והקליקו על “מסך מלא” – הכרטיס אמור להתרחב למסך מלא.</li>
  <li>גללו בתוך קופסת הקוד ובדקו שהגלילה חלקה והפורמט נשמר.</li>
  <li>החליפו חזרה בעזרת הכפתור או מקש <code>Esc</code> – יציאה ממסך מלא.</li>
  <li>בדקו מובייל (מסך קטן) ודסקטופ – הכפתור מוצג ופועל בשני המצבים.</li>
</ol>

<h3>Risks / Rollback</h3>
<ul>
  <li>סיכון נמוך: שינוי ממוקד בקובץ תבנית אחד.</li>
  <li>Rollback: החזרת השינויים ב‑<code>view_file.html</code> לגרסה הקודמת.</li>
</ul>

<h3>Notes</h3>
<ul>
  <li>אין תלות ב‑backend / DB.</li>
  <li>בדיקות CI צפויות: “🔍 Code Quality & Security”, “🧪 Unit Tests (3.11)”, “🧪 Unit Tests (3.12)”.</li>
</ul>

<!-- אופציונלי: צירוף צילומי מסך -->
<!--
<p>
  <img src="before.png" alt="Before - code view" width="380" />
  <img src="after.png" alt="After - fullscreen code view" width="380" />
</p>
-->

---
<a href="https://cursor.com/background-agent?bcId=bc-fae18e4c-d276-4d04-879d-52aa0633b0c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fae18e4c-d276-4d04-879d-52aa0633b0c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

