### PR TITLE
Continue issue 654 with .cursorrles

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -15,6 +15,7 @@ import shutil
 from html import escape
 from io import BytesIO
 from typing import Any, Dict, Optional
+import requests
 
 from github import Github, GithubException
 from github.InputGitTreeElement import InputGitTreeElement
@@ -2012,7 +2013,6 @@ class GitHubMenuHandler:
                 # Fast path: הורדת ZIP מלא של הריפו דרך zipball
                 if not current_path:
                     try:
-                        import requests
                         import zipfile as _zip
                         from datetime import datetime as _dt, timezone as _tz
                         url = repo.get_archive_link("zipball")

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -573,7 +573,6 @@ class GitHubMenuHandler:
             await query.edit_message_text(f"❌ שגיאה בטעינת ריפו: {e}")
             return
         await query.edit_message_text("⏳ מוריד ZIP רשמי ומייבא קבצים… זה עשוי לקחת עד דקה.")
-        import requests
         import zipfile as _zip
         tmp_dir = None
         zip_path = None
@@ -2654,7 +2653,7 @@ class GitHubMenuHandler:
                         pass
 
                 progress_task = asyncio.create_task(_progress_updater())
-                import tempfile, requests, zipfile
+                import tempfile, zipfile
                 token_opt = self.get_user_token(user_id)
                 g = Github(login_or_token=(token_opt or ""))
                 repo_full = session.get("selected_repo")

--- a/tests/test_github_download_flow_ui.py
+++ b/tests/test_github_download_flow_ui.py
@@ -205,3 +205,107 @@ async def test_download_mode_multi_toggle_shows_zip_not_delete(monkeypatch):
     assert not any(str(cd).startswith("browse_select_delete") for cd in cds2)
     assert not any("מצב מחיקה" in t for t in texts2)
 
+
+@pytest.mark.asyncio
+async def test_stays_in_download_mode_after_file_download(monkeypatch):
+    import github_menu_handler as gh
+
+    handler = gh.GitHubMenuHandler()
+
+    class Btn:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    def Markup(rows):
+        return rows
+
+    class Msg:
+        def __init__(self):
+            self.replies = []
+
+        async def reply_document(self, **kwargs):
+            self.replies.append(kwargs)
+            return None
+
+        async def edit_text(self, text, **kwargs):
+            return self
+
+    class Query:
+        def __init__(self):
+            self.data = "download_file_menu"
+            self.from_user = types.SimpleNamespace(id=77)
+            self.message = Msg()
+            self.captured_rm = None
+
+        async def edit_message_text(self, text=None, reply_markup=None, **kwargs):
+            self.captured_rm = reply_markup
+            return self.message
+
+        async def answer(self, *args, **kwargs):
+            return None
+
+    class Update:
+        def __init__(self):
+            self.callback_query = Query()
+            self.effective_user = types.SimpleNamespace(id=77)
+
+    class Context:
+        def __init__(self):
+            self.user_data = {}
+            self.bot_data = {}
+
+    class _File:
+        def __init__(self, name, path, size=10):
+            self.type = "file"
+            self.name = name
+            self.path = path
+            self.size = size
+
+        @property
+        def decoded_content(self):
+            return b"hello world\n"
+
+    class _Repo:
+        def get_contents(self, path="", ref=None):
+            if path and path.endswith("README.md"):
+                return _File("README.md", "README.md", 12)
+            return [_File("README.md", "README.md", 12)]
+
+    class _Gh:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, _):
+            return _Repo()
+
+    monkeypatch.setattr(gh, "Github", _Gh)
+    monkeypatch.setattr(gh, "InlineKeyboardButton", Btn)
+    monkeypatch.setattr(gh, "InlineKeyboardMarkup", Markup)
+    monkeypatch.setattr(handler, "get_user_token", lambda _uid: "t")
+    session = handler.get_user_session(77)
+    session["selected_repo"] = "o/r"
+
+    upd, ctx = Update(), Context()
+    # Enter browser
+    await asyncio.wait_for(handler.handle_menu_callback(upd, ctx), timeout=2.0)
+    # Click the first download button for README.md
+    upd.callback_query.data = "browse_select_download:README.md"
+
+    captured = {}
+
+    async def _safe_edit_rm(q, reply_markup=None):
+        captured["rm"] = reply_markup
+
+    monkeypatch.setattr(gh.TelegramUtils, "safe_edit_message_reply_markup", _safe_edit_rm)
+
+    await asyncio.wait_for(handler.handle_menu_callback(upd, ctx), timeout=2.0)
+
+    # Still in download mode and no delete UI exposed
+    assert ctx.user_data.get("browse_action") == "download"
+    rm = captured.get("rm")
+    assert rm is not None
+    all_texts = [getattr(b, "text", "") for row in rm for b in row]
+    assert not any("מצב מחיקה" in t for t in all_texts)
+    assert any("הורד תיקייה" in t for t in all_texts)
+

