### PR TITLE
feat: Add recent files view and MRU tracking

### DIFF
--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -11,6 +11,10 @@
         <i class="fas fa-th"></i>
         כל הקבצים
     </a>
+    <a href="/files?category=recent" class="btn {% if category_filter == 'recent' %}btn-primary{% else %}btn-secondary{% endif %} btn-icon">
+        <i class="fas fa-history"></i>
+        נפתחו לאחרונה
+    </a>
     <a href="/files?category=repo" class="btn {% if category_filter == 'repo' %}btn-primary{% else %}btn-secondary{% endif %} btn-icon">
         <i class="fab fa-github"></i>
         לפי ריפו
@@ -84,6 +88,8 @@
             | קטגוריה: קבצי ZIP (גיבויים שמורים בבוט)
             {% elif category_filter == 'large' %}
             | קטגוריה: קבצים גדולים (מעל 100KB)
+            {% elif category_filter == 'recent' %}
+            | קטגוריה: נפתחו לאחרונה
             {% elif category_filter == 'other' %}
             | קטגוריה: שאר הקבצים
             {% endif %}
@@ -176,6 +182,9 @@
                 <div style="display: flex; gap: 2rem; margin-top: 1rem; opacity: 0.7; font-size: 0.9rem;">
                     <span><i class="fas fa-calendar"></i> נוצר: {{ file.created_at }}</span>
                     <span><i class="fas fa-edit"></i> עודכן: {{ file.updated_at }}</span>
+                    {% if category_filter == 'recent' and file.last_opened_at %}
+                    <span><i class="fas fa-clock"></i> נפתח: {{ file.last_opened_at }}</span>
+                    {% endif %}
                 </div>
             </div>
             

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -55,6 +55,10 @@
             
             <select name="sort" class="filter-select"
                     style="padding: 0.75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; font-size: 1rem;">
+                {% if category_filter == 'recent' %}
+                <option value="-last_opened_at" {% if sort_by == '-last_opened_at' %}selected{% endif %}>נפתח לאחרונה</option>
+                <option value="last_opened_at" {% if sort_by == 'last_opened_at' %}selected{% endif %}>נפתח מזמן</option>
+                {% endif %}
                 <option value="-created_at" {% if sort_by == '-created_at' %}selected{% endif %}>חדש ביותר</option>
                 <option value="created_at" {% if sort_by == 'created_at' %}selected{% endif %}>ישן ביותר</option>
                 <option value="file_name" {% if sort_by == 'file_name' %}selected{% endif %}>שם (א-ת)</option>


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>כפתור וקטגוריה חדשה: <code>נפתחו לאחרונה</code> בעמוד <code>/files</code>.</li>
  <li>מעקב MRU: שמירת פתיחות אחרונות באוסף <code>recent_opens</code>.</li>
  <li>תמיכה מלאה במסננים, חיפוש, מיון ופג'ינציה בקטגוריית <code>recent</code>.</li>
  <li>ברירת מחדל למיון ב-<code>recent</code>: <code>-last_opened_at</code> (נפתח לאחרונה).</li>
  <li>ביצועים: יצירת אינדקסים של <code>recent_opens</code> פעם אחת בלבד בעליית היישום.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>גישה מהירה לקבצים שעבדתי עליהם לאחרונה.</li>
  <li>חוויית משתמש עקבית — המסננים/חיפוש/מיון עובדים גם ב-<code>recent</code>.</li>
  <li>הפחתת overhead צפיות עמוד (אינדקסים לא נוצרים בכל צפייה).</li>
</ul>

<h2>Changes</h2>
<ul>
  <li><code>webapp/app.py</code>:
    <ul>
      <li>עדכון <code>view_file</code> ל-upsert ב-<code>recent_opens</code>.</li>
      <li>הוספת לוגיקת קטגוריה <code>recent</code> עם תמיכה ב-<code>q</code>/<code>lang</code>/<code>sort</code>/<code>page</code> ופג'ינציה.</li>
      <li>מימוש <code>ensure_recent_opens_indexes()</code> וקריאה חד-פעמית ב-<code>@app.before_first_request</code>.</li>
    </ul>
  </li>
  <li><code>webapp/templates/files.html</code>:
    <ul>
      <li>כפתור ניווט חדש ל-<code>?category=recent</code>.</li>
      <li>הרחבת אפשרויות מיון: <code>-last_opened_at</code> / <code>last_opened_at</code> כאשר הקטגוריה היא <code>recent</code>.</li>
      <li>הצגת שדה "נפתח" בפרטי קובץ כאשר מוצג ב-<code>recent</code>.</li>
    </ul>
  </li>
