### PR TITLE
Fix tablet code view blank space

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -50,7 +50,7 @@
             box-sizing: border-box;
         }
         
-        html, body { height: 100%; }
+        html, body { height: 100%; overflow-x: hidden; }
         
         body {
             font-family: 'Heebo', sans-serif;


### PR DESCRIPTION
Add `overflow-x: hidden` to `html, body` to prevent horizontal scrolling and eliminate dead space in the mini web app viewer on tablets.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e705622-9dcc-412e-b7dc-52b9bba9e326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e705622-9dcc-412e-b7dc-52b9bba9e326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

