### PR TITLE
Fix/weapp md copy spacing hljs

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -60,29 +60,25 @@
   overflow-x: auto;
 }
 #md-content .code-block { position: relative; margin: 1rem 0; }
-<<<<<<< HEAD
 #md-content .code-block pre {
   margin: 0;
   padding: .6rem 1rem;           /* מרווח בסיסי קטן ונעים */
   padding-right: 3.25rem;        /* מקום לכפתור Copy מימין */
 }
-=======
-#md-content .code-block pre { margin: 0; padding-top: 2.2rem; padding-right: 2.5rem; }
->>>>>>> origin/main
 #md-content .md-copy-btn {
   position: absolute;
   top: 6px;
   right: 6px;
   font-size: 12px;
   padding: 4px 8px;
-  border: 1px solid #d1d5db;
-  background: rgba(255,255,255,0.92);
+  background: transparent;
+  border: none;
   border-radius: 6px;
   cursor: pointer;
-  color: #111111;
+  color: #666;
   z-index: 2;
 }
-#md-content .md-copy-btn:hover { background: #ffffff; }
+#md-content .md-copy-btn:hover { color: #000; }
 #md-content .md-copy-btn.copied { background: #d1fae5; border-color: #10b981; }
 #md-content code:not(pre code) {
   background: #f3f4f6;            /* אפור בהיר עם ניגודיות טובה על לבן */
@@ -123,11 +119,18 @@ input.md-task-checkbox {
   </div>
 
   <div id="md-content" class="glass-card" style="padding:1rem;"></div>
+  <script type="application/json" id="mdText">{{ md_code | tojson | safe }}</script>
 </div>
 
 <script>
 // תוכן ה-Markdown מועבר בבטחה JSON-encoded
-const MD_TEXT = {{ md_code | tojson | safe }};
+const MD_TEXT = (function(){
+  try {
+    var el = document.getElementById('mdText');
+    if (!el) return "";
+    return JSON.parse(el.textContent || '""');
+  } catch(_) { return ""; }
+})();
 
 // שמירת מצב רשימות משימות (לפי קובץ) ב-localStorage
 const STORAGE_KEY = `md_tasks_state:{{ file.id }}`;

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -63,7 +63,7 @@
 #md-content .code-block pre {
   margin: 0;
   padding: .6rem 1rem;           /* מרווח בסיסי קטן ונעים */
-  padding-right: 3.25rem;        /* מקום לכפתור Copy מימין */
+  padding-top: 2.2rem;           /* מקום לשורת כפתורים עליונה */
 }
 #md-content .md-copy-btn {
   position: absolute;
@@ -151,7 +151,7 @@ const CDN = {
   mdAnchor: 'https://cdn.jsdelivr.net/npm/markdown-it-anchor@8.6.7/dist/markdown-it-anchor.min.js',
   mdFootnote: 'https://cdn.jsdelivr.net/npm/markdown-it-footnote@3.0.3/dist/markdown-it-footnote.min.js',
   mdTocDone: 'https://cdn.jsdelivr.net/npm/markdown-it-toc-done-right@4.2.0/dist/markdown-it-toc-done-right.min.js',
-  hljs: 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js',
+  hljs: 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/highlight.min.js',
   hljsCss: 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css',
   katexCss: 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css',
   katexJs: 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js',

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -79,7 +79,7 @@
   z-index: 2;
 }
 #md-content .md-copy-btn:hover { color: #000; }
