### PR TITLE
Fix hidden character removal bug

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -81,12 +81,17 @@ def _safe_rmtree_tmp(target_path: str) -> None:
 
 
 def safe_html_escape(text):
-    """Escape text for Telegram HTML; preserves \n/\r/\t and keeps existing HTML entities."""
+    """Escape text for Telegram HTML; preserves \n/\r/\t and keeps existing HTML entities.
+
+    מרחיב ניקוי תווים בלתי נראים: ZWSP/ZWNJ/ZWJ, BOM/ZWNBSP, ותווי כיווניות LRM/RLM/LRE/RLE/PDF/LRO/RLO/LRI/RLI/FSI/PDI.
+    """
     if text is None:
         return ""
     s = escape(str(text))
-    # נקה תווים בלתי נראים
-    s = re.sub(r"[\u200b\u200c\u200d\ufeff]", "", s)
+    # נקה תווים בלתי נראים (Zero-width) + BOM
+    s = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", s)
+    # נקה סימוני כיווניות (Cf) נפוצים שגורמים לבלבול בהצגה
+    s = re.sub(r"[\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069]", "", s)
     # נקה תווי בקרה אך השאר \n, \r, \t
     s = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "", s)
     return s

--- a/tests/test_save_flow_patch.py
+++ b/tests/test_save_flow_patch.py
@@ -125,6 +125,8 @@ def test_get_code_normalizes_zero_width():
     class _Msg:
         def __init__(self, text: str):
             self.text = text
+            # שדה document נדרש בענף לוגיקה של long_collect_receive
+            self.document = None
 
         async def reply_text(self, *args, **kwargs):
             pass
@@ -151,6 +153,8 @@ def test_long_collect_receive_normalizes_text():
     class _Msg:
         def __init__(self, text: str):
             self.text = text
+            # נדרש עבור הענף הבודק קבצים ב-long_collect_receive
+            self.document = None
 
         async def reply_text(self, *args, **kwargs):
             pass

--- a/tests/test_save_flow_patch.py
+++ b/tests/test_save_flow_patch.py
@@ -104,3 +104,166 @@ def test_save_file_final_escapes_note_markdown(monkeypatch):
     assert expected in calls['text']
     assert calls['kwargs'].get('parse_mode') == 'Markdown'
 
