### PR TITLE
Adjust container width for larger screens

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -359,6 +359,18 @@
         }
         body.telegram-mini-app .navbar::after { display: none; }
         
+        /* Mini WebApp: במסכי טאבלט ומעלה – מכולה ראשית ברוחב מלא וללא ריווח צדדי */
+        @media (min-width: 768px) {
+            body.telegram-mini-app .container {
+                width: 100% !important;
+                max-width: none !important;
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+                margin-left: 0 !important;
+                margin-right: 0 !important;
+            }
+        }
+        
         /* Loading animation */
         .loading {
             display: inline-block;


### PR DESCRIPTION
<h3>What</h3>
<ul>
  <li>פריסת כל התצוגה ב‑Mini WebApp לרוחב מלא בטאבלט ומעלה (md+).</li>
  <li>ביטול ריווח צדדי (padding/margin) של ה‑container ב‑md+ באמצעות width:100%, max-width:none ו‑px:0.</li>
  <li>במובייל נשמר padding קטן לשמירת מרווח נעים.</li>
  <li>קובץ שהשתנה: <code>webapp/templates/base.html</code>.</li>
</ul>

<h3>Why</h3>
<p>
בטאבלטים התוכן לא מילא את כל הרוחב ונראה “צף” באמצע. העדכון מיישר את החוויה לכרטיסים שכבר נמתחים עד הקצוות ומשפר את השימושיות.
</p>

<h3>How</h3>
<ul>
  <li>נוסף כלל <code>@media (min-width: 768px)</code> תחת <code>body.telegram-mini-app .container</code> שמחיל <code>width:100%</code>, <code>max-width:none</code>, ו‑<code>padding-left/right:0</code>.</li>
  <li>השינוי חל רק בתוך ה‑Mini WebApp; אתר רגיל בדפדפן אינו מושפע.</li>
</ul>

<h3>Tests</h3>
<ol>
  <li>פתחו את ה‑Mini WebApp בטאבלט: ודאו שהתוכן נפרס לכל הרוחב ללא שוליים מיותרים.</li>
  <li>פתחו במובייל: ודאו שיש מעט מרווח צדדי כפי שהיה.</li>
  <li>פתחו בדפדפן רגיל: אין שינוי בהתנהגות.</li>
</ol>

<h3>Risk & Rollback</h3>
<ul>
  <li>סיכון נמוך (שינוי CSS ממוקד למחלקה <code>telegram-mini-app</code> בלבד).</li>
  <li>Rollback: הסרת בלוק ה‑<code>@media</code> שנוסף.</li>
</ul>
---
<a href="https://cursor.com/background-agent?bcId=bc-eb570850-4870-443d-98be-4175ba990d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb570850-4870-443d-98be-4175ba990d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

