### PR TITLE
Add tests for show_command

### DIFF
--- a/tests/test_bot_handlers_show_command_more.py
+++ b/tests/test_bot_handlers_show_command_more.py
@@ -220,7 +220,8 @@ async def test_show_command_renders_html_and_escapes_code_and_buttons_id(monkeyp
     rm = kwargs.get('reply_markup')
     assert rm is not None
     buttons = getattr(rm, 'inline_keyboard', [])
-    assert buttons and isinstance(buttons, list)
+    # telegram InlineKeyboardMarkup.inline_keyboard יכול להיות list או tuple
+    assert buttons and isinstance(buttons, (list, tuple))
     fav_btn = buttons[-1][0]
     assert getattr(fav_btn, 'text', '').startswith('⭐')
     assert getattr(fav_btn, 'callback_data', '').startswith('fav_toggle_id:')


### PR DESCRIPTION
## ✨ תיאור קצר
הוספת בדיקות יחידה מקיפות לפקודה `/show` בבוט. הבדיקות מכסות תרחישים שונים כגון קלט חסר, קובץ לא קיים, רינדור HTML תקין ולוגיקת כפתורי מועדפים (ID מול טוקן).

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- יצירת קובץ טסטים חדש: `tests/test_bot_handlers_show_command_more.py`.
- הוספת סטאבים מינימליים למודולי `telegram` ו־`conversation_handlers` כדי לאפשר בדיקות יחידה מבודדות.
- בדיקת התנהגות `show_command` ללא ארגומנטים (הצגת הודעת שימוש).
- בדיקת התנהגות `show_command` כאשר קובץ לא נמצא.
- בדיקת רינדור HTML, כולל escaping נכון של תוכן הקוד.
- בדיקת לוגיקת כפתור המועדפים: שימוש ב־ID ישיר ובנפילה ל־token קצר (עם מיפוי ב־`user_data`) כאשר ה־ID ארוך מדי.
- בדיקת תווית כפתור המועדפים הנכונה כאשר הקובץ כבר מסומן כמועדף.

## 🧪 בדיקות
- [x] Unit
- [ ] Integration
- [ ] Manual

הבדיקות נכתבו ב־`pytest` והורצו באופן מקומי. כל הטסטים החדשים עברו בהצלחה.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [x] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
אין השפעה על פרודקשן, ביצועים או אבטחה. מדובר בהוספת בדיקות בלבד.

## 🔗 קישורים
- Issues קשורים: #654
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
אין סיכון. במקרה תקלה, ניתן למחוק את קובץ הטסטים החדש.

---
<a href="https://cursor.com/background-agent?bcId=bc-834e877e-51ce-4539-bc7b-1761374210ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-834e877e-51ce-4539-bc7b-1761374210ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new test suite covering `/show` command flows, including usage/no-args, missing file, HTML rendering/escaping, and favorite button ID/token logic.
> 
> - **Tests**:
>   - Add `tests/test_bot_handlers_show_command_more.py` with async `pytest` cases for `AdvancedBotHandlers.show_command`.
>     - No args → usage message; missing file → not-found message.
>     - HTML rendering with `parse_mode='HTML'`, proper code escaping, and inline keyboard presence.
>     - Favorite button: ID-based callback, token fallback for long IDs with `user_data['fav_tokens']` mapping.
>     - Favorite label reflects existing favorite state (⭐/💔 toggle).
>   - Lightweight stubs for `telegram`, `telegram.constants`, `telegram.ext`, and `conversation_handlers.MAIN_KEYBOARD` to isolate tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee37683e335da5647f019ea940c7bce616209a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->