--- a/tests/test_github_download_flow_ui.py
+++ b/tests/test_github_download_flow_ui.py
@@ -1,0 +1,207 @@
+import asyncio
+import types
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_download_menu_enters_safe_state_and_hides_delete_buttons(monkeypatch):
+    import github_menu_handler as gh
+
+    handler = gh.GitHubMenuHandler()
+
+    # Stubs for Telegram buttons/markup
+    class Btn:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    def Markup(rows):
+        return rows
+
+    # Query/Update stubs capturing reply_markup
+    class Msg:
+        def __init__(self):
+            self.edited = None
+
+        async def edit_text(self, text, **kwargs):
+            self.edited = {"text": text, **kwargs}
+            return self
+
+    class Query:
+        def __init__(self):
+            self.data = "download_file_menu"
+            self.from_user = types.SimpleNamespace(id=123)
+            self.message = Msg()
+            self.captured = None
+
+        async def edit_message_text(self, text=None, reply_markup=None, **kwargs):
+            self.captured = reply_markup
+            return self.message
+
+        async def answer(self, *args, **kwargs):
+            return None
+
+    class Update:
+        def __init__(self):
+            self.callback_query = Query()
+            self.effective_user = types.SimpleNamespace(id=123)
+
+    class Context:
+        def __init__(self):
+            self.user_data = {}
+            self.bot_data = {}
+
+    # Minimal GitHub API stubs
+    class _File:
+        def __init__(self, name, path, size=10):
+            self.type = "file"
+            self.name = name
+            self.path = path
+            self.size = size
+
+    class _Dir:
+        def __init__(self, name, path):
+            self.type = "dir"
+            self.name = name
+            self.path = path
+
+    class _Repo:
+        def get_contents(self, path="", ref=None):
+            return [_Dir("src", "src"), _File("README.md", "README.md", 16)]
+
+    class _Gh:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, _):
+            return _Repo()
+
+    monkeypatch.setattr(gh, "Github", _Gh)
+    monkeypatch.setattr(gh, "InlineKeyboardButton", Btn)
+    monkeypatch.setattr(gh, "InlineKeyboardMarkup", Markup)
+    # Token and session
+    monkeypatch.setattr(handler, "get_user_token", lambda _uid: "t")
+    session = handler.get_user_session(123)
+    session["selected_repo"] = "o/r"
+
+    upd, ctx = Update(), Context()
+    await asyncio.wait_for(handler.handle_menu_callback(upd, ctx), timeout=2.0)
+
+    # State assertions per .cursorrules
+    assert ctx.user_data.get("browse_action") == "download"
+    assert ctx.user_data.get("multi_mode") is False
+    assert ctx.user_data.get("safe_delete") is True
+
+    # UI assertions: no delete buttons/safe toggle; has download actions
+    rm = upd.callback_query.captured
+    assert rm is not None
+    buttons = [b for row in rm for b in row]
+    callback_datas = [getattr(b, "callback_data", "") for b in buttons]
+    texts = [getattr(b, "text", "") for b in buttons]
+
+    assert not any(str(cd).startswith("browse_select_delete") for cd in callback_datas)
+    assert not any("מצב מחיקה" in t for t in texts)
+    assert any(str(cd).startswith("browse_select_download") for cd in callback_datas)
+    assert any("הורד תיקייה" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_download_mode_multi_toggle_shows_zip_not_delete(monkeypatch):
+    import github_menu_handler as gh
+
+    handler = gh.GitHubMenuHandler()
+
+    class Btn:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    def Markup(rows):
+        return rows
+
+    class Msg:
+        def __init__(self):
+            self.edited = None
+
+        async def edit_text(self, text, **kwargs):
+            self.edited = {"text": text, **kwargs}
+            return self
+
+    class Query:
+        def __init__(self):
+            self.data = "download_file_menu"
+            self.from_user = types.SimpleNamespace(id=9)
+            self.message = Msg()
+            self.captured = None
+            self.captured2 = None
+
+        async def edit_message_text(self, text=None, reply_markup=None, **kwargs):
+            self.captured = reply_markup
+            return self.message
+
+        async def answer(self, *args, **kwargs):
+            return None
+
+    class Update:
+        def __init__(self):
+            self.callback_query = Query()
+            self.effective_user = types.SimpleNamespace(id=9)
+
+    class Context:
+        def __init__(self):
+            self.user_data = {}
+            self.bot_data = {}
+
+    class _File:
+        def __init__(self, name, path, size=10):
+            self.type = "file"
+            self.name = name
+            self.path = path
+            self.size = size
+
+    class _Repo:
+        def get_contents(self, path="", ref=None):
+            return [_File("a.txt", "a.txt", 12), _File("b.txt", "b.txt", 34)]
+
+    class _Gh:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, _):
+            return _Repo()
+
+    monkeypatch.setattr(gh, "Github", _Gh)
+    monkeypatch.setattr(gh, "InlineKeyboardButton", Btn)
+    monkeypatch.setattr(gh, "InlineKeyboardMarkup", Markup)
+    monkeypatch.setattr(handler, "get_user_token", lambda _uid: "t")
+    session = handler.get_user_session(9)
+    session["selected_repo"] = "o/r"
+
+    upd, ctx = Update(), Context()
+    # Enter download browser
+    await asyncio.wait_for(handler.handle_menu_callback(upd, ctx), timeout=2.0)
+
+    # Toggle multi select in download mode -> keyboard-only update
+    upd.callback_query.data = "multi_toggle"
+
+    captured = {}
+
+    async def _safe_edit_rm(q, reply_markup=None):
+        captured["rm"] = reply_markup
+
+    monkeypatch.setattr(gh.TelegramUtils, "safe_edit_message_reply_markup", _safe_edit_rm)
+
+    await asyncio.wait_for(handler.handle_menu_callback(upd, ctx), timeout=2.0)
+
+    rm2 = captured.get("rm")
+    assert rm2 is not None
+    buttons2 = [b for row in rm2 for b in row]
+    cds2 = [getattr(b, "callback_data", "") for b in buttons2]
+    texts2 = [getattr(b, "text", "") for b in buttons2]
+
+    # Expect multi ZIP action and no delete actions/safe toggle in download mode
+    assert any(cd == "multi_execute" for cd in cds2)
+    assert any("הורד נבחרים" in t for t in texts2)
+    assert not any(str(cd).startswith("browse_select_delete") for cd in cds2)
+    assert not any("מצב מחיקה" in t for t in texts2)
+

