### PR TITLE
Refactor: Use TextUtils.escape_markdown for notes

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -22,7 +22,7 @@ from utils import get_language_emoji as get_file_emoji
 from user_stats import user_stats
 from typing import List, Optional
 from html import escape as html_escape
-from utils import TelegramUtils
+from utils import TelegramUtils, TextUtils
 from services import code_service
 from i18n.strings_he import MAIN_MENU as MAIN_KEYBOARD
 from handlers.pagination import build_pagination_row
@@ -969,7 +969,7 @@ async def handle_file_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         
         # הוסף הצגת הערה אם קיימת
         note = file_data.get('description') or ''
-        note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
+        note_line = f"\n📝 הערה: {TextUtils.escape_markdown(note, version=1)}\n\n" if note else "\n📝 הערה: —\n\n"
         await TelegramUtils.safe_edit_message_text(
             query,
             f"🎯 *מרכז בקרה מתקדם*\n\n"
@@ -1303,7 +1303,7 @@ async def handle_edit_note(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await query.edit_message_text(
             f"📝 *עריכת הערה לקובץ*\n\n"
             f"📄 **שם:** `{file_name}`\n"
-            f"🔎 **הערה נוכחית:** {html_escape(current_note)}\n\n"
+            f"🔎 **הערה נוכחית:** {TextUtils.escape_markdown(current_note, version=1)}\n\n"
             f"✏️ שלח/י הערה חדשה (או 'מחק' כדי להסיר)",
             reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("🔙 חזרה", callback_data=f"file_{file_index}")]]),
             parse_mode='Markdown'

--- a/handlers/file_view.py
+++ b/handlers/file_view.py
@@ -103,7 +103,7 @@ async def handle_file_menu(update, context: ContextTypes.DEFAULT_TYPE) -> int:
         keyboard.append([InlineKeyboardButton("🔙 חזרה לרשימה", callback_data=back_cb)])
         reply_markup = InlineKeyboardMarkup(keyboard)
         note = file_data.get('description') or ''
-        note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
+        note_line = f"\n📝 הערה: {TextUtils.escape_markdown(note, version=1)}\n\n" if note else "\n📝 הערה: —\n\n"
         await TelegramUtils.safe_edit_message_text(
             query,
             f"🎯 *מרכז בקרה מתקדם*\n\n"
@@ -824,14 +824,15 @@ async def handle_view_direct_file(update, context: ContextTypes.DEFAULT_TYPE) ->
             keyboard.insert(-1, [InlineKeyboardButton(show_more_label, callback_data=f"fv_more:direct:{file_name}:{max_length}")])
         reply_markup = InlineKeyboardMarkup(keyboard)
         note = file_data.get('description') or ''
-        note_line = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
+        note_line_html = f"\n📝 הערה: {html_escape(note)}\n\n" if note else "\n📝 הערה: —\n\n"
         large_note_md = "\nזה קובץ גדול\n\n" if is_large_file else ""
         large_note_html = "\n<i>זה קובץ גדול</i>\n\n" if is_large_file else ""
+        note_line_md = f"\n📝 הערה: {TextUtils.escape_markdown(note, version=1)}\n\n" if note else "\n📝 הערה: —\n\n"
         # Markdown מוצג ב-HTML רק עבור קבצי Markdown; לשאר נשתמש ב-Markdown עם בלוק קוד
         if (language or '').lower() == 'markdown':
             safe_code = html_escape(code_preview)
             header_html = (
-                f"📄 <b>{html_escape(file_name)}</b> ({html_escape(language)}) - גרסה {version}{note_line}"
+                f"📄 <b>{html_escape(file_name)}</b> ({html_escape(language)}) - גרסה {version}{note_line_html}"
             )
             await TelegramUtils.safe_edit_message_text(
                 query,
@@ -848,7 +849,7 @@ async def handle_view_direct_file(update, context: ContextTypes.DEFAULT_TYPE) ->
             safe_code_md = str(code_preview).replace('```', '\\`\\`\\`')
             await TelegramUtils.safe_edit_message_text(
                 query,
-                f"📄 *{safe_file_name}* ({language}) - גרסה {version}{note_line}{large_note_md}"
+                f"📄 *{safe_file_name}* ({language}) - גרסה {version}{note_line_md}{large_note_md}"
                 f"```{language}\n{safe_code_md}\n```",
                 reply_markup=reply_markup,
                 parse_mode='Markdown',


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון אופן הטיפול בתווים מיוחדים בהודעות טלגרם עם `parse_mode='Markdown'`. השינוי מונע בליעה או הדגשה שגויה של מחרוזות כמו `__main__` על ידי שימוש ב-`TextUtils.escape_markdown` במקום `html_escape` לא מתאים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- ב-`conversation_handlers.py`: ייבוא `TextUtils` והחלפת `html_escape` ב-`TextUtils.escape_markdown(..., version=1)` עבור הודעות Markdown.
- ב-`handlers/file_view.py`:
    - עדכון `note_line` לשימוש ב-`TextUtils.escape_markdown(..., version=1)` בהודעות Markdown.
    - יצירת `note_line_md` ו-`note_line_html` עבור תצוגה ישירה של קבצים, כדי להבטיח שימוש נכון ב-escape בהתאם ל-parse_mode.

## 🧪 בדיקות
- נבדק ידנית בבוט על ידי שליחת טקסטים המכילים תווים מיוחדים כמו `__main__` ו-`*stars*` בהודעות עם `parse_mode='Markdown'`. הטקסטים הוצגו כטקסט רגיל ולא נבלעו/הודגשו.
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית: טקסטים המכילים תווים מיוחדים ב-Markdown יוצגו כהלכה ולא יפורשו בטעות על ידי טלגרם.
- סיכון נמוך: השינוי מתקן התנהגות שגויה קיימת.

## 🔗 קישורים
- Issues קשורים: https://github.com/amirbiron/CodeBot/pull/672#issue-3493691265
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה של תקלה, ניתן לבצע Rollback ל-PR זה.