### PR TITLE
Refactor: Preserve markdown in message text extraction

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # Ensure safe environment defaults for docs builds (RTD / local)
 os.environ.setdefault('DISABLE_DB', 'true')
 os.environ.setdefault('SPHINX_MOCK_IMPORTS', 'true')
+os.environ.setdefault('SPHINX_FAIL_ON_WARNING', 'true')
 os.environ.setdefault('BOT_TOKEN', 'dummy_bot_token_for_docs')
 os.environ.setdefault('MONGODB_URL', 'mongodb://localhost:27017/test')
 
@@ -67,7 +68,7 @@ autodoc_mock_imports = [
     'fuzzywuzzy', 'python_levenshtein', 'Levenshtein',
     'redis', 'aioredis', 'celery', 'psutil', 'sentry_sdk',
     # Web frameworks and servers (not needed for docs)
-    'flask', 'uvicorn', 'gunicorn', 'telegram', 'telegram.ext',
+    'flask', 'uvicorn', 'gunicorn', 'telegram', 'telegram.ext', 'telegram.constants', 'telegram.error',
     # Google APIs
     'google', 'googleapiclient', 'googleapiclient.discovery', 'google.oauth2',
     # GitHub API

--- a/handlers/file_view.py
+++ b/handlers/file_view.py
@@ -285,7 +285,11 @@ async def receive_new_code(update, context: ContextTypes.DEFAULT_TYPE) -> int:
             await update.message.reply_text("❌ שגיאה בעדכון ההערה")
         return ConversationHandler.END
 
-    new_code = update.message.text
+    # שחזור טקסט עם סימוני Markdown שנבלעו ע"י לקוח טלגרם
+    try:
+        new_code = TelegramUtils.extract_message_text_preserve_markdown(update.message)
+    except Exception:
+        new_code = update.message.text
     editing_large_file = context.user_data.get('editing_large_file')
     if editing_large_file:
         try:

--- a/handlers/save_flow.py
+++ b/handlers/save_flow.py
@@ -7,6 +7,7 @@ from telegram.ext import ContextTypes, ConversationHandler
 from handlers.states import GET_CODE, GET_FILENAME, GET_NOTE, WAIT_ADD_CODE_MODE, LONG_COLLECT
 from services import code_service
 from utils import TextUtils
+from utils import TelegramUtils
 from utils import normalize_code  # נרמול קלט כדי להסיר תווים נסתרים מוקדם
 
 logger = logging.getLogger(__name__)
@@ -188,7 +189,11 @@ async def long_collect_receive(update, context: ContextTypes.DEFAULT_TYPE) -> in
             await update.message.reply_text("📎 קיבלתי קובץ שאינו טקסט. שלח/י מסמך טקסט או הדבק/י את הקוד כהודעת טקסט.")
             return LONG_COLLECT
     elif update.message.text:
-        text = update.message.text or ''
+        # שחזור טקסט עם סימוני Markdown שנבלעו (למשל __main__)
+        try:
+            text = TelegramUtils.extract_message_text_preserve_markdown(update.message) or ''
+        except Exception:
+            text = update.message.text or ''
     else:
         await update.message.reply_text("🖼️ התקבלה הודעה שאינה טקסט. שלח/י קוד כהודעת טקסט או קובץ טקסט.")
         return LONG_COLLECT
@@ -272,7 +277,11 @@ async def long_collect_done(update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 
 async def get_code(update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    code = update.message.text
+    # שחזור טקסט עם סימוני Markdown שנבלעו
+    try:
+        code = TelegramUtils.extract_message_text_preserve_markdown(update.message)
+    except Exception:
+        code = update.message.text
     # נרמול מוקדם כדי למנוע תווים נסתרים כבר בשלב האיסוף
     try:
         code = normalize_code(code)

--- a/tests/test_handlers_receive_new_code_preserve.py
+++ b/tests/test_handlers_receive_new_code_preserve.py
@@ -1,0 +1,52 @@
+import types
+import sys
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_receive_new_code_uses_preserve(monkeypatch):
+    # Stub TelegramUtils.extract_message_text_preserve_markdown to observe usage
+    import handlers.file_view as fv
+
+    captured = {}
+
+    def fake_extract(msg):
+        captured['called'] = True
+        # חיקוי הודעת משתמש עם __main__
+        return "print('__main__')\n"
+
+    monkeypatch.setattr(fv.TelegramUtils, 'extract_message_text_preserve_markdown', fake_extract)
+
+    # Stub database
+    class _DB:
+        @staticmethod
+        def save_large_file(*a, **k):
+            return False
+        @staticmethod
+        def save_file(user_id, file_name, content, detected_language):
+            return True
+        @staticmethod
+        def get_latest_version(user_id, file_name):
+            return {'version': 1}
+
+    db_mod = types.ModuleType('database')
+    db_mod.db = _DB()
+    monkeypatch.setitem(sys.modules, 'database', db_mod)
+
+    # prepare context and update
+    ctx = types.SimpleNamespace(user_data={
+        'editing_file_data': {'file_name': 't.py', 'code': '', 'programming_language': 'python'},
+        'editing_file_index': '1',
+    })
+
+    class Q:
+        def __init__(self):
+            self.captured = None
+        async def reply_text(self, *a, **k):
+            self.captured = a[0] if a else None
+
+    upd = types.SimpleNamespace(message=types.SimpleNamespace(text="main", reply_text=Q().reply_text), effective_user=types.SimpleNamespace(id=1))
+
+    await fv.receive_new_code(upd, ctx)
+
+    assert captured.get('called') is True

--- a/tests/test_handlers_receive_new_code_preserve.py
+++ b/tests/test_handlers_receive_new_code_preserve.py
@@ -10,7 +10,7 @@ async def test_receive_new_code_uses_preserve(monkeypatch):
 
     captured = {}
 
-    def fake_extract(msg):
+    def fake_extract(msg, reconstruct_from_entities=True):
         captured['called'] = True
         # חיקוי הודעת משתמש עם __main__
         return "print('__main__')\n"

--- a/tests/test_utils_extract_preserve_markdown.py
+++ b/tests/test_utils_extract_preserve_markdown.py
@@ -1,0 +1,48 @@
+import types
+
+
+def test_extract_message_text_prefers_markdown_v2():
+    from utils import TelegramUtils
+
+    class Msg:
+        def __init__(self):
+            self.text_markdown_v2 = "__main__"
+            self.text_markdown = None
+            self.text = "main"
+            self.caption = None
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == "__main__"
+
+
+def test_extract_message_text_falls_back_to_text():
+    from utils import TelegramUtils
+
+    class Msg:
+        def __init__(self):
+            self.text_markdown_v2 = None
+            self.text_markdown = None
+            self.text = "plain"
+            self.caption = None
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == "plain"
+
+
+def test_extract_message_text_uses_caption_markdown_when_available():
+    from utils import TelegramUtils
+
+    class Msg:
+        def __init__(self):
+            self.text_markdown_v2 = None
+            self.text_markdown = None
+            self.text = None
+            self.caption_markdown = "__caption__"
+            self.caption = "caption"
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == "__caption__"
+

--- a/tests/test_utils_extract_preserve_markdown.py
+++ b/tests/test_utils_extract_preserve_markdown.py
@@ -101,3 +101,56 @@ def test_extract_message_text_entities_clamped_offsets():
     out = TelegramUtils.extract_message_text_preserve_markdown(m)
     assert out == "_a_bc"
 
+
+def test_extract_message_text_ignores_unknown_entity_type():
+    from utils import TelegramUtils
+
+    class _Ent:
+        def __init__(self, type, offset, length):
+            self.type = type
+            self.offset = offset
+            self.length = length
+
+    class Msg:
+        def __init__(self):
+            self.text = "abc"
+            # underline אינו נתמך – אמור להתעלם
+            self.entities = [_Ent("underline", 0, 3)]
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == "abc"
+
+
+def test_extract_message_text_full_range_bold_closes_at_end():
+    from utils import TelegramUtils
+
+    class _Ent:
+        def __init__(self, type, offset, length):
+            self.type = type
+            self.offset = offset
+            self.length = length
+
+    class Msg:
+        def __init__(self):
+            self.text = "abc"
+            self.entities = [_Ent("bold", 0, 3)]
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == "__abc__"
+
+
+def test_extract_message_text_empty_base_returns_empty():
+    from utils import TelegramUtils
+
+    class Msg:
+        def __init__(self):
+            self.text = ""
+            self.caption = None
+            self.entities = []
+
+    m = Msg()
+    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    assert out == ""
+

--- a/tests/test_utils_extract_preserve_markdown.py
+++ b/tests/test_utils_extract_preserve_markdown.py
@@ -27,12 +27,18 @@ def test_extract_message_text_falls_back_to_text():
             self.caption = None
 
     m = Msg()
-    out = TelegramUtils.extract_message_text_preserve_markdown(m)
+    out = TelegramUtils.extract_message_text_preserve_markdown(m, reconstruct_from_entities=False)
     assert out == "plain"
 
 
 def test_extract_message_text_uses_caption_markdown_when_available():
     from utils import TelegramUtils
+
+    class _Ent:
+        def __init__(self, type, offset, length):
+            self.type = type
+            self.offset = offset
+            self.length = length
 
     class Msg:
         def __init__(self):
@@ -41,6 +47,7 @@ def test_extract_message_text_uses_caption_markdown_when_available():
             self.text = None
             self.caption_markdown = "__caption__"
             self.caption = "caption"
+            self.caption_entities = [_Ent("bold", 0, len(self.caption))]
 
     m = Msg()
     out = TelegramUtils.extract_message_text_preserve_markdown(m)

--- a/utils.py
+++ b/utils.py
@@ -493,15 +493,19 @@ class TelegramUtils:
 
     @staticmethod
     def extract_message_text_preserve_markdown(message: "Message", *, reconstruct_from_entities: bool = True) -> str:
-        """שחזור טקסט ההודעה תוך ניסיון להחזיר את מה שהמשתמש התכוון מבחינת תווי Markdown.
+        """
+        שחזור טקסט ההודעה תוך ניסיון להחזיר את מה שהמשתמש התכוון מבחינת תווי Markdown.
 
         עקרונות:
-        - ברירת מחדל: נשתמש ב-`text`/`caption` (התוכן הגולמי כפי שנשלח לשרת לאחר עיבוד Markdown).
-          זאת כדי לא לשמור מחרוזת "מרונדרת" (כמו \*_name_*), שלא משקפת קלט משתמש.
-        - במידה ו-`reconstruct_from_entities=True` ויש ישויות עיצוב (bold/italic), ננסה לשחזר
+
+        - ברירת מחדל: נשתמש ב-``text``/``caption`` (התוכן הגולמי כפי שנשלח לשרת לאחר עיבוד Markdown).
+          זאת כדי לא לשמור מחרוזת "מרונדרת" (למשל ``*_name_*``), שאינה משקפת קלט משתמש.
+
+        - במידה ו-``reconstruct_from_entities=True`` ויש ישויות עיצוב (``bold``/``italic``), ננסה לשחזר
           תווי Markdown שהיוו כנראה את מקור העיצוב ע"י הוספת תחיליות/סיומות סביב הטקסט שסומן.
-          מיפוי פשוט: bold → "__", italic → "_". שאר ישויות נשמרות כפי שהן.
-        - אם יש כיתוב (caption), נשתמש במקבילות `caption_entities`.
+          מיפוי פשוט: ``bold`` → ``"__"``, ``italic`` → ``"_"``. שאר ישויות נשמרות כפי שהן.
+
+        - אם יש כיתוב (caption), נשתמש במקבילות ``caption_entities``.
         """
         # 1) תוכן בסיסי
         try:

--- a/utils.py
+++ b/utils.py
@@ -491,6 +491,33 @@ class TelegramUtils:
                 return
             raise
 
+    @staticmethod
+    def extract_message_text_preserve_markdown(message: "Message") -> str:
+        """שחזור טקסט ההודעה תוך שימור סימוני Markdown שנבלעו ע"י טלגרם.
+
+        מנסה להעדיף `text_markdown_v2`/`text_markdown` (או `caption_*`) אם קיימים באובייקט
+        ההודעה, כיוון שהם נבנים על סמך ה-entities ומייצגים נאמנה תווים כמו `__`, `_`, `*` וכו'.
+        נופל חכם ל-`text`/`caption` אם המאפיינים אינם זמינים (למשל בסביבת בדיקות/סטאבים).
+        """
+        try:
+            candidates = [
+                getattr(message, "text_markdown_v2", None),
+                getattr(message, "text_markdown", None),
+                getattr(message, "caption_markdown_v2", None),
+                getattr(message, "caption_markdown", None),
+                getattr(message, "text", None),
+                getattr(message, "caption", None),
+            ]
+            for val in candidates:
+                if isinstance(val, str) and val:
+                    return val
+        except Exception:
+            pass
+        try:
+            return str(getattr(message, "text", "") or getattr(message, "caption", "") or "")
+        except Exception:
+            return ""
+
 class CallbackQueryGuard:
     """Guard גורף ללחיצות כפולות על כפתורי CallbackQuery.
 

--- a/utils.py
+++ b/utils.py
@@ -542,6 +542,10 @@ class TelegramUtils:
                 except Exception:
                     continue
 
+                # התעלם מ-entities ריקים/מחוץ לתחום לאחר קלמפינג
+                if end <= start:
+                    continue
+
                 # מיפוי לסימני Markdown מועדפים
                 if etype == "bold":
                     opens[start].append("__")

--- a/utils.py
+++ b/utils.py
@@ -537,8 +537,15 @@ class TelegramUtils:
                     etype = getattr(ent, "type", "") or ""
                     offset = int(getattr(ent, "offset", 0) or 0)
                     ent_len = int(getattr(ent, "length", 0) or 0)
-                    start = max(0, min(length, offset))
-                    end = max(0, min(length, offset + ent_len))
+                    # חשב טווח מקורי
+                    start_raw = offset
+                    end_raw = offset + ent_len
+                    # קלמפינג ראשוני
+                    start = max(0, min(length, start_raw))
+                    end = max(0, min(length, end_raw))
+                    # אם offset שלילי גרם לכך ש-end==start, הרחב לפי האורך המבוקש
+                    if start_raw < 0 and ent_len > 0 and end <= start:
+                        end = min(length, start + ent_len)
                 except Exception:
                     continue
 


### PR DESCRIPTION
<b>What</b>
<ul>
  <li>שחזור טקסט נכנס עם סימוני Markdown שנבלעו ע״י טלגרם (למשל <code>__main__</code>).</li>
  <li>הוספת פונקציה: <code>TelegramUtils.extract_message_text_preserve_markdown</code> – מעדיפה <code>text_markdown_v2</code>/<code>text_markdown</code> ו-nfallback ל-<code>text</code>/<code>caption</code>.</li>
  <li>יישום בזרימות קבלת טקסט:
    <ul>
      <li><code>handlers/save_flow.py</code> – איסוף/שמירה רגילים ו-long collect.</li>
      <li><code>handlers/file_view.py</code> – <code>receive_new_code</code>.</li>
    </ul>
  </li>
  <li>טסטים:
    <ul>
      <li><code>tests/test_utils_extract_preserve_markdown.py</code> – כיסוי עדיפויות ונפילות.</li>
      <li><code>tests/test_handlers_receive_new_code_preserve.py</code> – שימוש בפונקציה במסלול עריכת קובץ.</li>
    </ul>
  </li>
</ul>

<b>Why</b>
<ul>
  <li>טלגרם ממיר/“בולע” תווי Markdown בצד הלקוח עוד לפני שהבוט מקבל את ההודעה. זה גרם לאיבוד תווים (למשל <code>__</code>), ולשמירה שגויה של קוד/הערות.</li>
  <li>הסתמכות על <code>text_markdown_v2</code>/<code>text_markdown</code> משחזרת מחרוזת נאמנה על בסיס entities.</li>
</ul>

<b>Tests</b>
<ul>
  <li>כיסוי פונקציה חדשה + אימות שה-handlers משתמשים בה.</li>
  <li>CI: להריץ יחידות על Python 3.11/3.12 בהתאם ל-Required Checks.</li>
</ul>

<b>Docs & Policy</b>
<ul>
  <li>נשמרו כללי <code>.cursorrules</code>: ללא מחיקות מסוכנות, ללא <code>sudo</code>, <code>parse_mode</code> בטוח להצגה.</li>
  <li>אין הכנסת סודות; לוגים מנוקים ע״פ המדיניות.</li>
</ul>

<b>What's new since initial PR</b>
<ul>
  <li><b>Input preservation refined</b>: ברירת מחדל נשמר <code>text/caption</code> (raw); נוספה בנייה אופציונלית מסומנת מ-entities בלבד.</li>
  <li><b>Entity clamping</b>: טיפול ב-offset שלילי/מחוץ לטווח. ישויות שמחוץ לטווח נזרקות; שליליות מורחבות לשמירת האורך המבוקש (ללא גלישה).</li>
  <li><b>Ordering</b>: סדר פתיחה/סגירה ב-overlap (italic→bold) כדי למנוע ערבוב סימנים.</li>
  <li><b>Docs</b>: תיקון docstring לפי Sphinx (ריווח, רשימות, code-literals). הוספת mock ל-<code>telegram.constants</code>/<code>telegram.error</code>.</li>
  <li><b>Tests & Coverage</b>: נוספו טסטים חדשים ל-<code>utils</code> ו-<code>handlers</code>; כיסינו מקרים: raw vs markdown, caption_entities, overlap, clamped offsets, unknown entity, full-range bold, empty input.</li>
</ul>

<b>Why</b>
<ul>
  <li>מונע “בליעה”/עיוות של <code>__</code>, <code>_</code>, <code>*</code> בטקסט נכנס; שומר קלט משתמש נאמן.</li>
  <li>מחזיק התנהגות עקבית גם כשלקוחות טלגרם מייצרים entities מהצד שלהם.</li>
</ul>

<b>Impact</b>
<ul>
  <li>שמירת קוד/הערות כפי שהוקלדו, ללא escape מיותר.</li>
  <li>שילוח הודעות ממשיך עם escape מתאים (Markdown/HTML) בצד היציאה.</li>
</ul>


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use `TelegramUtils.extract_message_text_preserve_markdown` to retain Markdown in user code/messages across edit and save flows.
> 
> - **Utils**:
>   - Add `TelegramUtils.extract_message_text_preserve_markdown` to prefer `text_markdown_v2`/`text_markdown` (and caption variants) with safe fallbacks.
> - **Handlers**:
>   - `handlers/file_view.py`:
>     - In `receive_new_code`, extract `new_code` via `TelegramUtils.extract_message_text_preserve_markdown` with fallback to `update.message.text`.
>   - `handlers/save_flow.py`:
>     - Import `TelegramUtils`.
>     - In `long_collect_receive`, extract `text` via `TelegramUtils.extract_message_text_preserve_markdown` for text messages.
>     - In `get_code`, extract `code` via `TelegramUtils.extract_message_text_preserve_markdown` before normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec9d64ef57e0829e896d89517d0fdf5b2fb3a344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->