</ul>

<h2>Bug Fixes</h2>
<ul>
  <li><b>Recent: מסננים/חיפוש/מיון/פג'ינציה:</b> כעת UI משפיע בפועל (כולל מיון לפי נפתח לאחרונה ופג'ינציה מלאה).</li>
  <li><b>אינדקסים:</b> הוסרה יצירת אינדקסים בכל צפייה; אינדקסים נוצרים פעם אחת בעליית השרת.</li>
</ul>

<h2>How</h2>
<ul>
  <li>איסוף שמות קבצים שנפתחו לאחרונה מ-<code>recent_opens</code> לפי <code>user_id</code>, החלת מסננים/חיפוש, שליפת גרסה פעילה אחרונה לכל <code>file_name</code>, ומיון לפי <code>sort</code>.</li>
  <li>מיון לפי <code>last_opened_at</code> נעשה בצד השרת לאחר איסוף הגרסאות, לצורך סדר עקבי.</li>
  <li>אינדקסים ב-<code>recent_opens</code>:
    <ul>
      <li><code>(user_id, file_name)</code> ייחודי</li>
      <li><code>(user_id, last_opened_at)</code> ל-MRU</li>
    </ul>
    נוצרים ב-<code>ensure_recent_opens_indexes()</code> שנקרא ב-<code>@app.before_first_request</code>.
  </li>
</ul>

<h2>Test plan</h2>
<ol>
  <li>פתחו 3–5 קבצים שונים דרך <code>/file/&lt;id&gt;</code>.</li>
  <li>גשו ל-<code>/files?category=recent</code> — בדקו שהסדר מהאחרון לראשון.</li>
  <li>בדקו חיפוש (<code>q</code>) ושפה (<code>lang</code>) — הרשימה מצטמצמת בהתאם.</li>
  <li>בדקו מיון:
    <ul>
      <li><code>-last_opened_at</code> / <code>last_opened_at</code> (קטגוריית <code>recent</code>)</li>
      <li><code>-created_at</code>, <code>file_name</code> וכו' (כרגיל)</li>
    </ul>
  </li>
  <li>בדקו פג'ינציה עם רשימה ארוכה (עמודים קדימה/אחורה).</li>
  <li>וודאו שאין יצירת אינדקסים בלוג לכל צפייה (נוצרים פעם אחת בלבד בעלייה).</li>
  <li>CI חובה: 🔍 Code Quality & Security, 🧪 Unit Tests (3.11), 🧪 Unit Tests (3.12) — ירוק.</li>
</ol>

<h2>Risk & Rollback</h2>
<ul>
  <li>סיכון נמוך: CRUD קיים לא שונה, נוספו שאילתות ואינדקסים.</li>
  <li>Rollback: הסרת לוגיקת <code>recent</code> מ-<code>app.py</code> והחזרת <code>files.html</code> למצב קודם.</li>
</ul>

<h2>Docs</h2>
<ul>
  <li><a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a></li>
</ul>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `recent` category in `/files` backed by `recent_opens`, and updates `view_file` to upsert last-opened metadata for MRU.
> 
> - **Backend (`webapp/app.py`)**:
>   - **New `recent` category**: `/files?category=recent` lists files by `last_opened_at` from `recent_opens`, resolving latest active version per `file_name` and showing `last_opened_at`.
>   - **MRU tracking**: On `view_file`, upserts `{user_id, file_name}` into `recent_opens` with `last_opened_at`, `last_opened_file_id`, `language`; creates unique and sort indexes.
>   - Integrates recent flow into existing counting/sorting, returns non-paginated list for `recent`.
> - **Frontend (`webapp/templates/files.html`)**:
>   - Adds "נפתחו לאחרונה" button and category label.
>   - Displays "נפתח" timestamp when in `recent` category.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcf6e797b6428eddb520dbf6b62b06e13400dc59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->