### PR TITLE
Feat/webapp md layout padding and fullscreen scroll

### DIFF
--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -3,47 +3,6 @@ name: Notify Telegram
 on:
   workflow_run:
     workflows: ["CI/CD Pipeline"]
-    types: [completed]
-
-jobs:
-  notify:
-    name: Send Telegram Notification
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
-    steps:
-      - name: Prepare message
-        id: prep
-        run: |
-          set -euo pipefail
-          title='CI/CD Pipeline – Status'
-          conclusion='${{ github.event.workflow_run.conclusion }}'
-          if [ "${conclusion}" = "success" ]; then
-            title="${title} ✅"
-          fi
-          # Escape MarkdownV2 reserved characters for Telegram
-          esc() { printf '%s' "$1" | sed -e 's/[\\_\*\[\]\(\)~`>#\+\-=|{}\.!]/\\&/g'; }
-          msg="$(esc "${title}")\nRun: $(esc "${{ github.event.workflow_run.html_url }}")"
-          echo "text<<__MSG__" >> "$GITHUB_OUTPUT"
-          printf '%s\n' "$msg" >> "$GITHUB_OUTPUT"
-          echo "__MSG__" >> "$GITHUB_OUTPUT"
-
-      - name: Send Telegram message
-        env:
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-          CHAT_ID: ${{ secrets.CHAT_ID }}
-          TEXT: ${{ steps.prep.outputs.text }}
-        run: |
-          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ]; then
-            echo "BOT_TOKEN or CHAT_ID is missing" >&2
-            exit 1
-          fi
-          jq -nc --arg chat_id "$CHAT_ID" --arg text "$TEXT" '{chat_id:$chat_id, text:$text, parse_mode:"MarkdownV2", disable_web_page_preview:true}' |
-            curl -sS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" -H 'Content-Type: application/json' -d @-
-name: Notify Telegram
-
-on:
-  workflow_run:
-    workflows: ["CI/CD Pipeline"]
     types:
       - completed
 
@@ -210,7 +169,7 @@ jobs:
           CHAT_ID: ${{ secrets.CHAT_ID }}
           TEXT: ${{ steps.msg.outputs.text }}
         run: |
-          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ]; then
+          if [ -z "${BOT_TOKEN:-}" ] || [ -ז "${CHAT_ID:-}" ]; then
             echo "BOT_TOKEN or CHAT_ID is missing" >&2
             exit 1
           fi

--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -3,6 +3,47 @@ name: Notify Telegram
 on:
   workflow_run:
     workflows: ["CI/CD Pipeline"]
+    types: [completed]
+
+jobs:
+  notify:
+    name: Send Telegram Notification
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Prepare message
+        id: prep
+        run: |
+          set -euo pipefail
+          title='CI/CD Pipeline – Status'
+          conclusion='${{ github.event.workflow_run.conclusion }}'
+          if [ "${conclusion}" = "success" ]; then
+            title="${title} ✅"
+          fi
+          # Escape MarkdownV2 reserved characters for Telegram
+          esc() { printf '%s' "$1" | sed -e 's/[\\_\*\[\]\(\)~`>#\+\-=|{}\.!]/\\&/g'; }
+          msg="$(esc "${title}")\nRun: $(esc "${{ github.event.workflow_run.html_url }}")"
+          echo "text<<__MSG__" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$msg" >> "$GITHUB_OUTPUT"
+          echo "__MSG__" >> "$GITHUB_OUTPUT"
+
+      - name: Send Telegram message
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.CHAT_ID }}
+          TEXT: ${{ steps.prep.outputs.text }}
+        run: |
+          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ]; then
+            echo "BOT_TOKEN or CHAT_ID is missing" >&2
+            exit 1
+          fi
+          jq -nc --arg chat_id "$CHAT_ID" --arg text "$TEXT" '{chat_id:$chat_id, text:$text, parse_mode:"MarkdownV2", disable_web_page_preview:true}' |
+            curl -sS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" -H 'Content-Type: application/json' -d @-
+name: Notify Telegram
+
+on:
+  workflow_run:
+    workflows: ["CI/CD Pipeline"]
     types:
       - completed
 

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -190,6 +190,10 @@
             box-sizing: border-box;
             min-width: 0;
         }
