### PR TITLE
Fix default repo tag on file upload

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1643,7 +1643,9 @@ def upload_file_web():
                     prev_tags = list((prev or {}).get('tags') or [])
                 except Exception:
                     prev_tags = []
-                final_tags = tags if tags else prev_tags
+                # אל תוסיף תגיות repo:* כברירת מחדל בעת העלאה חדשה; שמור רק תגיות רגילות אם המשתמש לא הקליד
+                safe_prev_tags = [t for t in prev_tags if not (isinstance(t, str) and t.strip().lower().startswith('repo:'))]
+                final_tags = tags if tags else safe_prev_tags
 
                 now = datetime.now(timezone.utc)
                 doc = {


### PR DESCRIPTION
<!-- PR Description -->
<p><strong>What</strong></p>
<ul>
  <li>מניעת הוספת תגיות <code>repo:*</code> אוטומטית בעת העלאת קובץ דרך המיני WebApp.</li>
  <li>עדכון נקודתי בנתיב <code>/upload</code> בקובץ <code>webapp/app.py</code>:
    סינון תגיות <code>repo:*</code> מברירות מחדל כאשר שדה התגיות ריק.
  </li>
</ul>

<p><strong>Why</strong></p>
<ul>
  <li>התווספה תגית ריפו כברירת מחדל בלי שהמשתמש ביקש, מה שגרם לתיוג מבלבל.</li>
</ul>

<p><strong>Tests</strong></p>
<ol>
  <li>פתח את עמוד <code>/upload</code>, העלה קובץ ללא תגיות → ודא שבמסד אין תגיות <code>repo:*</code>.</li>
  <li>העלה שוב עם תגיות ידניות (כולל <code>repo:owner/name</code>) → ודא שהתגיות נשמרות בדיוק כפי שהוזנו.</li>
  <li>ערוך קובץ קיים ושמור ללא שינוי תגיות → ודא שלא מתווספת תגית <code>repo:*</code> חדשה.</li>
</ol>

<p><strong>Notes</strong></p>
<ul>
  <li>אין שינויי סכימה/מיגרציות; שינוי לוגי בלבד.</li>
  <li>CI נדרש: 🔍 Code Quality & Security, 🧪 Unit Tests (3.11), 🧪 Unit Tests (3.12).</li>
  <li>Docs: <a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a></li>
  <li>Rollback: שחזור הערך הקודם של <code>final_tags</code> ב-<code>webapp/app.py</code> (החלפת <code>safe_prev_tags</code> חזרה ל-<code>prev_tags</code>).</li>
</ul>

---
<a href="https://cursor.com/background-agent?bcId=bc-790288e8-558b-4f65-87be-389120b9fe03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-790288e8-558b-4f65-87be-389120b9fe03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