-#md-content .md-copy-btn.copied { background: #d1fae5; border-color: #10b981; }
+#md-content .md-copy-btn.copied { background: #d1fae5; border: 1px solid #10b981; }
 #md-content code:not(pre code) {
   background: #f3f4f6;            /* אפור בהיר עם ניגודיות טובה על לבן */
   color: #111111;                 /* טקסט כהה לקריאות */

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -250,18 +250,18 @@ function loadScript(src){ return new Promise((res,rej)=>{ const s=document.creat
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'md-copy-btn';
-        btn.textContent = 'Copy';
+        btn.textContent = 'העתק';
         btn.addEventListener('click', async () => {
           try {
             const codeEl = wrapper.querySelector('code');
             const text = codeEl ? codeEl.innerText : pre.innerText;
             await navigator.clipboard.writeText(text);
-            btn.textContent = 'Copied!';
+            btn.textContent = 'הועתק!';
             btn.classList.add('copied');
-            setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 1500);
+            setTimeout(() => { btn.textContent = 'העתק'; btn.classList.remove('copied'); }, 1500);
           } catch(e) {
-            btn.textContent = 'Failed';
-            setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+            btn.textContent = 'נכשל';
+            setTimeout(() => { btn.textContent = 'העתק'; }, 1200);
           }
         });
         wrapper.appendChild(btn);


### PR DESCRIPTION
<div dir="rtl">

<h3>What</h3>
<ul>
  <li>עיגון כפתור העתקה לכל בלוק קוד בפינה הימנית העליונה (WeApp Markdown view).</li>
  <li>ביטול "עמודת רווח" מימין: מעבר ל-padding-top במקום padding-right.</li>
  <li>תיוגים בעברית לכפתור: "העתק" / "הועתק!" / "נכשל".</li>
  <li>הפעלת הדגשת תחביר: מעבר ל-<code>highlight.js</code> גרסת <code>highlight.min.js</code> וקריאה ל-<code>highlightElement</code> אחרי הרינדור.</li>
  <li>ניקוי קונפליקט CSS + תיקון לינט: הזרקת תוכן Markdown דרך <code>&lt;script type=\"application/json\"&gt;</code>.</li>
</ul>

<h3>Why</h3>
<ul>
  <li>כפתור ההעתקה הופיע מעל/מתחת לבלוק – ללא "עוגן" בתוך הבלוק עצמו.</li>
  <li>הייתה עמודת רווח מיותרת בגלל padding-right.</li>
  <li>לא הופיעה הדגשת תחביר עקבית אחרי רינדור דינמי.</li>
</ul>

<h3>Changes</h3>
<ul>
  <li><code>webapp/templates/md_preview.html</code>:
    <ul>
      <li>עטיפת <code>&lt;pre&gt;</code> ב-<code>&lt;div class=\"code-block\"&gt;</code> + <code>position: relative</code>.</li>
      <li>כפתור <code>.md-copy-btn</code> עם <code>position: absolute; top: 6px; right: 6px;</code> ורקע שקוף.</li>
      <li><code>padding-top</code> ל-<code>pre</code> במקום <code>padding-right</code> כדי למנוע רווח אנכי.</li>
      <li>פידבק הצלחה: גבול ירוק נראה לעין ב-<code>.md-copy-btn.copied</code>.</li>
      <li>טעינת <code>highlight.js</code> דרך <code>highlight.min.js</code> + שמירת CSS של ה-theme.</li>
      <li>טעינת Markdown בבטחה (JSON) למניעת שגיאות לינט והזרקות.</li>
    </ul>
  </li>
</ul>

<h3>How to test</h3>
<ol>
  <li>פתח/י קובץ Markdown ב-<em>תצוגת Markdown</em>.</li>
  <li>וידוא: כפתור "העתק" מופיע בפינה הימנית העליונה של כל בלוק קוד.</li>
  <li>לחיצה: הכיתוב מתחלף ל-"הועתק!", הכפתור מציג גבול ירוק, וחוזר ל-"העתק" לאחר ~1.5 שניות.</li>
  <li>אין רווח/עמודה מיותרת מתחת לכפתור; הטקסט מיושר יפה.</li>
  <li>הדגשת תחביר נראית (keywords/strings/comments) עבור בלוקים עם <code>class=\"language-xxx\"</code>.</li>
  <li>מובייל (טלגרם Mini App): הכפתור ממוקם נכון, גלילה אופקית עובדת בקוד ארוך.</li>
</ol>

<h3>Risks & Rollback</h3>
<ul>
  <li>סיכון נמוך: שינויי CSS/JS בצד לקוח בלבד.</li>
  <li>Rollback: Revert PR במידת הצורך.</li>
</ul>

<h3>Security</h3>
<ul>
  <li>אין סודות/PII. Markdown מרונדר ללא HTML גולמי; הדגשה לאחר רינדור בלבד.</li>
</ul>

<h3>CI</h3>
<ul>
  <li>מצופה: "🔍 Code Quality & Security", "🧪 Unit Tests (3.11/3.12)".</li>
</ul>

</div>




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Anchors the copy button inside code blocks with updated styling, switches to highlight.min.js, localizes button text to Hebrew, and safely loads markdown via a JSON script tag.
> 
> - **Markdown preview (`webapp/templates/md_preview.html`)**:
>   - **Code blocks UI**:
>     - Anchor `md-copy-btn` inside `.code-block` and switch `pre` spacing to `padding-top: 2.2rem` (drop right-padding column).
>     - Update button styling: transparent background, no border, hover color tweak; success state shows green border.
>     - Localize button labels: `"העתק"`, `"הועתק!"`, `"נכשל"`.
>   - **Syntax highlighting**:
>     - Change Highlight.js source to `highlight.min.js` (from `lib/common.min.js`).
>   - **Data loading**:
>     - Safely inject markdown via `<script type="application/json" id="mdText">` and parse to `MD_TEXT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ab8729946061f8e695469fd09676de86306abc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->