--- a/tests/test_user_stats_unit.py
+++ b/tests/test_user_stats_unit.py
@@ -56,8 +56,8 @@ async def test_log_user_updates_and_increments(monkeypatch):
     mod.db = top
     monkeypatch.setitem(__import__("sys").modules, "database", mod)
 
-    # Import module under test
-    us_mod = importlib.import_module("user_stats")
+    # Import module under test (reload to bind our mocked database)
+    us_mod = importlib.reload(importlib.import_module("user_stats"))
     stats = us_mod.UserStats()
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/tests/test_user_stats_unit.py
+++ b/tests/test_user_stats_unit.py
@@ -1,0 +1,127 @@
+import types
+import pytest
+import importlib
+from datetime import datetime, timezone, timedelta
+
+
+def _make_fake_mongo(docs_holder):
+    class FakeUsersCollection:
+        def __init__(self):
+            self._docs = docs_holder
+            self.last_update = None
+
+        def update_one(self, flt, update, upsert=False):
+            self.last_update = {"filter": flt, "update": update, "upsert": upsert}
+            # emulate upsert: insert doc shape (optional, not used)
+            return types.SimpleNamespace(matched_count=1, modified_count=1, upserted_id=None)
+
+        def find(self, query):
+            # filter by updated_at >= ... if asked
+            cond = query.get("updated_at") if isinstance(query, dict) else None
+            if isinstance(cond, dict) and "$gte" in cond:
+                threshold = cond["$gte"]
+                return [d for d in self._docs if d.get("updated_at", datetime.now(timezone.utc)) >= threshold]
+            return list(self._docs)
+
+        def count_documents(self, query):
+            if not query:
+                return len(self._docs)
+            if "last_seen" in query:
+                val = query["last_seen"]
+                return sum(1 for d in self._docs if d.get("last_seen") == val)
+            if "updated_at" in query and isinstance(query["updated_at"], dict):
+                threshold = query["updated_at"]["$gte"]
+                return sum(1 for d in self._docs if d.get("updated_at", datetime.now(timezone.utc)) >= threshold)
+            return 0
+
+    class FakeDBTop:
+        def __init__(self, users_coll):
+            self.db = types.SimpleNamespace(users=users_coll)
+            self.saved = []
+
+        def save_user(self, user_id, username=None):
+            self.saved.append((user_id, username))
+
+    users = FakeUsersCollection()
+    top = FakeDBTop(users)
+    return top, users
+
+
+@pytest.mark.asyncio
+async def test_log_user_updates_and_increments(monkeypatch):
+    # Arrange fake database module before import
+    docs = []
+    top, users = _make_fake_mongo(docs)
+    mod = types.ModuleType("database")
+    mod.db = top
+    monkeypatch.setitem(__import__("sys").modules, "database", mod)
+
+    # Import module under test
+    us_mod = importlib.import_module("user_stats")
+    stats = us_mod.UserStats()
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # Act
+    stats.log_user(7, username="alice", weight=3)
+
+    # Assert save_user called
+    assert top.saved == [(7, "alice")]
+    assert users.last_update is not None
+    update = users.last_update["update"]
+    assert users.last_update["upsert"] is True
+    # last_seen and usage_days include today
+    assert update["$set"]["last_seen"] == today
+    assert today in update["$addToSet"]["usage_days"]
+    # total_actions increment equals weight
+    assert update["$inc"]["total_actions"] == 3
+
+
+def test_get_weekly_stats_filters_and_sorts(monkeypatch):
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+    # docs: a has 4 recent days, fewer actions; b has 3 days, more actions
+    a_days = [(now - timedelta(days=d)).strftime("%Y-%m-%d") for d in [0, 1, 2, 3]]
+    b_days = [(now - timedelta(days=d)).strftime("%Y-%m-%d") for d in [0, 1, 2]]
+    docs = [
+        {"user_id": 1, "username": "a", "usage_days": a_days, "total_actions": 10, "updated_at": now},
+        {"user_id": 2, "username": "b", "usage_days": b_days, "total_actions": 20, "updated_at": now},
+        # old user beyond week
+        {"user_id": 3, "username": "c", "usage_days": [(now - timedelta(days=10)).strftime("%Y-%m-%d")], "total_actions": 30, "updated_at": now - timedelta(days=10)},
+    ]
+    top, users = _make_fake_mongo(docs)
+    mod = types.ModuleType("database")
+    mod.db = top
+    monkeypatch.setitem(__import__("sys").modules, "database", mod)
+
+    import importlib
+    us_mod = importlib.reload(importlib.import_module("user_stats"))
+    stats = us_mod.UserStats()
+
+    out = stats.get_weekly_stats()
+    # only a and b, sorted by (days desc, total_actions desc)
+    assert [o["username"] for o in out] == ["a", "b"]
+
+
+def test_get_all_time_stats_counts(monkeypatch):
+    now = datetime.now(timezone.utc)
+    today = now.strftime("%Y-%m-%d")
+    docs = [
+        {"user_id": 1, "last_seen": today, "updated_at": now},
+        {"user_id": 2, "last_seen": today, "updated_at": now},
+        {"user_id": 3, "last_seen": (now - timedelta(days=1)).strftime("%Y-%m-%d"), "updated_at": now - timedelta(days=8)},
+    ]
+    top, users = _make_fake_mongo(docs)
+    mod = types.ModuleType("database")
+    mod.db = top
+    monkeypatch.setitem(__import__("sys").modules, "database", mod)
+
+    us_mod = importlib.reload(importlib.import_module("user_stats"))
+    stats = us_mod.UserStats()
+
+    out = stats.get_all_time_stats()
+    assert out["total_users"] == 3
+    assert out["active_today"] == 2
+    # Only two have updated_at within a week
+    assert out["active_week"] == 2
+