+
+# --- New tests to cover early normalization in save_flow ---
+
+def _has_invisibles(s: str) -> bool:
+    """Helper: detect zero-width and bidi marks in string."""
+    invis = [
+        "\u200b", "\u200c", "\u200d", "\u2060", "\ufeff",  # zero-width/BOM/WJ
+        "\u200e", "\u200f",  # LRM/RLM
+        "\u202a", "\u202b", "\u202c", "\u202d", "\u202e",  # LRE/RLE/PDF/LRO/RLO
+        "\u2066", "\u2067", "\u2068", "\u2069",  # LRI/RLI/FSI/PDI
+    ]
+    return any(c in s for c in invis)
+
+
+def test_get_code_normalizes_zero_width():
+    import asyncio
+    from handlers.save_flow import get_code
+
+    class _Msg:
+        def __init__(self, text: str):
+            self.text = text
+
+        async def reply_text(self, *args, **kwargs):
+            pass
+
+    class _Update:
+        def __init__(self, text: str):
+            self.message = _Msg(text)
+
+    class _Ctx:
+        def __init__(self):
+            self.user_data = {}
+
+    u = _Update("A\u200bB\u200fC\u200d")
+    c = _Ctx()
+    asyncio.run(get_code(u, c))
+    cleaned = c.user_data.get('code_to_save', '')
+    assert cleaned and not _has_invisibles(cleaned)
+
+
+def test_long_collect_receive_normalizes_text():
+    import asyncio
+    from handlers.save_flow import long_collect_receive
+
+    class _Msg:
+        def __init__(self, text: str):
+            self.text = text
+
+        async def reply_text(self, *args, **kwargs):
+            pass
+
+    class _Update:
+        def __init__(self, text: str):
+            self.message = _Msg(text)
+            self.effective_chat = types.SimpleNamespace(id=111)
+            self.effective_user = types.SimpleNamespace(id=222)
+
+    class _Job:
+        pass
+
+    class _JobQueue:
+        def run_once(self, *args, **kwargs):
+            return _Job()
+
+    class _Ctx:
+        def __init__(self):
+            self.user_data = {}
+            self.job_queue = _JobQueue()
+
+    u = _Update("x\u200b y\u202e z\u2060")
+    c = _Ctx()
+    asyncio.run(long_collect_receive(u, c))
+    parts = c.user_data.get('long_collect_parts') or []
+    assert parts and all(not _has_invisibles(p) for p in parts)
+
+
+def test_long_collect_done_normalizes_combined():
+    import asyncio
+    from handlers.save_flow import long_collect_done
+
+    class _Msg:
+        async def reply_text(self, *args, **kwargs):
+            pass
+
+    class _Update:
+        def __init__(self):
+            self.message = _Msg()
+
+    class _Ctx:
+        def __init__(self):
+            self.user_data = {
+                'long_collect_parts': [
+                    "a\u200b\u200f\u200d",
+                    "b\u202a\u202b\u202c\u202d\u202e",
+                    "c\u2066\u2067\u2068\u2069\u2060",
+                ]
+            }
+
+    u = _Update()
+    c = _Ctx()
+    asyncio.run(long_collect_done(u, c))
+    combined = c.user_data.get('code_to_save', '')
+    assert combined and not _has_invisibles(combined)
+
+
+def test_save_file_final_normalizes_code_content(monkeypatch):
+    # Stub telegram keyboard classes used in save_flow to keep test lightweight
+    import handlers.save_flow as sf
+    sf.InlineKeyboardButton = lambda *a, **k: ('btn', a, k)
+    sf.InlineKeyboardMarkup = lambda rows: ('kb', rows)
+
+    # Stub services.code_service.detect_language
+    monkeypatch.setattr(sf.code_service, 'detect_language', lambda code, fn: 'python')
+
+    # Provide a lightweight 'database' module with db & CodeSnippet capturing snippet
+    db_mod = types.ModuleType('database')
+
+    class _DB:
+        def __init__(self):
+            self.last_snip = None
+
+        def save_code_snippet(self, snip):
+            self.last_snip = snip
+            return True
+
+        def get_latest_version(self, user_id, filename):
+            return {'_id': 'xyz'}
+
+    class _CodeSnippet:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    db_mod.db = _DB()
+    db_mod.CodeSnippet = _CodeSnippet
+    monkeypatch.setitem(sys.modules, 'database', db_mod)
+
+    # Build update/context stubs
+    calls = {}
+
+    class _Msg:
+        async def reply_text(self, text, **kwargs):
+            calls['text'] = text
+            calls['kwargs'] = kwargs
+
+    class _Update:
+        def __init__(self):
+            self.message = _Msg()
+
+    class _Ctx:
+        def __init__(self):
+            self.user_data = {
+                'code_to_save': 'print(1)\u200b\u200f',
+                'note_to_save': 'ok'
+            }
+
+    u = _Update()
+    c = _Ctx()
+
+    import asyncio
+    asyncio.run(sf.save_file_final(u, c, filename='a.py', user_id=1))
+
+    saved = db_mod.db.last_snip.kwargs['code']
+    assert saved and not _has_invisibles(saved)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,6 +31,9 @@ ROOT_DIR = str(Path(__file__).resolve().parents[1])
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
+# נרמול טקסט/קוד לפני שמירה (הסרת תווים נסתרים, כיווניות, אחידות שורות)
+from utils import normalize_code  # noqa: E402
+
 # יצירת האפליקציה
 app = Flask(__name__)
 app.secret_key = os.getenv('SECRET_KEY', 'dev-secret-key-change-in-production')
@@ -1285,6 +1288,8 @@ def edit_file_page(file_id):
         try:
             file_name = (request.form.get('file_name') or '').strip()
             code = request.form.get('code') or ''
+            # נרמול התוכן כדי להסיר תווים נסתרים וליישר פורמט עוד לפני שמירה
+            code = normalize_code(code)
             language = (request.form.get('language') or '').strip() or (file.get('programming_language') or 'text')
             description = (request.form.get('description') or '').strip()
             raw_tags = (request.form.get('tags') or '').strip()
@@ -1766,6 +1771,9 @@ def upload_file_web():
                             code = ''
                     if not file_name:
                         file_name = uploaded.filename or ''
+
+            # נרמול התוכן (בין אם הגיע מהטופס או מקובץ שהועלה)
+            code = normalize_code(code)
 
             if not file_name:
                 error = 'יש להזין שם קובץ'


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li><strong>Normalize on save (WebApp):</strong> הוחל נרמול קוד מיד בקבלת טופס בעריכת קובץ ובהעלאה חדשה כדי להסיר תווים נסתרים, סימוני כיווניות, לאחד שורות ולנקות רווחים סופיים.</li>
  <li><strong>Early normalization (Bot):</strong> הוסף נרמול מוקדם בזרימות הבוט <code>get_code</code>, <code>long_collect_receive</code>, <code>long_collect_done</code> ולפני השמירה הסופית. כך התוכן נקי כבר מרגע הקליטה.</li>
  <li><strong>Safer HTML escape:</strong> הרחבת <code>safe_html_escape</code> להסרת סימוני כיווניות (LRM/RLM/LRE/RLE/PDF/LRO/RLO/LRI/RLI/FSI/PDI) ו־WJ בנוסף ל־ZWSP/ZWNJ/ZWJ/BOM.</li>
