### PR TITLE
Feat/recycle bin and backfill UI copy

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -263,7 +263,7 @@ HELP_PAGES = [
         "📦 <b>קבצי ZIP</b> — גיבויים/ארכיונים\n\n"
         "<b>לכל קובץ יש תפריט עם:</b>\n"
         "👁️ הצג | ✏️ ערוך | 📝 שנה שם\n"
-        "📚 היסטוריה | 📥 הורד | 🗑️ מחק\n\n"
+        "📚 היסטוריה | 📥 הורד | 🗑️ העבר לסל\n\n"
         "<b>טיפ:</b> יש עימוד (10 לעמוד) וגם 'הצג עוד/פחות' בתצוגת קוד"
     ),
     (
@@ -481,6 +481,7 @@ async def show_all_files(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             [InlineKeyboardButton("📦 קבצי ZIP", callback_data="backup_list")],
             [InlineKeyboardButton("📂 קבצים גדולים", callback_data="show_large_files")],
             [InlineKeyboardButton("📁 שאר הקבצים", callback_data="show_regular_files")],
+            [InlineKeyboardButton("🗑️ סל מיחזור", callback_data="recycle_bin")],
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await update.message.reply_text(
@@ -613,8 +614,8 @@ async def show_regular_files_callback(update: Update, context: ContextTypes.DEFA
             if pagination_row:
                 keyboard.append(pagination_row)
 
-            # כפתור מחיקה מרובה
-            keyboard.append([InlineKeyboardButton("🗑️ מחיקה מרובה", callback_data="rf_multi_start")])
+            # כפתור העברה מרובה לסל
+            keyboard.append([InlineKeyboardButton("🗑️ העברה מרובה לסל", callback_data="rf_multi_start")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="files")])
             reply_markup = InlineKeyboardMarkup(keyboard)
 
@@ -707,13 +708,13 @@ async def show_regular_files_page_callback(update: Update, context: ContextTypes
 
         if multi_on:
             count_sel = len(selected_ids)
-            # כפתורי מחיקה/ביטול במצב מחיקה מרובה
-            keyboard.append([InlineKeyboardButton(f"🗑️ מחק נבחרים ({count_sel})", callback_data="rf_delete_confirm")])
-            keyboard.append([InlineKeyboardButton("❌ בטל מחיקה מרובה", callback_data="rf_multi_cancel")])
+            # כפתורי העברה/ביטול במצב מחיקה מרובה
+            keyboard.append([InlineKeyboardButton(f"🗑️ העבר נבחרים לסל ({count_sel})", callback_data="rf_delete_confirm")])
+            keyboard.append([InlineKeyboardButton("❌ בטל העברה מרובה", callback_data="rf_multi_cancel")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="files")])
         else:
-            # כפתור מחיקה מרובה במצב רגיל
-            keyboard.append([InlineKeyboardButton("🗑️ מחיקה מרובה", callback_data="rf_multi_start")])
+            # כפתור העברה מרובה לסל במצב רגיל
+            keyboard.append([InlineKeyboardButton("🗑️ העברה מרובה לסל", callback_data="rf_multi_start")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="files")])
         reply_markup = InlineKeyboardMarkup(keyboard)
 
@@ -1564,17 +1565,16 @@ async def handle_delete_confirmation(update: Update, context: ContextTypes.DEFAU
         
         keyboard = [
             [
-                InlineKeyboardButton("✅ כן, מחק", callback_data=f"confirm_del_{file_index}"),
+                InlineKeyboardButton("✅ כן, העבר לסל", callback_data=f"confirm_del_{file_index}"),
                 InlineKeyboardButton("❌ לא, בטל", callback_data=f"file_{file_index}")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         
         await query.edit_message_text(
-            f"⚠️ *אישור מחיקה*\n\n"
+            f"⚠️ *אישור העברה לסל*\n\n"
             f"📄 **קובץ:** `{file_name}`\n\n"
-            f"🗑️ האם אתה בטוח שברצונך למחוק את הקובץ?\n"
-            f"⚠️ **פעולה זו לא ניתנת לביטול!**",
+            f"🗑️ הקובץ יועבר לסל המיחזור. ניתן לשחזר עד {config.RECYCLE_TTL_DAYS} ימים לפני מחיקה אוטומטית.",
             reply_markup=reply_markup,
             parse_mode='Markdown'
         )
@@ -1612,9 +1612,9 @@ async def handle_delete_file(update: Update, context: ContextTypes.DEFAULT_TYPE)
             reply_markup = InlineKeyboardMarkup(keyboard)
             
             await query.edit_message_text(
-                f"✅ *הקובץ נמחק בהצלחה!*\n\n"
-                f"📄 **קובץ שנמחק:** `{file_name}`\n"
-                f"🗑️ **הקובץ הוסר לחלוטין מהמערכת**",
+                f"✅ *הקובץ הועבר לסל המיחזור!*\n\n"
+                f"📄 **קובץ:** `{file_name}`\n"
+                f"♻️ ניתן לשחזר מסל המיחזור עד {config.RECYCLE_TTL_DAYS} ימים.",
                 reply_markup=reply_markup,
                 parse_mode='Markdown'
             )
@@ -2175,9 +2175,9 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
                 return ConversationHandler.END
             last_page = context.user_data.get('files_last_page') or 1
             warn = (
-                f"⚠️ עומד/ת למחוק <b>{count_sel}</b> קבצים שנבחרו.\n"
-                "המחיקה היא מקומית במסד של הבוט בלבד — אין שום פעולה מול GitHub,\n"
-                "ולא נמחקים קבצי ZIP/גדולים.\n\n"
+                f"⚠️ עומד/ת להעביר <b>{count_sel}</b> קבצים לסל המיחזור.\n"
+                f"הקבצים יהיו ניתנים לשחזור עד {config.RECYCLE_TTL_DAYS} ימים, ולאחר מכן יימחקו אוטומטית.\n"
+                "אין שום פעולה מול GitHub, ולא נמחקים קבצי ZIP/גדולים.\n\n"
                 "אם זה בטעות, חזור/י אחורה."
             )
             kb = [
@@ -2189,13 +2189,12 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             # אישור שני
             last_page = context.user_data.get('files_last_page') or 1
             text2 = (
-                "🧨 אישור סופי למחיקה\n"
-                "הקבצים הנבחרים יימחקו מהמסד של הבוט בלבד.\n"
+                "🧨 אישור סופי להעברה לסל\n"
+                f"הקבצים יועברו לסל המיחזור ויישארו לשחזור עד {config.RECYCLE_TTL_DAYS} ימים.\n"
                 "אין שום פעולה מול GitHub, ולא נמחקים קבצי ZIP/גדולים.\n"
-                "הפעולה בלתי הפיכה."
             )
             kb = [
-                [InlineKeyboardButton("🧨 כן, מחק", callback_data="rf_delete_do")],
+                [InlineKeyboardButton("🧨 כן, העבר לסל", callback_data="rf_delete_do")],
                 [InlineKeyboardButton("🔙 בטל", callback_data=f"files_page_{last_page}")],
             ]
             await query.edit_message_text(text2, reply_markup=InlineKeyboardMarkup(kb), parse_mode=ParseMode.HTML)
@@ -2229,8 +2228,8 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
                 last_page = total_pages or 1
             context.user_data['files_last_page'] = last_page
             msg = (
-                f"✅ נמחקו {deleted} קבצים מהמסד של הבוט בלבד.\n"
-                "ℹ️ אין שינוי בריפו ב‑GitHub ולא נמחקו קבצי ZIP/גדולים."
+                f"✅ הועברו לסל {deleted} קבצים.\n"
+                f"♻️ ניתן לשחזר מסל המיחזור עד {config.RECYCLE_TTL_DAYS} ימים."
             )
             kb = [
                 [InlineKeyboardButton("🔙 חזור לשאר הקבצים", callback_data=f"files_page_{last_page}")],
@@ -2504,8 +2503,8 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             pagination_row = build_pagination_row(1, total, FILES_PAGE_SIZE, f"by_repo_page:{tag}:")
             if pagination_row:
                 keyboard.append(pagination_row)
-            # פעולת מחיקה לריפו הנוכחי
-            keyboard.append([InlineKeyboardButton("🗑️ מחק את כל הריפו", callback_data=f"byrepo_delete_confirm:{tag}")])
+            # פעולת העברה לריפו הנוכחי לסל המיחזור
+            keyboard.append([InlineKeyboardButton("🗑️ העבר את כל הריפו לסל", callback_data=f"byrepo_delete_confirm:{tag}")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="back_to_repo_menu")])
             keyboard.append([InlineKeyboardButton("🏠 תפריט ראשי", callback_data="main")])
             await query.edit_message_text(
@@ -2536,10 +2535,9 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             files = db.search_code(user_id, query="", tags=[tag], limit=10000) or []
             total = len(files)
             warn_text = (
-                f"⚠️ עומד/ת למחוק <b>{total}</b> קבצים תחת התגית <code>{tag}</code>\n"
-                "פעולה זו תסמן את הקבצים כלא־פעילים במסד של הבוט בלבד, \n"
-                "ולא תמחוק דבר ב‑GitHub. \n"
-                "לא תימחק פיזית גם אף קובץ ZIP/גדול.\n\n"
+                f"⚠️ עומד/ת להעביר <b>{total}</b> קבצים של <code>{tag}</code> לסל המיחזור.\n"
+                f"הקבצים יהיו ניתנים לשחזור עד {config.RECYCLE_TTL_DAYS} ימים, ולאחר מכן יימחקו אוטומטית.\n"
+                "אין שום פעולה מול GitHub, ולא נמחקים קבצי ZIP/גדולים.\n\n"
                 "אם זה בטעות, חזור/י אחורה."
             )
             kb = [
@@ -2551,13 +2549,12 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             # שלב אישור שני
             tag = data.split(":", 1)[1]
             text2 = (
-                "🧨 אישור סופי למחיקה\n"
-                f"כל הקבצים תחת <code>{tag}</code> יוגדרו כלא־פעילים במסד של הבוט בלבד.\n"
+                "🧨 אישור סופי להעברה לסל\n"
+                f"כל הקבצים תחת <code>{tag}</code> יועברו לסל המיחזור ויישארו לשחזור עד {config.RECYCLE_TTL_DAYS} ימים.\n"
                 "אין שום פעולה מול GitHub, ולא נמחקים קבצי ZIP/גדולים.\n"
-                "הפעולה בלתי הפיכה."
             )
             kb = [
-                [InlineKeyboardButton("🧨 כן, מחק", callback_data=f"byrepo_delete_do:{tag}")],
+                [InlineKeyboardButton("🧨 כן, העבר לסל", callback_data=f"byrepo_delete_do:{tag}")],
                 [InlineKeyboardButton("🔙 בטל", callback_data=f"by_repo:{tag}")],
             ]
             await query.edit_message_text(text2, reply_markup=InlineKeyboardMarkup(kb), parse_mode=ParseMode.HTML)
@@ -2594,7 +2591,7 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
             pagination_row = build_pagination_row(page, total, FILES_PAGE_SIZE, f"by_repo_page:{tag}:")
             if pagination_row:
                 keyboard.append(pagination_row)
-            keyboard.append([InlineKeyboardButton("🗑️ מחק את כל הריפו", callback_data=f"byrepo_delete_confirm:{tag}")])
+            keyboard.append([InlineKeyboardButton("🗑️ העבר את כל הריפו לסל", callback_data=f"byrepo_delete_confirm:{tag}")])
             keyboard.append([InlineKeyboardButton("🔙 חזור", callback_data="back_to_repo_menu")])
             keyboard.append([InlineKeyboardButton("🏠 תפריט ראשי", callback_data="main")])
             try:
@@ -2719,8 +2716,8 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
                     except Exception:
                         pass
             msg = (
-                f"✅ נמחקו {deleted} קבצים תחת <code>{tag}</code> מהמסד של הבוט בלבד.\n"
-                "ℹ️ אין שינוי בריפו ב‑GitHub ולא נמחקו קבצי ZIP/גדולים."
+                f"✅ הועברו לסל {deleted} קבצים תחת <code>{tag}</code>.\n"
+                f"♻️ ניתן לשחזר מסל המיחזור עד {config.RECYCLE_TTL_DAYS} ימים."
             )
             kb = [
                 [InlineKeyboardButton("🔙 חזור לתפריט ריפו", callback_data="by_repo_menu")],

--- a/tests/test_bulk_move_to_trash_texts.py
+++ b/tests/test_bulk_move_to_trash_texts.py
@@ -1,0 +1,55 @@
+import types
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bulk_move_to_trash_texts(monkeypatch):
+    # Ensure env for importing
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    import importlib
+    ch = importlib.import_module("conversation_handlers")
+
+    captured = {"text": None, "kb": None}
+
+    class DummyQuery:
+        def __init__(self, data):
+            self.data = data
+        async def answer(self, *a, **k):
+            return None
+        async def edit_message_text(self, text=None, reply_markup=None, parse_mode=None):
+            captured["text"] = text
+            captured["kb"] = reply_markup
+
+    class DummyUpdate:
+        def __init__(self, data):
+            self.callback_query = DummyQuery(data)
+        @property
+        def effective_user(self):
+            return types.SimpleNamespace(id=7)
+
+    class DummyContext:
+        def __init__(self):
+            self.user_data = {"rf_selected_ids": ["id1", "id2"], "files_last_page": 1}
+
+    # First confirm step
+    u = DummyUpdate("rf_delete_confirm")
+    ctx = DummyContext()
+    await ch.handle_callback_query(u, ctx)
+
+    assert captured["text"] is not None
+    assert "להעביר" in captured["text"] and "סל" in captured["text"]
+
+    # Second confirm step
+    u2 = DummyUpdate("rf_delete_double_confirm")
+    await ch.handle_callback_query(u2, ctx)
+
+    assert captured["text"] is not None
+    assert "אישור סופי להעברה לסל" in captured["text"]
+    # keyboard contains the proceed button with the new label
+    kb = captured["kb"]
+    assert kb is not None
+    btn_texts = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert any("כן, העבר לסל" in t for t in btn_texts)

--- a/tests/test_by_repo_delete_to_trash_texts.py
+++ b/tests/test_by_repo_delete_to_trash_texts.py
@@ -1,0 +1,70 @@
+import types
+import importlib
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_by_repo_delete_to_trash_texts(monkeypatch):
+    # Env for imports
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    ch = importlib.import_module("conversation_handlers")
+
+    # Stub db.search_code to return 2 items
+    mod = types.ModuleType("database")
+    class DummyDB:
+        def search_code(self, user_id, query, tags=None, limit=10000):
+            return [{"file_name": "a.py"}, {"file_name": "b.py"}]
+        def delete_file(self, user_id, file_name):
+            return True
+    mod.db = DummyDB()
+    monkeypatch.setitem(__import__('sys').modules, "database", mod)
+
+    captured = {"text": None, "reply_markup": None}
+
+    class DummyQuery:
+        def __init__(self, data):
+            self.data = data
+            self.message = types.SimpleNamespace(message_id=1)
+        async def answer(self, *a, **k):
+            return None
+        async def edit_message_text(self, text=None, reply_markup=None, parse_mode=None):
+            captured["text"] = text
+            captured["reply_markup"] = reply_markup
+
+    class DummyUpdate:
+        def __init__(self, data):
+            self.callback_query = DummyQuery(data)
+        @property
+        def effective_user(self):
+            return types.SimpleNamespace(id=7)
+
+    class DummyContext:
+        def __init__(self):
+            self.user_data = {}
+
+    tag = "repo:me/app"
+
+    # Step 1: open confirm
+    u1 = DummyUpdate(f"byrepo_delete_confirm:{tag}")
+    ctx = DummyContext()
+    await ch.handle_callback_query(u1, ctx)
+
+    assert captured["text"] is not None
+    assert "להעביר" in captured["text"] and "סל" in captured["text"]
+
+    # Step 2: second confirm text
+    u2 = DummyUpdate(f"byrepo_delete_double_confirm:{tag}")
+    await ch.handle_callback_query(u2, ctx)
+
+    assert captured["text"] is not None
+    assert "אישור סופי להעברה לסל" in captured["text"]
+
+    # Step 3: perform action and final message
+    u3 = DummyUpdate(f"byrepo_delete_do:{tag}")
+    await ch.handle_callback_query(u3, ctx)
+
+    assert captured["text"] is not None
+    assert "הועברו לסל" in captured["text"]

--- a/tests/test_recycle_backfill.py
+++ b/tests/test_recycle_backfill.py
@@ -1,0 +1,137 @@
+import types
+import importlib
+import pytest
+
+
+class DummyColl:
+    def __init__(self, raise_on_index=False, modified_at=1, modified_exp=1):
+        self.raise_on_index = raise_on_index
+        self.calls = {"create_index": 0, "update_many": []}
+        self.modified_at = modified_at
+        self.modified_exp = modified_exp
+
+    def create_index(self, *a, **k):
+        self.calls["create_index"] += 1
+        if self.raise_on_index:
+            raise RuntimeError("index error")
+        return None
+
+    def update_many(self, flt, upd):
+        self.calls["update_many"].append((flt, upd))
+        if "$set" in upd and "deleted_at" in upd["$set"]:
+            return types.SimpleNamespace(modified_count=self.modified_at)
+        if "$set" in upd and "deleted_expires_at" in upd["$set"]:
+            return types.SimpleNamespace(modified_count=self.modified_exp)
+        return types.SimpleNamespace(modified_count=0)
+
+
+class FakeMessage:
+    def __init__(self):
+        self.sent = []
+
+    async def reply_text(self, text):
+        self.sent.append(text)
+
+
+class FakeUser:
+    def __init__(self, uid):
+        self.id = uid
+
+
+class FakeUpdate:
+    def __init__(self, uid=0):
+        self.effective_user = FakeUser(uid)
+        self.message = FakeMessage()
+
+
+class FakeContext:
+    def __init__(self, args=None):
+        self.args = args or []
+
+
+@pytest.mark.asyncio
+async def test_recycle_backfill_denied_for_non_admin(monkeypatch):
+    # Ensure required env for importing main/config
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    # Import fresh module
+    m = importlib.import_module("main")
+    # Force no admins
+    monkeypatch.setattr(m, "get_admin_ids", lambda: [])
+
+    upd = FakeUpdate(uid=111)
+    ctx = FakeContext()
+
+    await m.recycle_backfill_command(upd, ctx)
+
+    assert any("למנהלים בלבד" in s for s in upd.message.sent)
+
+
+@pytest.mark.asyncio
+async def test_recycle_backfill_backfills_and_reports(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    # Reload module to ensure clean state
+    if "main" in __import__("sys").modules:
+        importlib.reload(__import__("sys").modules["main"])  # type: ignore
+    m = importlib.import_module("main")
+    # Make current user admin
+    monkeypatch.setattr(m, "get_admin_ids", lambda: [999])
+
+    # Provide dummy db with one real collection and one missing
+    coll = DummyColl(raise_on_index=False, modified_at=2, modified_exp=3)
+    dummy_db = types.SimpleNamespace(collection=coll, large_files_collection=None)
+
+    # Inject database module that main imports inside the function
+    mod = types.ModuleType("database")
+    mod.db = dummy_db
+    monkeypatch.setitem(__import__('sys').modules, "database", mod)
+
+    upd = FakeUpdate(uid=999)
+    ctx = FakeContext(args=["5"])  # TTL days override
+
+    await m.recycle_backfill_command(upd, ctx)
+
+    # Verify report contains our TTL and counts, and mentions missing collection
+    out = "\n".join(upd.message.sent)
+    assert "TTL=5" in out
+    assert "deleted_at=2, deleted_expires_at=3" in out
+    assert "קבצים גדולים" in out and "דילוג" in out
+    # Ensure index ensured and two updates executed
+    assert coll.calls["create_index"] == 1
+    assert len(coll.calls["update_many"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_recycle_backfill_handles_index_errors(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    # Reload module to ensure clean state
+    if "main" in __import__("sys").modules:
+        importlib.reload(__import__("sys").modules["main"])  # type: ignore
+    m = importlib.import_module("main")
+
+    monkeypatch.setattr(m, "get_admin_ids", lambda: [1])
+    coll_ok = DummyColl(raise_on_index=True, modified_at=1, modified_exp=1)
+    coll2 = DummyColl(raise_on_index=False, modified_at=0, modified_exp=0)
+    dummy_db = types.SimpleNamespace(collection=coll_ok, large_files_collection=coll2)
+
+    mod = types.ModuleType("database")
+    mod.db = dummy_db
+    monkeypatch.setitem(__import__('sys').modules, "database", mod)
+
+    upd = FakeUpdate(uid=1)
+    ctx = FakeContext(args=[])
+
+    await m.recycle_backfill_command(upd, ctx)
+
+    out = "\n".join(upd.message.sent)
+    # Both collections reported, counts present (may be zeros on second)
+    assert "Backfill סל מיחזור" in out
+    assert "deleted_at=" in out and "deleted_expires_at=" in out

--- a/tests/test_recycle_button_in_files_menu.py
+++ b/tests/test_recycle_button_in_files_menu.py
@@ -1,0 +1,47 @@
+import types
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_recycle_button_present_in_files_menu_callback(monkeypatch):
+    # Ensure env
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    import importlib
+    ch = importlib.import_module("conversation_handlers")
+
+    captured = {}
+    async def fake_safe_edit_message_text(query, text, reply_markup=None, parse_mode=None):
+        captured["reply_markup"] = reply_markup
+
+    from utils import TelegramUtils
+    monkeypatch.setattr(TelegramUtils, "safe_edit_message_text", fake_safe_edit_message_text)
+
+    class DummyQuery:
+        def __init__(self):
+            self.data = "files"
+        async def answer(self):
+            return None
+
+    class DummyUpdate:
+        def __init__(self):
+            self.callback_query = DummyQuery()
+        @property
+        def effective_user(self):
+            return types.SimpleNamespace(id=1)
+
+    class DummyContext:
+        def __init__(self):
+            self.user_data = {}
+
+    u = DummyUpdate()
+    ctx = DummyContext()
+
+    await ch.show_all_files_callback(u, ctx)
+
+    rm = captured.get("reply_markup")
+    assert rm is not None
+    callbacks = [row[0].callback_data for row in rm.inline_keyboard]
+    assert "recycle_bin" in callbacks

--- a/tests/test_single_delete_to_trash_texts.py
+++ b/tests/test_single_delete_to_trash_texts.py
@@ -1,0 +1,57 @@
+import types
+import importlib
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_single_delete_to_trash_flow(monkeypatch):
+    # Env for imports
+    monkeypatch.setenv("BOT_TOKEN", "dummy")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/test")
+    monkeypatch.setenv("DISABLE_DB", "1")
+
+    ch = importlib.import_module("conversation_handlers")
+
+    # Prepare files cache and DB stub
+    class DummyDB:
+        def delete_file(self, user_id, file_name):
+            DummyDB.last = (user_id, file_name)
+            return True
+
+    mod = types.ModuleType("database")
+    mod.db = DummyDB()
+    monkeypatch.setitem(__import__('sys').modules, "database", mod)
+
+    captured = {"text": None}
+
+    class DummyQuery:
+        def __init__(self, data):
+            self.data = data
+        async def answer(self, *a, **k):
+            return None
+        async def edit_message_text(self, text=None, reply_markup=None, parse_mode=None):
+            captured["text"] = text
+
+    class DummyUpdate:
+        def __init__(self, data):
+            self.callback_query = DummyQuery(data)
+        @property
+        def effective_user(self):
+            return types.SimpleNamespace(id=42)
+
+    class DummyContext:
+        def __init__(self):
+            self.user_data = {"files_cache": {"0": {"file_name": "a.py"}}}
+
+    # Step 1: open confirm dialog
+    u1 = DummyUpdate("del_0")
+    ctx = DummyContext()
+    await ch.handle_callback_query(u1, ctx)
+    assert captured["text"] is not None
+    assert "אישור העברה לסל" in captured["text"]
+
+    # Step 2: confirm and perform deletion (move to bin)
+    u2 = DummyUpdate("confirm_del_0")
+    await ch.handle_callback_query(u2, ctx)
+    assert captured["text"] is not None
+    assert "הועבר לסל המיחזור" in captured["text"]


### PR DESCRIPTION
<h3>What</h3> <ul> <li>הוספת כפתור “🗑️ סל מיחזור” לתפריט הראשי של “📚 הצג את כל הקבצים שלי”.</li> <li>עדכון כל ניסוחי המחיקה ל“העברה לסל” (קובץ יחיד, מחיקה מרובה, “לפי ריפו”) כולל הסבר על אפשרות שחזור ו‑TTL.</li> <li>פקודת מנהלים חדשה: <code>/recycle_backfill</code> – מבטיחה אינדקס TTL על <code>deleted_expires_at</code> בשתי הקולקציות, ומבצעת backfill לשדות <code>deleted_at</code> ו‑<code>deleted_expires_at</code> לכל <code>is_active=false</code> שחסר להם תוקף. ערך TTL נקבע מ‑ארגומנט X או מ‑<code>RECYCLE_TTL_DAYS</code> (ברירת מחדל 7).</li> <li>בדיקות יחידה ממוקדות להעלאת כיסוי ה‑Patch.</li> </ul> <h3>Why</h3> <ul> <li>יישור חוויית המשתמש למחיקה רכה אחידה בכל הזרימות + שקיפות לגבי שחזור/TTL.</li> <li>ניקוי אוטומטי עקבי של פריטים “בסל” באמצעות TTL; כלי backfill למנהלים עבור נתונים היסטוריים.</li> </ul> <h3>Impact</h3> <ul> <li>UI: שינוי טקסטים בלבד (מחיקה → העברה לסל) והוספת כפתור “סל מיחזור”.</li> <li>DB: יצירת אינדקס TTL על <code>deleted_expires_at</code> (אידמפוטנטי); backfill לערכים חסרים עבור <code>is_active=false</code>.</li> <li>אבטחה/הרשאות: <code>/recycle_backfill</code> מוגבלת ל‑Admins לפי <code>ADMIN_USER_IDS</code>.</li> </ul> <h3>Configuration</h3> <ul> <li><code>RECYCLE_TTL_DAYS</code> – ברירת מחדל 7 ימים.</li> <li><code>ADMIN_USER_IDS</code> – מזהי משתמשים מורשים לפקודת <code>/recycle_backfill</code>.</li> </ul> <h3>Tests</h3> <ul> <li><code>tests/test_recycle_backfill.py</code> – בדיקת אינדקס TTL, backfill והדו״ח; כיסוי למקרה ללא הרשאות.</li> <li><code>tests/test_recycle_button_in_files_menu.py</code> – כפתור “🗑️ סל מיחזור” בתפריט הקבצים.</li> <li><code>tests/test_bulk_move_to_trash_texts.py</code> – טקסטים בזרימת העברה מרובה לסל.</li> <li><code>tests/test_single_delete_to_trash_texts.py</code> – טקסטי “אישור העברה לסל” ו״הועבר לסל״ לקובץ יחיד.</li> <li><code>tests/test_by_repo_delete_to_trash_texts.py</code> – זרימת “לפי ריפו” (confirm/double confirm/do) עם ניסוחי העברה לסל.</li> </ul> <h3>Manual Test Plan</h3> <ul> <li>“📚” → ודא כפתור “🗑️ סל מיחזור” קיים ופועל (רשימה/שחזור/פירוק).</li> <li>מחיקת קובץ יחיד: כפתור 🗑️ → “אישור העברה לסל” → הודעת סיום “הועבר לסל המיחזור”.</li> <li>מחיקה מרובה: בחירה מרובה → שני שלבי אישור עם ניסוחי “העברה לסל” → סיכום עם ספירה.</li> <li>“לפי ריפו”: שלבי אישור מעודכנים + התקדמות; הודעת סיום “הועברו לסל …”.</li> <li><code>/recycle_backfill</code>: כ‑Admin בלבד. בדוק עם/בלי ארגומנט ימים. וודא דו״ח TTL וספירות.</li> </ul> <h3>Rollback</h3> <ul> <li>Revert לענף/קומיט. האינדקס TTL אידמפוטנטי.</li> <li>אם נדרש לבטל מחיקה עתידית של פריטים “בסל” שכבר קיבלו <code>deleted_expires_at</code>, ניתן להסיר את השדה ידנית (Bulk <code>$unset</code> עבור <code>is_active=false</code>), ואז להסיר את אינדקס ה‑TTL.</li> </ul> <h3>Docs</h3> <ul> <li>עיינתי ב‑<a href=\"https://amirbiron.github.io/CodeBot/\">CodeBot – Project Docs</a> והחידושים מתיישרים עם מדיניות המחיקה הרכה/TTL.</li> </ul> <h3>Checklist</h3> <ul> <li>[x] שינויי UI: טקסטים + כפתור “סל מיחזור”.</li> <li>[x] פקודת Admin <code>/recycle_backfill</code> עם הרשאות.</li> <li>[x] אינדקס TTL אידמפוטנטי בשתי הקולקציות.</li> <li>[x] בדיקות יחידה ממוקדות להעלאת כיסוי.</li> <li>[x] ללא שינויי התנהגות מסוכנים ב‑CI/קבצים.</li> </ul>