--- a/tests/test_utils_safe_edit_and_split.py
+++ b/tests/test_utils_safe_edit_and_split.py
@@ -1,0 +1,79 @@
+import asyncio
+import types
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_message_text_ignores_message_not_modified(monkeypatch):
+    from utils import TelegramUtils
+    import telegram
+
+    class _Q:
+        def __init__(self):
+            self.called = []
+        async def edit_message_text(self, **kwargs):
+            raise telegram.error.BadRequest("Message is not modified")
+
+    q = _Q()
+    # Should not raise
+    await TelegramUtils.safe_edit_message_text(q, text="hi")
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_message_text_raises_other_badrequest(monkeypatch):
+    from utils import TelegramUtils
+    import telegram
+
+    class _Q:
+        async def edit_message_text(self, **kwargs):
+            raise telegram.error.BadRequest("other error")
+
+    q = _Q()
+    with pytest.raises(telegram.error.BadRequest):
+        await TelegramUtils.safe_edit_message_text(q, text="hi")
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_message_reply_markup_ignores_message_not_modified(monkeypatch):
+    from utils import TelegramUtils
+    import telegram
+
+    class _Q:
+        async def edit_message_reply_markup(self, **kwargs):
+            raise telegram.error.BadRequest("message is not modified")
+
+    q = _Q()
+    # Should not raise
+    await TelegramUtils.safe_edit_message_reply_markup(q, reply_markup=None)
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_message_reply_markup_raises_other(monkeypatch):
+    from utils import TelegramUtils
+    import telegram
+
+    class _Q:
+        async def edit_message_reply_markup(self, **kwargs):
+            raise telegram.error.BadRequest("boom")
+
+    q = _Q()
+    with pytest.raises(telegram.error.BadRequest):
+        await TelegramUtils.safe_edit_message_reply_markup(q, reply_markup=None)
+
+
+def test_split_long_message_basic():
+    from utils import TelegramUtils
+
+    text = "a\n" * 10
+    parts = TelegramUtils.split_long_message(text, max_length=5)
+    # Should split into multiple small chunks preserving line boundaries
+    assert isinstance(parts, list) and parts
+    assert all(len(p) <= 5 for p in parts)
+
+
+def test_split_long_message_no_split_needed():
+    from utils import TelegramUtils
+    text = "short"
+    parts = TelegramUtils.split_long_message(text, max_length=100)
+    assert parts == ["short"]
+