</ul>

<h2>Why</h2>
<p>
תווים בלתי נראים (Zero-width) וסימוני כיווניות (Bidi) “זולגים” מטקסטים שמועתקים מהרשת וגורמים להפתעות בהצגה/חיפוש.
נרמול עקבי מונע תקלות, מיישר פורמט, ומונע בלבול בהודעות/תצוגות.
</p>

<h2>Scope / Impact</h2>
<ul>
  <li>חל על כל שמירה דרך הבוט וה־WebApp. הפעולה אידמפוטנטית ובטוחה.</li>
  <li>נוסף נרמול <em>מוקדם</em> (ללא תלות בדגל הקונפיג), בנוסף לנרמול בצד ה־Repository שכבר מכבד את <code>NORMALIZE_CODE_ON_SAVE</code>.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>כבר קיימת בדיקה לוגית לפונקציה: <code>tests/test_utils.py::test_normalize_code_removes_invisibles_and_normalizes_newlines</code>.</li>
  <li><strong>תוכנית בדיקות ידנית:</strong>
    <ol>
      <li>בבוט: שלח טקסט עם תווים נסתרים (ZWSP/ZWNJ/ZWJ/WJ ו־LRM/RLM/…); שמור קובץ והצג/הורד – התווים יוסרו.</li>
      <li>ב־WebApp: העלה/ערוך קובץ עם אותם תווים דרך הטופס – שמור – התווים יוסרו.</li>
      <li>ודא שהודעות HTML (למשל תפריטי GitHub) מציגות טקסט נקי בזכות <code>safe_html_escape</code> המורחב.</li>
    </ol>
  </li>
</ul>

<h2>Backward compatibility / Risks</h2>
<ul>
  <li>הסרת תווי <code>Cf</code> וכיווניות עלולה לשנות הצגה של טקסט דו־כיווני נדיר שנועד במכוון; זה התנהגות רצויה עבור קוד/טקסטים שמורים.</li>
  <li>אם יידרש, ניתן לשקול לאגד גם את הנרמול המוקדם לדגל <code>NORMALIZE_CODE_ON_SAVE</code>.</li>
</ul>

<h2>Rollback plan</h2>
<ul>
  <li>החזרות נקודתיות של הקבצים הבאים. אין מיגרציות/שינויים ב־DB.</li>
</ul>

<h2>Files changed</h2>
<ul>
  <li><code>handlers/save_flow.py</code> – נרמול מוקדם בקליטת הודעות ובאיחוד חלקים.</li>
  <li><code>webapp/app.py</code> – נרמול מיידי בשמירה/העלאה לפני הכנסת מסמך ל־DB.</li>
  <li><code>github_menu_handler.py</code> – הרחבת <code>safe_html_escape</code> לניקוי סימוני כיווניות ו־WJ.</li>
</ul>

<h2>Docs</h2>
<ul>
  <li>תיעוד הפרויקט: <a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a></li>
</ul>

<h2>Checklist</h2>
<ul>
  <li>[ ] Code review</li>
  <li>[ ] 🔍 Code Quality &amp; Security</li>
  <li>[ ] 🧪 Unit Tests (3.11)</li>
  <li>[ ] 🧪 Unit Tests (3.12)</li>
  <li>[ ] Docs/PR notes מעודכנים</li>
</ul>

<details>
  <summary>Example input (escaped) with hidden chars</summary>
  <pre><code>This\u200b is\u200f a\u200d test\u202c string\u200e with\u2060 hidden\u202d characters!
Line\u200b two\u202e also\u200f has\u200d some\u202a sneaky\u2060 stuff.
Even\u200b more\u202c here\u2060...</code></pre>
  <p><em>After save/normalize: אין תווי \u200b/\u200c/\u200d/\u2060 או סימוני כיווניות \u200e/\u200f/\u202a..\u202e/\u2066..\u2069.</em></p>
</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-8c8c98ea-f9d4-4cf7-af9e-411e10ddeaf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c8c98ea-f9d4-4cf7-af9e-411e10ddeaf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize code inputs across bot and web app; expand HTML escaping to remove more hidden and bidirectional characters.
> 
> - **Utils**:
>   - `safe_html_escape`: broaden removal of zero-width, BOM, and bidirectional marks (e.g., ZWSP/ZWNJ/ZWJ/ZWNBSP, LRM/RLM/LRE/RLE/PDF/LRO/RLO/LRI/RLI/FSI/PDI).
> - **Bot (handlers/save_flow.py)**:
>   - Apply `normalize_code` during long-collect (per-part and final), single-message code input, and pre-save to sanitize hidden/bidi chars and normalize newlines.
> - **Web App (webapp/app.py)**:
>   - Use `normalize_code` when editing and uploading code (form and file uploads) before validation/language detection/saving.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870914ea22d22bd3e29f983170fd815cb7d633ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->