### PR TITLE
Support multi-language code blocks in markdown

### DIFF
--- a/code_processor.py
+++ b/code_processor.py
@@ -111,8 +111,17 @@ class CodeProcessor:
             
             original_length = len(code)
             
-            # סניטציה ראשונית
-            cleaned_code = self.sanitize_code_blocks(code)
+            # עבור קבצי Markdown נשמור את התוכן כמו שהוא (כולל בלוקי ``` מרובי שפות)
+            # כדי לא לפגוע במסמך מרובה-שפות.
+            is_markdown: bool = False
+            try:
+                ext = Path((filename or "")).suffix.lower()
+                is_markdown = ext in (".md", ".markdown")
+            except Exception:
+                is_markdown = False
+
+            # סניטציה ראשונית (דלג עבור Markdown)
+            cleaned_code = code if is_markdown else self.sanitize_code_blocks(code)
             cleaned_length = len(cleaned_code)
             
             # רישום הצלחת סניטציה

--- a/handlers/file_view.py
+++ b/handlers/file_view.py
@@ -162,13 +162,26 @@ async def handle_view_file(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         reply_markup = InlineKeyboardMarkup(keyboard)
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n" if note else "\n📝 הערה: —\n"
-        await TelegramUtils.safe_edit_message_text(
-            query,
-            f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}\n"
-            f"```{language}\n{code_preview}\n```",
-            reply_markup=reply_markup,
-            parse_mode='Markdown',
-        )
+        # אם הקובץ הוא Markdown – נציג ב-HTML עם <pre><code> כדי למנוע שבירת ``` פנימיים
+        if (language or '').lower() == 'markdown':
+            safe_code = html_escape(code_preview)
+            header_html = (
+                f"📄 <b>{html_escape(file_name)}</b> ({html_escape(language)}) - גרסה {version}{note_line}\n"
+            )
+            await TelegramUtils.safe_edit_message_text(
+                query,
+                f"{header_html}<pre><code>{safe_code}</code></pre>",
+                reply_markup=reply_markup,
+                parse_mode='HTML',
+            )
+        else:
+            await TelegramUtils.safe_edit_message_text(
+                query,
+                f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}\n"
+                f"```{language}\n{code_preview}\n```",
+                reply_markup=reply_markup,
+                parse_mode='Markdown',
+            )
     except Exception as e:
         logger.error(f"Error in handle_view_file: {e}")
         await TelegramUtils.safe_edit_message_text(query, "❌ שגיאה בהצגת הקוד המתקדם")
@@ -717,12 +730,26 @@ async def handle_view_direct_file(update, context: ContextTypes.DEFAULT_TYPE) ->
         reply_markup = InlineKeyboardMarkup(keyboard)
         note = file_data.get('description') or ''
         note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
-        await query.edit_message_text(
-            f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}"
-            f"```{language}\n{code_preview}\n```",
-            reply_markup=reply_markup,
-            parse_mode='Markdown',
-        )
+        # Markdown מוצג ב-HTML כדי למנוע שבירת ``` פנימיים
+        if (language or '').lower() == 'markdown':
+            safe_code = html_escape(code_preview)
+            header_html = (
+                f"📄 <b>{html_escape(file_name)}</b> ({html_escape(language)}) - גרסה {version}{note_line}"
+            )
+            await TelegramUtils.safe_edit_message_text(
+                query,
+                f"{header_html}<pre><code>{safe_code}</code></pre>",
+                reply_markup=reply_markup,
+                parse_mode='HTML',
+            )
+        else:
+            await TelegramUtils.safe_edit_message_text(
+                query,
+                f"📄 *{file_name}* ({language}) - גרסה {version}{note_line}"
+                f"```{language}\n{code_preview}\n```",
+                reply_markup=reply_markup,
+                parse_mode='Markdown',
+            )
     except Exception as e:
         logger.error(f"Error in handle_view_direct_file: {e}")
         await query.edit_message_text("❌ שגיאה בהצגת הקוד המתקדם")


### PR DESCRIPTION
<div>
  <h3>What</h3>
  <ul>
    <li>תמיכה בשמירת Markdown עם בלוקים מרובי־שפות (fenced code) ללא סניטציה.</li>
    <li>שינוי: בקובץ <code>code_processor.py</code> פונקציית <code>validate_code_input</code> מדלגת על <code>sanitize_code_blocks</code> עבור <code>.md</code>/<code>.markdown</code>.</li>
  </ul>

  <h3>Why</h3>
  <ul>
    <li>כדי לשמור מסמכי תיעוד עם בלוקים כמו <code>```python</code> ו-<code>```sql</code> בדיוק כפי שנשלחו.</li>
    <li>מונע איבוד/שינוי של בלוקי קוד בזמן ולידציה.</li>
  </ul>

  <h3>Tests</h3>
  <ol>
    <li>לשמור קובץ <code>.md</code> עם בלוקים <code>```python</code> ו-<code>```sql</code> ולבדוק שהתוכן נשמר זהה.</li>
    <li>לשמור קובץ שאינו Markdown ולוודא שסניטציה עדיין פועלת כרגיל.</li>
    <li>להציג את הקובץ דרך הבוט ולוודא שהגדרות הקוד נשארות (fenced) תקינות.</li>
  </ol>

  <h3>Risk & Rollback</h3>
  <ul>
    <li>סיכון נמוך – חל רק על <code>.md</code>/<code>.markdown</code>.</li>
    <li>Rollback: החזרת השינוי ב-<code>validate_code_input</code>.</li>
  </ul>

  <h3>Docs</h3>
  <ul>
    <li><a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a></li>
  </ul>
</div>
---
<a href="https://cursor.com/background-agent?bcId=bc-89a01d71-b759-4298-a8d8-0125093e3cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89a01d71-b759-4298-a8d8-0125093e3cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