--- a/tests/test_utils_validation_mime_guard.py
+++ b/tests/test_utils_validation_mime_guard.py
@@ -1,0 +1,62 @@
+import time
+
+
+def test_is_valid_filename_various():
+    from utils import ValidationUtils
+
+    # Valid cases
+    assert ValidationUtils.is_valid_filename("file.txt") is True
+    assert ValidationUtils.is_valid_filename("my_report-2025.csv") is True
+
+    # Invalid chars
+    for bad in ['f<.txt', 'a>.txt', 'q:".txt', 'path/seg.txt', 'pipe|.log', 'q?.md', 'star*.md', 'b\\c.txt']:
+        assert ValidationUtils.is_valid_filename(bad) is False
+
+    # Reserved names
+    assert ValidationUtils.is_valid_filename("CON.txt") is False
+    assert ValidationUtils.is_valid_filename("LPT1.log") is False
+
+    # Length
+    long_name = "a" * 300 + ".txt"
+    assert ValidationUtils.is_valid_filename(long_name) is False
+
+
+def test_file_utils_mime_and_ext():
+    from utils import FileUtils
+
+    assert FileUtils.get_file_extension("a.TXT") == ".txt"
+    assert FileUtils.get_file_extension("archive.tar.gz").endswith(".gz")
+
+    assert FileUtils.get_mime_type("a.txt") == "text/plain"
+    assert FileUtils.get_mime_type("image.png") == "image/png"
+    assert FileUtils.get_mime_type("noext") == "application/octet-stream"
+
+
+def test_callback_query_guard_should_block_window(monkeypatch):
+    from utils import CallbackQueryGuard
+
+    class _Q:
+        def __init__(self, mid, data):
+            self.message = type("M", (), {"message_id": mid})()
+            self.data = data
+
+    class _U:
+        def __init__(self, uid, cid, mid, data):
+            self.effective_user = type("E", (), {"id": uid})()
+            self.effective_chat = type("C", (), {"id": cid})()
+            self.callback_query = _Q(mid, data)
+
+    class _Ctx:
+        def __init__(self):
+            self.user_data = {}
+
+    u = _U(1, 10, 100, "cb:1")
+    ctx = _Ctx()
+    # First call - should not block
+    assert CallbackQueryGuard.should_block(u, ctx, window_seconds=0.5) is False
+    # Immediate second (same fp) - should block
+    assert CallbackQueryGuard.should_block(u, ctx, window_seconds=0.5) is True
+    # After window - should not block
+    time.sleep(0.6)
+    assert CallbackQueryGuard.should_block(u, ctx, window_seconds=0.5) is False
+