+        /* ברזולוציות צרות – הוסף padding פנימי קל לימין לפיצוי על RTL ותפריטים */
+        @media (max-width: 480px) {
+            .main-content .glass-card { padding-right: 18px; }
+        }
         
         .btn {
             display: inline-flex;

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -16,7 +16,10 @@
   color: #111111;
   border-radius: 12px;
   border: none; /* ביטול מסגרת (שנתפסה כ"סגולה") */
-  padding: 14px 18px; /* מרווח פנימי כך שהטקסט לא דבוק לימין */
+  padding: 14px; /* בסיס לכל המסכים */
+  /* במובייל/מסכים צרים – הגדל ריווח מימין כדי שלא יהיה צמוד לקצה */
+  padding-right: clamp(22px, 6vw, 36px);
+  padding-left: clamp(14px, 4vw, 28px);
 }
 /* במסך מלא – לאפשר גלילה בתוך הכרטיס עצמו (תמיכה גם ב-WebKit) */
 #mdCard:fullscreen { height: 100vh; overflow: auto; }
@@ -92,6 +95,8 @@
 #md-content p, #md-content li, #md-content blockquote {
   overflow-wrap: anywhere;
   word-break: break-word;
+  /* ריווח שורה כדי שהטקסט לא ידבק לעמודה הימנית בזמן גלילה */
+  margin-right: 2px;
 }
 #md-content .code-block { position: relative; margin: 1rem 0; }
 #md-content .code-block pre {
@@ -196,7 +201,7 @@ input.md-task-checkbox {
       <button id="mdSearchNext" type="button" class="btn btn-secondary btn-icon" title="הבא" style="background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);flex:0 0 auto;">▶</button>
       <button id="mdSearchClear" type="button" class="btn btn-secondary btn-icon" title="נקה" style="background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);flex:0 0 auto;">✕</button>
     </div>
-    <div id="md-content" style="margin-inline:-16px;width:calc(100% + 32px);"></div>
+    <div id="md-content" style="margin-inline:-8px;width:calc(100% + 16px);"></div>
   </div>
   {% if not is_public %}
   <div class="glass-card" style="margin-top: 1rem;">

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -18,6 +18,9 @@
   border: none; /* ביטול מסגרת (שנתפסה כ"סגולה") */
   padding: 14px 18px; /* מרווח פנימי כך שהטקסט לא דבוק לימין */
 }
+/* במסך מלא – לאפשר גלילה בתוך הכרטיס עצמו (תמיכה גם ב-WebKit) */
+#mdCard:fullscreen { height: 100vh; overflow: auto; }
+#mdCard:-webkit-full-screen { height: 100vh; overflow: auto; }
 #md-content img {
   max-width: 100%;
   height: auto;

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -6,15 +6,17 @@
 <style>
 /* אזור התצוגה והביצועים */
 #md-root {
-  max-width: min(1400px, 98vw);
+  /* הרחבת אזור התוכן הלבן לצדדים והרחקה מהשוליים הסגולים */
+  max-width: min(1600px, 100vw);
   margin: 0 auto;
-  padding: 1rem;
+  padding: 0.5rem 0; /* את הריווח הצדדי ניתן דרך הכרטיס הפנימי */
 }
 #md-content {
   background: #ffffff;
   color: #111111;
-  border-radius: 10px;
+  border-radius: 12px;
   border: none; /* ביטול מסגרת (שנתפסה כ"סגולה") */
+  padding: 14px 18px; /* מרווח פנימי כך שהטקסט לא דבוק לימין */
 }
 #md-content img {
   max-width: 100%;
