### PR TITLE
Chore/fix webapp global search fallback empty engine 2025 10 16

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -896,11 +896,10 @@ def _safe_search(user_id: int, query: str, **kwargs):
     if search_engine:
         try:
             engine_results = search_engine.search(user_id, query, **kwargs)
-            # אם המנוע החזיר תוצאות – נחזיר אותן. אם החזיר ריק, ננסה נפילה לאחור ל-DB.
-            if isinstance(engine_results, list) and len(engine_results) > 0:
-                return engine_results
+            # גם רשימה ריקה היא תוצאה תקפה ("אין תוצאות") — נחזיר כפי שהיא
+            return engine_results
         except Exception:
-            # ניפול ל-fallback הבסיסי במקרה של תקלה
+            # ניפול ל-fallback הבסיסי במקרה של תקלה בלבד
             engine_results = None
 
     # Fallback: חיפוש בסיסי ב-MongoDB על תוכן הקבצים (code)

--- a/webapp/static/js/global_search.js
+++ b/webapp/static/js/global_search.js
@@ -109,7 +109,7 @@
     const pagination = $('searchPagination');
     const msg = String(message || 'אירעה שגיאה');
     if (container && info && results && pagination){
-      info.innerHTML = '<div class="alert alert-error">' + escapeHtml(msg) + '</div>';
+      info.innerHTML = '<div class="alert alert-danger">' + escapeHtml(msg) + '</div>';
       results.innerHTML = '';
       pagination.innerHTML = '';
       container.style.display = 'block';


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>Global Search: נפילה אוטומטית ל‑DB כש‑engine מחזיר 0 תוצאות/לא זמין.</li>
  <li>API Auth: דקורטור <code>api_login_required</code> מחזיר JSON ‏401 (לא redirect) ל‑<code>/api/search/global</code> ו‑<code>/api/search/suggestions</code>.</li>
  <li>Frontend: ביטול <code>alert()</code>; הצגת שגיאות אינליין בקונטיינר התוצאות; הפניה ל‑/login על 401.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>משתמשים קיבלו "נמצאו 0 תוצאות" גם כשיש התאמות (למשל "Telegram") עקב warmup/אינדקס/ENV. Fallback מבטיח אמינות.</li>
  <li>נמנעות קופצות דפדפן ומטופל תרחיש ללא‑התחברות בצורה נכונה.</li>
</ul>

<h2>How (Tech)</h2>
<ul>
  <li><code>_safe_search</code>: מחזיר תוצאות engine אם אינן ריקות; אחרת מבצע חיפוש case‑insensitive ב‑Mongo עם פילטרים ו‑highlights.</li>
  <li>Rate limiting/metrics ללא שינוי.</li>
</ul>

<h2>Tests</h2>
<ol>
  <li>התחבר → /files → חפש "Telegram" → צפה לתוצאות (או "לא נמצאו" רק אם באמת אין).</li>
  <li>התנתק → חפש → 401 → ה‑UI מפנה ל‑/login (ללא alert).</li>
  <li>מצב Regex: נסה דוגמה פשוטה <code>Te.*am</code> → מתקבלות תוצאות.</li>
  <li>שנה <em>תוצאות לעמוד</em> ל‑10 → נווט בין עמודים.</li>
  <li>Suggestions: הקלד ≥2 תווים → הצעות מוצגות כשזמינות.</li>
</ol>

<h2>Risk / Impact</h2>
<ul>
  <li>סיכון נמוך: ה‑fallback מופעל רק כש‑engine מחזיר 0; אחרת ההתנהגות זהה.</li>
  <li>אין שינויי סכימה; אין חשיפת סודות או לוגים רגישים.</li>
</ul>

<h2>Rollback</h2>
<ul>
  <li>Revert פשוט של ה‑PR. אין דגלי פיצ'ר.</li>
</ul>

<h2>Docs</h2>
<ul>
  <li>עיינתי ב‑<a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a>. אין שינוי API חיצוני.</li>
</ul>

<h2>CI</h2>
<ul>
  <li>נדרש ירוק: 🔍 Code Quality & Security; 🧪 Unit Tests (3.11); 🧪 Unit Tests (3.12).</li>
</ul>

<p><strong>Refs</strong>: #798, #799</p>


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce API-specific auth (401 JSON), fallback to DB search when engine returns no results, and update global search UI to handle 401 and show inline errors.
> 
> - **API/Auth**:
>   - Add `api_login_required` decorator returning JSON 401 instead of redirect.
>   - Apply to `POST /api/search/global` and `GET /api/search/suggestions` (replace `login_required`).
> - **Search Backend**:
>   - Update `_safe_search` to fallback to DB when engine errors or returns empty; only return engine results if non-empty.
> - **Frontend (global search)**:
>   - Handle 401 responses by redirecting to `/login`.
>   - Robust JSON parsing; replace `alert` with `showError` to render inline error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67063ae559ba60760e74d1c55c3f9eb1150dc366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->