### PR TITLE
Investigate repo tag cleanup discrepancy

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -556,8 +556,13 @@ def files():
                         {'is_active': {'$exists': False}}
                     ]
                 }
+                # נציג ריפואים לפי התגיות במסמך ה"גרסה האחרונה" של כל קובץ,
+                # כדי ליישר התנהגות עם הבוט (שמשתמש get_user_files ומחזיר latest בלבד)
                 repo_pipeline = [
                     {'$match': base_active_query},
+                    {'$sort': {'file_name': 1, 'version': -1}},
+                    {'$group': {'_id': '$file_name', 'latest': {'$first': '$$ROOT'}}},
+                    {'$replaceRoot': {'newRoot': '$latest'}},
                     {'$match': {'tags': {'$elemMatch': {'$regex': r'^repo:', '$options': 'i'}}}},
                     {'$project': {
                         'repo_tags': {


### PR DESCRIPTION
Align repo counting logic in the web app to match the bot's behavior.

The web app was counting repos from all document versions, while the bot only considered the latest version of each file. This led to discrepancies after a tag cleanup script. The fix ensures the web app now groups by `file_name` and selects the latest version before extracting `repo:` tags, making its count consistent with the bot.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ebdf183-82a2-4ac3-b783-7fa75ae13bfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ebdf183-82a2-4ac3-b783-7fa75ae13bfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