@@ -22,10 +24,11 @@
 }
 /* הרחבת הקונטיינר בעמוד Markdown כדי לצמצם את הסגול בצדדים */
 .main-content > .container {
+  /* מכולה רחבה כדי לצמצם "סגול" בצדדים */
   max-width: 100% !important;
   width: 100% !important;
-  padding-left: 10px !important;
-  padding-right: 10px !important;
+  padding-left: 8px !important;
+  padding-right: 8px !important;
 }
 /* טבלאות בסגנון GitHub */
 #md-content table {


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>הרחבת הבלוק הלבן בתצוגת Markdown והוספת ריווח פנימי דינמי ב־RTL כדי שהטקסט לא יצמד לימין.</li>
  <li>תיקון גלילה במסך מלא בכרטיס ה‑Markdown (<code>#mdCard:fullscreen</code> ו‑<code>:-webkit-full-screen</code>).</li>
  <li>תיקון הודעת ה‑Telegram ב‑CI: הוספת Escape מלא ל‑MarkdownV2 כדי למנוע שגיאת <em>can't parse entities</em>.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>שיפור קריאות וחוויית משתמש במובייל/מסכים צרים (RTL), ללא “דבוק לימין”.</li>
  <li>אפשרות גלילה תקינה במצב מסך מלא למסמכי MD ארוכים.</li>
  <li>מניעת כשלי התראות בטלגרם כאשר מופיעים תווים מיוחדים (כולל '#').</li>
</ul>

<h2>Changes</h2>
<ul>
  <li><code>webapp/templates/md_preview.html</code> – הרחבת פריסה, <code>padding-right</code> דינמי עם <code>clamp</code>, גלילה במסך מלא, ריווח עדין לרשימות/פסקאות.</li>
  <li><code>webapp/templates/base.html</code> – התאמת <code>padding-right</code> קל לכרטיסים במסכים צרים.</li>
  <li><code>.github/workflows/notify-telegram.yml</code> – פונקציית <code>esc</code> לאסקייפ של MarkdownV2 לפני שליחה.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>בדיקה ידנית בדפדפן במובייל/דסקטופ: ריווח צד ימין, גלילה במסך מלא, טבלאות וקוד.</li>
  <li>CI נדרש: “🔍 Code Quality &amp; Security”, “🧪 Unit Tests (3.11)”, “🧪 Unit Tests (3.12)”.</li>
</ul>

<h2>Links</h2>
<ul>
  <li>Branch: <code>feat/webapp-md-layout-padding-and-fullscreen-scroll</code></li>
  <li>Gist הצעה קודמת: <a href="https://gist.github.com/amirbiron/d09a8d31a183450d0a9f8f74f996b069">d09a8d31…</a></li>
  <li>Gist תמונה/הדגמה: <a href="https://gist.github.com/amirbiron/b7caff572ec7bedeb201dfce41d88b65">b7caff57…</a></li>
</ul>

<h2>Risks</h2>
<ul>
  <li>השפעה ויזואלית על עמוד תצוגת Markdown בלבד. סיכון נמוך.</li>
</ul>

<h2>Rollback</h2>
<ul>
  <li>להחזיר את השינויים ב‑<code>md_preview.html</code>, <code>base.html</code>, <code>.github/workflows/notify-telegram.yml</code>.</li>
</ul>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Widen and refine Markdown preview layout (padding/RTL/mobile and fullscreen scrolling) and add a GitHub Actions workflow that sends Telegram notifications with run metadata and test status.
> 
> - **Frontend/UI**
>   - **Markdown preview (`webapp/templates/md_preview.html`)**:
>     - Expand content width (`#md-root` to 1600px) and refine paddings/margins; increase card `border-radius` and internal padding with responsive clamps.
>     - Enable scroll in fullscreen for `#mdCard` and reduce outer negative margins on `#md-content`.
>     - Improve text wrapping and slight right margin for better RTL flow; narrow container side padding (8px).
>   - **Base layout (`webapp/templates/base.html`)**:
>     - Add small-screen RTL padding-right for `.main-content .glass-card`.
> - **CI/CD**
>   - **Telegram notifications (`.github/workflows/notify-telegram.yml`)**:
>     - Trigger on `workflow_run` completion for PRs; compute duration and finish time (Israel timezone) and derive PR metadata.
>     - Inspect jobs to summarize unit tests and code-quality results; build MarkdownV2-escaped message with links to PR/run.
>     - Send message via Telegram bot API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b05328f2014c2f387ce04cef90d74be4ed1d53b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->