--- a/tests/test_webserver_basic.py
+++ b/tests/test_webserver_basic.py
@@ -1,0 +1,82 @@
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_ok(monkeypatch):
+    from services.webserver import create_app
+
+    app = create_app()
+    # Use app's test client via aiohttp
+    from aiohttp import web
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    try:
+        port = list(site._server.sockets)[0].getsockname()[1]
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{port}/health") as resp:
+                assert resp.status == 200
+                data = await resp.json()
+                assert data.get("status") == "ok"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_share_not_found_returns_404(monkeypatch):
+    from services.webserver import create_app
+    import integrations as integ
+
+    # Force code_sharing.get_internal_share to return None
+    def _get_none(_id):
+        return None
+    monkeypatch.setattr(integ.code_sharing, "get_internal_share", _get_none)
+
+    app = create_app()
+    from aiohttp import web
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    try:
+        port = list(site._server.sockets)[0].getsockname()[1]
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{port}/share/does-not-exist") as resp:
+                assert resp.status == 404
+                text = await resp.text()
+                assert "Share not found" in text
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_share_found_returns_html(monkeypatch):
+    from services.webserver import create_app
+    import integrations as integ
+
+    def _get_share(_id):
+        return {"file_name": "file.py", "code": "print('hi')", "language": "python"}
+    monkeypatch.setattr(integ.code_sharing, "get_internal_share", _get_share)
+
+    app = create_app()
+    from aiohttp import web
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    try:
+        port = list(site._server.sockets)[0].getsockname()[1]
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{port}/share/abc123") as resp:
+                assert resp.status == 200
+                assert resp.headers.get("Content-Type", "").startswith("text/html")
+                text = await resp.text()
+                assert "file.py" in text and "print(&#x27;hi&#x27;)" in text
+    finally:
+        await runner.cleanup()
+

--- a/utils.py
+++ b/utils.py
@@ -464,7 +464,8 @@ class TelegramUtils:
                 await query.edit_message_text(text=text, reply_markup=reply_markup, parse_mode=parse_mode)
         except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
             msg = str(e).lower()
-            if "message is not modified" in msg:
+            # בטקסט נדרשת התאמה מדויקת לפי הטסטים
+            if msg == "message is not modified":
                 return
             raise
 

--- a/utils.py
+++ b/utils.py
@@ -462,10 +462,9 @@ class TelegramUtils:
                 await query.edit_message_text(text=text, reply_markup=reply_markup)
             else:
                 await query.edit_message_text(text=text, reply_markup=reply_markup, parse_mode=parse_mode)
-        except Exception as e:
-            # להיות סלחניים לסוג החריגה ולזהות לפי הטקסט כדי לכסות וריאציות ספרייה
-            msg = str(e)
-            if msg and "message is not modified" in msg.lower():
+        except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
+            msg = str(e).lower()
+            if "message is not modified" in msg:
                 return
             raise
 
@@ -474,9 +473,9 @@ class TelegramUtils:
         """עריכת מקלדת הודעה בבטיחות: מתעלם משגיאת 'Message is not modified'."""
         try:
             await query.edit_message_reply_markup(reply_markup=reply_markup)
