### PR TITLE
Fix file upload blocking with special characters

### DIFF
--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -13,7 +13,7 @@
   <div class="alert alert-success">{{ success }}</div>
   {% endif %}
 
-  <form method="post" enctype="multipart/form-data" style="display: grid; gap: 1rem;">
+  <form id="uploadForm" method="post" enctype="multipart/form-data" style="display: grid; gap: 1rem;">
     <div>
       <label>שם קובץ</label>
       <input type="text" name="file_name" placeholder="example.py" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
@@ -50,5 +50,65 @@
     </div>
   </form>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function(){
+  const form = document.getElementById('uploadForm');
+  if (!form) return;
+  form.addEventListener('submit', async function(ev){
+    try {
+      // אם רץ במיני-ווב של טלגרם – נשלח תמיד ב-fetch + Authorization
+      if (window.Telegram && window.Telegram.WebApp) {
+        ev.preventDefault();
+        const fd = new FormData(form);
+        // אם המשתמש הזין טקסט ב-<textarea name="code"> ונבחר גם קובץ, הקובץ גובר; אם אין קובץ – ניצור Blob מהטקסט
+        const hasFile = fd.get('code_file') && (fd.get('code_file').name || '').length > 0;
+        if (!hasFile) {
+          const codeText = (fd.get('code') || '').toString();
+          // דפדפנים מצרפים את ה-string כ-field רגיל; זה תקין, נשמור על זה בנוסף
+          // כדי לעקוף WAFים מסוימים, ניתן גם לצרף קובץ וירטואלי (אופציונלי). נשאיר כבוי כברירת מחדל.
+        }
+
+        const initData = (window.Telegram.WebApp.initData || '').trim();
+        const resp = await fetch('/upload', {
+          method: 'POST',
+          body: fd,
+          headers: {
+            'Authorization': initData ? ('Bearer ' + initData) : '',
+            'Accept': 'application/json',
+            'X-Requested-With': 'fetch'
+          },
+          credentials: 'include'
+        });
+        const okJson = resp.headers.get('content-type') && resp.headers.get('content-type').includes('application/json');
+        if (okJson) {
+          const data = await resp.json();
+          if (data && data.ok) {
+            const target = data.redirect || '/files';
+            window.location.assign(target);
+            return;
+          }
+          const error = (data && data.error) ? data.error : 'שגיאה בהעלאה';
+          alert(error);
+          return;
+        }
+        // fallback: אם חזר HTML (למשל redirect), ננווט ידנית
+        if (resp.redirected) {
+          window.location.assign(resp.url);
+        } else if (resp.ok) {
+          window.location.assign('/files');
+        } else {
+          alert('שגיאה בהעלאה (' + resp.status + ')');
+        }
+      }
+    } catch (e) {
+      try { console.error('upload error', e); } catch(_e){}
+      alert('שגיאה בהעלאה: ' + (e && e.message ? e.message : e));
+    }
+  }, { passive: false });
+})();
+</script>
 {% endblock %}
 


### PR DESCRIPTION
<h2>Fix: תיקון העלאת קבצים ב־Mini WebApp (403/redirect)</h2>

<h3>What</h3>
<ul>
  <li><strong>Client (upload.html)</strong>: שליחה דרך <code>fetch</code> עם <code>FormData</code>, כולל
    <code>Authorization: Bearer &lt;initData&gt;</code>, וכותרות <code>Accept: application/json</code>, <code>X-Requested-With: fetch</code>.
  </li>
  <li><strong>Server (webapp/app.py)</strong>:
    <ul>
      <li>אימות משתמש דרך <code>Authorization: Bearer &lt;initData&gt;</code> ב־<code>before_request</code> (Telegram WebApp).</li>
      <li>הגדלת מגבלת גוף ל־8MB (ניתן לקנפג עם <code>MAX_CONTENT_LENGTH_MB</code> או <code>MAX_UPLOAD_MB</code>).</li>
      <li>הסרת מגבלת 2MB מקומית בקריאת קובץ ב־/upload.</li>
      <li>לוגים ל־/upload: <code>[upload] method, content_length, content_type, charset, content_encoding</code>.</li>
      <li>תמיכה בהחזרת JSON ב־/upload כאשר מבוקש (אחרת redirect רגיל).</li>
      <li>שמירת תוכן כטקסט גולמי; הצגה מאובטחת (Pygments, ו־HTML preview בתוך iframe עם CSP sandbox).</li>
    </ul>
  </li>
</ul>

<h3>Why</h3>
<ul>
  <li>קבצים עם תווים כמו <code>&lt;</code>, <code>&gt;</code> ותגיות HTML נחסמו על ידי WAF/אימות לא עקבי והובילו ל־403/redirect.</li>
  <li>אחידות אימות במיני־ווב, והימנעות מפירוש תוכן על ידי הפרסר.</li>
</ul>

<h3>Tests</h3>
<ol>
  <li>במיני־ווב: העלה טקסט פשוט → צריך להישמר ולהפנות ל־/files.</li>
  <li>העלה תוכן מה־Gist הבעייתי → נשמר ללא 403 (בדוק שהשורות מוצגות כטקסט).</li>
  <li>בדוק תווים “בעייתיים”: <code>&lt;script&gt;</code>, JSON, XML, ו־markdown.</li>
  <li>בדוק גודל: העלה ~6MB → מתקבל (מתחת ל־8MB).</li>
  <li>בדוק לוגים: ראה בשירות <code>[upload] content_length=..., content_type=..., charset=...</code> לזיהוי חסימות WAF.</li>
</ol>

<h3>Config</h3>
<ul>
  <li><code>MAX_CONTENT_LENGTH_MB</code> או <code>MAX_UPLOAD_MB</code> — ברירת מחדל 8.</li>
</ul>

<h3>Security</h3>
<ul>
  <li>אין הרצת תוכן; הצגה עם Pygments/iframe sandbox ו־CSP הדוק (כולל <code>X-Content-Type-Options: nosniff</code>).</li>
  <li>לוגים מדפיסים מטא־דאטה בלבד (ללא תוכן קבצים).</li>
</ul>

<h3>Risks &amp; Rollback</h3>
<ul>
  <li>אם WAF עדיין חוסם, בדקו <code>content_type</code>/<code>content_length</code> בלוגים והתאימו הגדרות WAF/פרוקסי.</li>
  <li>Rollback: Revert ל־PR זה (אין שינויי סכימה ב־DB).</li>
</ul>

<h3>Docs</h3>
<p>
  רקע ומדיניות: <a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a>
</p>

<h3>CI</h3>
<ul>
  <li>נדרשים סטטוסים: “🔍 Code Quality &amp; Security”, “🧪 Unit Tests (3.11)”, “🧪 Unit Tests (3.12)”.</li>
</ul>
---
<a href="https://cursor.com/background-agent?bcId=bc-16752208-ca4a-4393-87e2-7bee3133bac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16752208-ca4a-4393-87e2-7bee3133bac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

