### PR TITLE
Refactor: Improve markdown preview styling and accessibility

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -90,6 +90,10 @@
   background: rgba(76, 175, 80, 0.3);
   border-color: rgba(76, 175, 80, 0.6);
 }
+#md-content .md-copy-btn.copy-error {
+  background: rgba(220, 38, 38, 0.25);
+  border-color: rgba(220, 38, 38, 0.55);
+}
 #md-content .md-copy-btn::before {
   content: "";
   display: inline-block;
@@ -283,15 +287,41 @@ function loadScript(src){ return new Promise((res,rej)=>{ const s=document.creat
         btn.setAttribute('aria-label', 'העתק קוד');
         btn.title = 'העתק קוד';
         btn.addEventListener('click', async () => {
+          const codeEl = wrapper.querySelector('code');
+          const text = codeEl ? codeEl.innerText : pre.innerText;
+          // ניקוי מצבי עבר
+          btn.classList.remove('copied');
+          btn.classList.remove('copy-error');
+          // ניסיון ראשון: Clipboard API
           try {
-            const codeEl = wrapper.querySelector('code');
-            const text = codeEl ? codeEl.innerText : pre.innerText;
             await navigator.clipboard.writeText(text);
             btn.classList.add('copied');
             setTimeout(() => { btn.classList.remove('copied'); }, 1500);
-          } catch(e) {
+            return;
+          } catch(_) {}
+
+          // Fallback: execCommand('copy') עם textarea זמני
+          let success = false;
+          try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            success = document.execCommand('copy');
+            document.body.removeChild(ta);
+          } catch(_) {
+            success = false;
+          }
+
+          if (success) {
             btn.classList.add('copied');
-            setTimeout(() => { btn.classList.remove('copied'); }, 1200);
+            setTimeout(() => { btn.classList.remove('copied'); }, 1500);
+          } else {
+            btn.classList.add('copy-error');
+            setTimeout(() => { btn.classList.remove('copy-error'); }, 1500);
           }
         });
         wrapper.appendChild(btn);


### PR DESCRIPTION
## ✨ תיאור קצר
שיפור תצוגת בלוקי קוד בקבצי Markdown ב-WebApp. הוטמע עיצוב כהה עם רקע גרדיאנט כחול-כהה, כפתור העתקה עם אייקון ופידבק ויזואלי, וערכת צבעים כהה ל-highlight.js, בהתאם להצעות בגיסט.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עדכון CSS ב-`md_preview.html` לבלוקי קוד (`pre`, `.code-block`): רקע גרדיאנט כחול-כהה, הגדלת ריווחים, עיגול פינות וצל.
- החלפת ערכת highlight.js ל-`github-dark-dimmed` לתאימות טובה יותר עם הרקע הכהה.
- שינוי כפתור ההעתקה לאייקון "שני ריבועים" עם מיקום בצד שמאל ופידבק ויזואלי ברור להצלחה/כישלון.
- הגדלת גודל גופן בבלוקי קוד לשיפור נגישות.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual - נבדק ידנית בתצוגת ה-Markdown ב-WebApp לוודא שהעיצוב החדש של בלוקי הקוד, כפתור ההעתקה וערכת הצבעים של highlight.js מוצגים כהלכה.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (שיפור ויזואלי)
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: השפעה ויזואלית בלבד על תצוגת בלוקי קוד בקבצי Markdown. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים: https://gist.github.com/amirbiron/8bdeacdcd714162873840ddc0a030605

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: החזרה לאחור פשוטה על ידי ריוורט של הקובץ `webapp/templates/md_preview.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d376dfe3-cb63-4a42-b40d-7523c5a2538a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d376dfe3-cb63-4a42-b40d-7523c5a2538a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply dark gradient styling to code blocks, switch highlight.js to github-dark-dimmed, and replace text copy button with icon-style accessible control.
> 
> - **Markdown Preview UI (`webapp/templates/md_preview.html`)**:
>   - **Code blocks (`#md-content pre`, `.code-block pre`, `code.hljs`)**:
>     - Dark blue gradient background, larger padding, rounded corners, shadow; font-size 16px.
>     - Adjusted internal spacing for toolbar area.
>   - **Copy button (`.md-copy-btn`)**:
>     - Moved to left, glassy styling with hover/active states; added SVG icon via `::before`.
>     - Accessibility: added `aria-label` and `title`; visual feedback via class toggle (removed text changes).
>   - **Syntax highlighting**:
>     - CDN CSS switched from `github.min.css` to `github-dark-dimmed.min.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b803f8bb086a59a05659fe0ca30fee13d3616d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->