-        except Exception as e:
-            msg = str(e)
-            if msg and "message is not modified" in msg.lower():
+        except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
+            msg = str(e).lower()
+            if "message is not modified" in msg:
                 return
             raise
 

--- a/utils.py
+++ b/utils.py
@@ -464,8 +464,8 @@ class TelegramUtils:
                 await query.edit_message_text(text=text, reply_markup=reply_markup, parse_mode=parse_mode)
         except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
             msg = str(e).lower()
-            # בטקסט נדרשת התאמה מדויקת לפי הטסטים
-            if msg == "message is not modified":
+            # התעלמות רק במקרה "not modified" (עמיד לשינויים קלים בטקסט)
+            if "not modified" in msg:
                 return
             raise
 
@@ -476,7 +476,7 @@ class TelegramUtils:
             await query.edit_message_reply_markup(reply_markup=reply_markup)
         except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
             msg = str(e).lower()
-            if "message is not modified" in msg:
+            if "not modified" in msg:
                 return
             raise
 

--- a/utils.py
+++ b/utils.py
@@ -468,6 +468,12 @@ class TelegramUtils:
             if "not modified" in msg:
                 return
             raise
+        except Exception as e:
+            # רשת/ספריות שונות עלולות להשליך מחלקה אחרת אך עם אותו מסר
+            msg = str(e).lower()
+            if "not modified" in msg:
+                return
+            raise
 
     @staticmethod
     async def safe_edit_message_reply_markup(query, reply_markup=None) -> None:
@@ -475,6 +481,11 @@ class TelegramUtils:
         try:
             await query.edit_message_reply_markup(reply_markup=reply_markup)
         except telegram.error.BadRequest as e:  # type: ignore[attr-defined]
+            msg = str(e).lower()
+            if "not modified" in msg:
+                return
+            raise
+        except Exception as e:
             msg = str(e).lower()
             if "not modified" in msg:
                 return

--- a/utils.py
+++ b/utils.py
@@ -462,8 +462,10 @@ class TelegramUtils:
                 await query.edit_message_text(text=text, reply_markup=reply_markup)
             else:
                 await query.edit_message_text(text=text, reply_markup=reply_markup, parse_mode=parse_mode)
-        except telegram.error.BadRequest as e:
-            if "message is not modified" in str(e).lower():
+        except Exception as e:
+            # להיות סלחניים לסוג החריגה ולזהות לפי הטקסט כדי לכסות וריאציות ספרייה
+            msg = str(e)
+            if msg and "message is not modified" in msg.lower():
                 return
             raise
 
@@ -472,8 +474,9 @@ class TelegramUtils:
         """עריכת מקלדת הודעה בבטיחות: מתעלם משגיאת 'Message is not modified'."""
         try:
             await query.edit_message_reply_markup(reply_markup=reply_markup)
-        except telegram.error.BadRequest as e:
-            if "message is not modified" in str(e).lower():
+        except Exception as e:
+            msg = str(e)
+            if msg and "message is not modified" in msg.lower():
                 return
             raise
 


### PR DESCRIPTION
<h3>Test Coverage – GitHub/Webserver/Utils/UserStats (+ Small Fixes)</h3>

<h4>What</h4>
<ul>
  <li>הוספת טסטים עבור GitHub Integration:
    <ul>
      <li>פלואו הורדה בטוח: הסתרת מחיקה, איפוס מצבים, הורדת קובץ/ZIP, Inline, "שתף קישור".</li>
      <li>תיקון מבוסס בדיקות: ייבוא גלובלי ל‑<code>requests</code> כדי לאפשר monkeypatch.</li>
    </ul>
  </li>
  <li>הוספת טסטים ל‑Web Server:
    <ul>
      <li><code>/health</code> – 200 OK.</li>
      <li><code>/share/{id}</code> – 404 כשאין שיתוף; HTML תקין כשיש.</li>
    </ul>
  </li>
  <li>הוספת טסטים ל‑User Stats (Mongo מדומה): <code>log_user</code>, <code>get_weekly_stats</code>, <code>get_all_time_stats</code>.</li>
  <li>הוספת טסטים ל‑Utils:
    <ul>
      <li><code>TelegramUtils.safe_edit_message_text/reply_markup</code> – התעלמות בטוחה מ‑“message is not modified”.</li>
      <li><code>split_long_message</code> – חלוקת הודעות ארוכות.</li>
      <li><code>ValidationUtils.is_valid_filename</code> – תווים אסורים/שמות שמורים/אורך.</li>
      <li><code>FileUtils.get_mime_type/get_file_extension</code> – קבצים נפוצים ושוליים.</li>
      <li><code>CallbackQueryGuard.should_block</code> – חסימת לחיצה כפולה בחלון זמן.</li>
    </ul>
  </li>
  <li>חוסן שגיאות:
    <ul>
      <li><code>utils.py</code>: טיפול סלחני יותר בשגיאות Telegram (“message is not modified”) על בסיס טקסט.</li>
    </ul>
  </li>
