### PR TITLE
feat(webapp): add Markdown browser preview (🌐)

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1553,9 +1553,7 @@ def raw_markdown(file_id):
     th, td {{ border: 1px solid #e1e4e8; padding: 6px 10px; }}
     h1, h2, h3, h4, h5, h6 {{ border-bottom: 1px solid #eaecef; padding-bottom: .3em; }}
   </style>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
-  <meta http-equiv="Referrer-Policy" content="no-referrer">
-  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <!-- CSP and security headers are set via HTTP headers to avoid conflicts -->
 </head>
 <body>
   <article class="markdown-body">{html_body}</article>

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -195,6 +195,13 @@
                     </a>
                 </div>
                 {% endif %}
+                {% if file.language|lower == 'markdown' or (file.file_name|lower).endswith('.md') or (file.file_name|lower).endswith('.markdown') %}
+                <div>
+                    <a href="/markdown/{{ file.id }}" class="btn btn-secondary" style="padding: 0.5rem 1rem;" title="תצוגת דפדפן">
+                        🌐
+                    </a>
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/webapp/templates/markdown_preview.html
+++ b/webapp/templates/markdown_preview.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}תצוגת Markdown - {{ file.file_name }}{% endblock %}
+
+{% block extra_css %}
+<style>
+.preview-container {
+    width: 100%;
+    height: calc(100vh - 180px);
+    background: rgba(255,255,255,0.05);
+    border-radius: 12px;
+    overflow: hidden;
+}
+.preview-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
+}
+.preview-iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: white;
+}
+@media (max-width: 768px) {
+    .preview-container { height: calc(100vh - 220px); }
+}
+
+@media (max-width: 480px) {
+    .preview-actions .btn { padding: 0.5rem 0.75rem; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="file-header">
+    <div class="file-info">
+        <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+            <span style="font-size: 3rem;">🌐</span>
+            <div>
+                <h1 style="margin: 0;">תצוגת Markdown: {{ file.file_name }}</h1>
+                <div style="display: flex; gap: 1rem; margin-top: 0.5rem;">
+                    <span class="badge">{{ file.language }}</span>
+                </div>
+            </div>
+        </div>
+        <p style="margin: 0.5rem 0; opacity: 0.85;">
+            התוכן מוצג בתוך מסגרת מבודדת (sandbox) ללא הרצת סקריפטים.
+        </p>
+    </div>
+
+    <div class="preview-actions">
+        <a href="/file/{{ file.id }}" class="btn btn-secondary btn-icon" title="צפה בקוד">
+            <i class="fas fa-code"></i>
+            קוד
+        </a>
+        <a href="/download/{{ file.id }}" class="btn btn-secondary btn-icon" title="הורד">
+            <i class="fas fa-download"></i>
+            הורד
+        </a>
+        <a href="#" onclick="return goBack(event)" class="btn btn-secondary btn-icon" title="חזור לרשימה">
+            <i class="fas fa-arrow-right"></i>
+            חזור
+        </a>
+    </div>
+</div>
+
+<div class="glass-card preview-container">
+    <div style="display: flex; gap: .5rem; padding: .5rem; align-items: center; flex-wrap: wrap;">
+        <button id="btnFullscreen" class="btn btn-secondary btn-icon" style="margin-inline-start:auto;">
+            <i class="fas fa-expand"></i>
+            מסך מלא
+        </button>
+        <a id="btnNewWindow" href="/raw_markdown/{{ file.id }}" target="_blank" rel="noopener" class="btn btn-secondary btn-icon">
+            <i class="fas fa-external-link-alt"></i>
+            חלון חדש
+        </a>
+    </div>
+    <iframe
+        id="previewFrame"
+        class="preview-iframe"
+        src="/raw_markdown/{{ file.id }}"
+        sandbox="allow-modals"
+        referrerpolicy="no-referrer"
+        loading="eager"
+        title="Markdown Preview"
+    ></iframe>
+    
+</div>
+<script>
+(function(){
+  const frame = document.getElementById('previewFrame');
+  const btnFs = document.getElementById('btnFullscreen');
+  if (!frame) return;
+  if (btnFs) {
+    btnFs.addEventListener('click', async function(){
+      try {
+        if (document.fullscreenElement === frame) {
+          await document.exitFullscreen();
+        } else {
+          await frame.requestFullscreen();
+        }
+      } catch(e) { console.error(e); }
+    });
+  }
+})();
+
+// חזרה אחורה שמכבדת את היסטוריית הניווט במסך אחד בלבד
+function goBack(ev){
+  try { if (ev) ev.preventDefault(); } catch(e){}
+  try {
+    if (window.history && window.history.length > 1) {
+      window.history.back();
+      return false;
+    }
+    if (document.referrer) {
+      const ref = new URL(document.referrer, window.location.origin);
+      if (ref.origin === window.location.origin) {
+        window.location.href = ref.toString();
+        return false;
+      }
+    }
+  } catch(e) {}
+  window.location.href = '/files';
+  return false;
+}
+</script>
+{% endblock %}
+

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -294,6 +294,11 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
             🌐 תצוגת דפדפן
         </a>
         {% endif %}
+        {% if file.language|lower == 'markdown' or (file.file_name|lower).endswith('.md') or (file.file_name|lower).endswith('.markdown') %}
+        <a href="/markdown/{{ file.id }}" class="btn btn-secondary btn-icon">
+            🌐 תצוגת דפדפן
+        </a>
+        {% endif %}
         <a href="/download/{{ file.id }}" class="btn btn-secondary btn-icon">
             <i class="fas fa-download"></i>
             הורד


### PR DESCRIPTION
<h3>What</h3>
<ul>
  <li>Add Markdown preview in WebApp (browser view)</li>
  <li>Backend routes: <code>/markdown/&lt;id&gt;</code>, <code>/raw_markdown/&lt;id&gt;</code></li>
  <li>New template: <code>webapp/templates/markdown_preview.html</code></li>
  <li>UI: 🌐 button for Markdown in <code>files.html</code> and <code>view_file.html</code></li>
</ul>

<h3>Why</h3>
<p>
מאפשר לצפות בקבצי <code>.md</code> ישירות בדפדפן בעיצוב קריא, בדומה לתצוגת HTML קיימת.
</p>

<h3>Implementation Notes</h3>
<ul>
  <li><code>/raw_markdown/&lt;id&gt;</code> מרנדר Markdown ל-HTML (Python-Markdown, עם הרחבות: extra, fenced_code, codehilite, toc).</li>
  <li>אכיפת אבטחה: <code>iframe sandbox</code> + <code>Content-Security-Policy</code> מחמיר, ללא <code>script</code> והרשאות רשת.</li>
  <li>עיצוב בסיסי לקריאות (קוד, כותרות, טבלאות, תמונות; תמיכה ב-RTL).</li>
  <li>שמירה על אותו UX של תצוגת HTML (מסך מלא, חלון חדש, חזרה).</li>
</ul>

<h3>Testing</h3>
<ul>
  <li>נווט ל-<code>/files</code>, פתח קובץ Markdown בלחיצה על 🌐, בדוק רינדור כותרות/קוד/טבלאות/תמונות.</li>
  <li>בדוק כפתורי מסך מלא וחלון חדש.</li>
  <li>ווידאתי שאין אזהרות לינט ב-<code>webapp/app.py</code>.</li>
</ul>

<h3>Docs & Policy</h3>
<ul>
  <li>עומד במדיניות האבטחה וה-UI של הפרויקט.</li>
  <li>תיעוד כללי: <a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a></li>
</ul>
