### PR TITLE
Fix file name and icon overflow in details view

### DIFF
--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -83,6 +83,40 @@
     gap: 1rem;
 }
 
+/* כותרת ושורת מידע: מניעת גלישה ויישור אליפסות */
+.file-title-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    min-width: 0; /* מאפשר אליפסות בצאצאים */
+}
+.file-icon {
+    font-size: 2.25rem; /* היה 3rem – מקטין למניעת גלישה */
+    line-height: 1;
+    flex: 0 0 auto;
+}
+.file-title-wrap {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+.file-title {
+    margin: 0;
+    font-size: 1.5rem; /* גודל שקול ל-section-title */
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+}
+.file-subrow {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    min-width: 0;
+}
+
 .file-info {
     flex: 1;
 }
@@ -116,6 +150,8 @@
     font-size: 1.1rem;
     font-weight: 500;
 }
+
+.muted { opacity: 0.7; }
 
 .copy-button {
     position: relative;
@@ -182,6 +218,8 @@
         font-size: 12px !important;
         padding: 0.75rem !important;
     }
+    .file-icon { font-size: 2rem; }
+    .file-title { font-size: 1.25rem; }
     .highlighttable td.linenos { width: 2.8rem; }
     .main-content > .container { padding-left: 10px; padding-right: 10px; }
 }
@@ -190,6 +228,9 @@
 /* Mini WebApp: שיפורים כאשר נטען בתוך טלגרם */
 body.telegram-mini-app .source { font-size: 12px !important; padding: 0.75rem !important; }
 body.telegram-mini-app .main-content > .container { padding-left: 10px !important; padding-right: 10px !important; }
+/* Mini App: הקטנת הכותרת והאייקון ומניעת גלישה */
+body.telegram-mini-app .file-icon { font-size: 1.9rem; }
+body.telegram-mini-app .file-title { font-size: 1.125rem; }
 </style>
 {% endblock %}
 
@@ -212,13 +253,13 @@ body.telegram-mini-app .main-content > .container { padding-left: 10px !importan
 </script>
 <div class="file-header">
     <div class="file-info">
-        <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-            <span style="font-size: 3rem;">{{ file.icon }}</span>
-            <div>
-                <h1 style="margin: 0;">{{ file.file_name }}</h1>
-                <div style="display: flex; gap: 1rem; margin-top: 0.5rem;">
+        <div class="file-title-row">
+            <span class="file-icon">{{ file.icon }}</span>
+            <div class="file-title-wrap">
+                <h1 class="file-title">{{ file.file_name }}</h1>
+                <div class="file-subrow">
                     <span class="badge">{{ file.language }}</span>
-                    <span style="opacity: 0.7;">גרסה {{ file.version }}</span>
+                    <span class="muted">גרסה {{ file.version }}</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<h3>What</h3>
<p>כוונון תצוגת כותרת במסך "פרטי קובץ" במיני‑ווב‑אפ:</p>
<ul>
  <li>הקטנת אייקון הקובץ והפונט של שם הקובץ</li>
  <li>מניעת גלישה של שם הקובץ בעזרת ellipsis</li>
  <li>שיפורי מובייל ו‑Telegram Mini App (גדלים קטנים יותר)</li>
</ul>

<h3>Why</h3>
<p>במספר קבצים הכותרת והאייקון גלשו מגבולות הכרטיס והסתירו תוכן. המטרה: קריאות עקבית ומראה מסודר בכל מסכים.</p>

<h3>Changes</h3>
<ul>
  <li>תוספת מחלקות: <code>file-title-row</code>, <code>file-icon</code>, <code>file-title-wrap</code>, <code>file-title</code>, <code>file-subrow</code></li>
  <li>CSS: הקטנת גדלים, <code>white-space: nowrap</code>, <code>overflow: hidden</code>, <code>text-overflow: ellipsis</code>, ו‑<code>min-width: 0</code></li>
  <li>התאמות @media ו‑<code>body.telegram-mini-app</code></li>
</ul>

<h3>Tests</h3>
<ul>
  <li>בדיקת קבצים עם שמות ארוכים במיוחד במובייל ואנדרואיד Telegram</li>
  <li>וידוא שאין גלילה אופקית וששם הקובץ נחתך באליפסות</li>
</ul>

<h3>Risks & Rollback</h3>
<ul>
  <li>השפעה מינימלית ומקומית לתבנית <code>view_file.html</code></li>
  <li>במקרה בעיה: החזרת מחלקות/גדלים קודמים ב‑<code>view_file.html</code></li>
</ul>

---
<a href="https://cursor.com/background-agent?bcId=bc-2279df73-9922-4a99-8088-516948baef1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2279df73-9922-4a99-8088-516948baef1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