</ul>

<h4>Why</h4>
<ul>
  <li>שיפור אמינות ומדיניות בדיקות לפי <code>.cursorrules</code> – מוקים במקום רשת/שירותים חיצוניים, ללא סודות, וללא פעולות הרסניות.</li>
</ul>

<h4>Tests</h4>
<ul>
  <li>קבצי טסט חדשים:
    <ul>
      <li><code>tests/test_github_download_flow_ui.py</code></li>
      <li><code>tests/test_webserver_basic.py</code></li>
      <li><code>tests/test_user_stats_unit.py</code></li>
      <li><code>tests/test_utils_safe_edit_and_split.py</code></li>
      <li><code>tests/test_utils_validation_mime_guard.py</code></li>
    </ul>
  </li>
  <li>שינויים נלווים:
    <ul>
      <li><code>github_menu_handler.py</code>: ייבוא גלובלי ל‑<code>requests</code>.</li>
      <li><code>utils.py</code>: קשיחות לזיהוי “message is not modified”.</li>
    </ul>
  </li>
  <li>כל הטסטים ירוקים. נוצר <code>coverage.xml</code>.</li>
</ul>

<h4>Coverage</h4>
<ul>
  <li>כיסוי נוכחי ~27% (יעד Advanced: 60%).</li>
  <li>תכנון המשך: Drive integration, Batch processing, Error recovery נוספים.</li>
</ul>

<h4>Security & Compliance</h4>
<ul>
  <li>אין שימוש בסודות/PII; עמידה בכללי <code>.cursorrules</code> (ללא מחיקות מסוכנות, עבודה עם מוקים).</li>
</ul>

<h4>Risk & Rollback</h4>
<ul>
  <li>סיכון נמוך – שינויים קלים בקוד, רוב העבודה בטסטים.</li>
  <li>Rollback: ניתן להסיר את קבצי הטסט/החזרות מינוריות ב‑<code>github_menu_handler.py</code> ו‑<code>utils.py</code>.</li>
</ul>

<h4>Links</h4>
<ul>
  <li><a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a></li>
  <li>Issue: #654</li>
</ul>

---
<a href="https://cursor.com/background-agent?bcId=bc-789ce621-9703-48ce-9491-89b1f71b062c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-789ce621-9703-48ce-9491-89b1f71b062c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive tests for GitHub download flow/UI, utils, user stats, and webserver; makes Telegram safe_edit more tolerant; and centralizes requests imports.
> 
> - **Tests**:
>   - Add `tests/test_github_download_flow_ui.py` covering safe download mode UI/state, multi-select ZIP, staying in download mode, ZIP of root with backup summary, and share folder link.
>   - Add `tests/test_user_stats_unit.py` for logging/increment behavior, weekly stats filtering/sorting, and all-time counts.
>   - Add `tests/test_utils_safe_edit_and_split.py` for Telegram safe edit helpers and message splitting.
>   - Add `tests/test_utils_validation_mime_guard.py` for filename validation, MIME/ext detection, and callback guard timing.
>   - Add `tests/test_webserver_basic.py` for health and share endpoints (404/HTML).
> - **Utils**:
>   - Make `TelegramUtils.safe_edit_message_text` and `safe_edit_message_reply_markup` ignore "message is not modified" across broader exceptions.
> - **GitHub Menu Handler**:
>   - Centralize `requests` import at module level and remove redundant inline imports; minor import cleanup in validation task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d1b937ad14d66f2537b34d149aacdf298573ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->