### PR TITLE
Check codemirror editor loading status

### DIFF
--- a/webapp/static/js/editor-manager.js
+++ b/webapp/static/js/editor-manager.js
@@ -16,8 +16,8 @@
         const saved = localStorage.getItem('preferredEditor');
         if (saved === 'codemirror' || saved === 'simple') return saved;
       } catch(_) {}
-      // ברירת מחדל: עורך מתקדם (CodeMirror) — כוונת ה‑PR
-      return 'codemirror';
+      // ברירת מחדל: עורך רגיל (textarea)
+      return 'simple';
     }
 
     savePreference(editorType) {


### PR DESCRIPTION
#<h2>What</h2>
<ul>
  <li>ברירת המחדל של העורך נשארת <strong>העורך הרגיל</strong> (<code>simple</code> / <code>textarea</code>).</li>
  <li>אפשרות מעבר מיידית לעורך המתקדם (CodeMirror) באמצעות כפתור, עם שמירת העדפה.</li>
  <li>שיפור יציבות טעינת CodeMirror:
    <ul>
      <li>טעינת מודולי הבסיס במקביל (Promise.all) עם מגני timeout פר-מודול.</li>
      <li>Failover בין CDN‑ים (jsDelivr → unpkg → esm.sh) עם timeout פר CDN (~8s) ובקרת timeout כוללת (~30s) שלא חותכת את ה‑failover.</li>
      <li>Fallback אוטומטי לעורך הרגיל ובאנר שגיאה ידידותי אם הטעינה נכשלת.</li>
    </ul>
  </li>
</ul>

<h2>Why</h2>
<ul>
  <li>התאמה להעדפת המוצר: משתמשים חדשים יקבלו חוויה יציבה כברירת מחדל.</li>
  <li>העדפת המשתמש נשמרת לטווח ארוך, כך שמי שמעדיף CodeMirror יקבל אותו בכל טעינה.</li>
  <li>שיפור UX בתרחישי רשת איטית/חסימת CDN, ללא “תקיעות שקטות”.</li>
</ul>

<h2>User Preference Persistence</h2>
<ul>
  <li>העדפה נשמרת ב־<code>localStorage('preferredEditor')</code> ומתעדכנת גם בצד השרת דרך:
    <code>/api/ui_prefs</code> ו־<code>/api/user/preferences</code>.</li>
</ul>

<h2>Implementation</h2>
<ul>
  <li>קובץ: <code>webapp/static/js/editor-manager.js</code></li>
  <li>שינויים עיקריים:
    <ul>
      <li><code>loadPreference()</code>: ברירת מחדל ל־<code>'simple'</code> אם אין העדפה שמורה.</li>
      <li>הוספת <code>withTimeout()</code> סביב טעינת CodeMirror (עד ~30s) כדי לאפשר ניסיון לכל CDN.</li>
      <li>טעינת חבילות CodeMirror במקביל ו־failover מסודר בין CDN‑ים.</li>
      <li>Fallback לעורך הרגיל + באנר שגיאה ידידותי במקרה כשל.</li>
    </ul>
  </li>
</ul>

<h2>Test Plan</h2>
<ol>
  <li>פתיחת עמודי "עריכת קובץ" ו"העלה קובץ": וידוא שהברירת מחדל היא עורך רגיל.</li>
  <li>לחיצה על הכפתור "עורך מתקדם": מעבר ל‑CodeMirror, עריכה פעילה, ושמירת ההעדפה.</li>
  <li>רענון הדף: וידוא שהעורך הנבחר נטען לפי ההעדפה השמורה.</li>
  <li>חסימת CDN (לבדיקה): וידוא fallback לעורך רגיל ובאנר שגיאה, ללא שגיאות קונסול.</li>
  <li>בדיקת <code>localStorage.getItem('preferredEditor')</code> והבקשות ל־<code>/api/ui_prefs</code>, <code>/api/user/preferences</code>.</li>
</ol>

<h2>Risk & Rollback</h2>
<ul>
  <li>סיכון נמוך – במקרי כשל רשת יש fallback לעורך הרגיל.</li>
  <li>Rollback: החזרת ברירת המחדל ל־<code>'codemirror'</code> או revert לקובץ <code>editor-manager.js</code>.</li>
</ul>

<h2>Docs</h2>
<ul>
  <li>נסקר: <a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a>.</li>
  <li>אין שינויי RTD/סכמות. נשקול הוספת סעיף העדפת עורך בתיעוד משתמש.</li>
</ul>

<h2>CI</h2>
<ul>
  <li>נדרש: "🔍 Code Quality & Security", "🧪 Unit Tests (3.11)", "🧪 Unit Tests (3.12)".</li>
</ul>

<h2>Screenshots</h2>
<ul>
  <li>רצוי לצרף צילום של המעבר בין העורכים ובאנר ה‑fallback.</li>
</ul>
---
<a href="https://cursor.com/background-agent?bcId=bc-5891608e-9c0e-4844-9c0e-a68ebebb943f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5891608e-9c0e-4844-9c0e-a68ebebb943f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds timeout-guarded, parallel loading for CodeMirror core, language, and theme modules to improve reliability and fallback behavior.
> 
> - **Editor reliability (`webapp/static/js/editor-manager.js`)**:
>   - Add `withTimeout` helper to guard async operations and surface timeouts.
>   - Wrap `loadCodeMirror`, `getLanguageSupport`, and `getTheme` calls with timeouts.
>   - Parallelize core CodeMirror module imports (`state`, `view`, `commands`, `language`, `search`, `autocomplete`) via `Promise.all`, each with timeouts.
>   - Keep a consistent CDN across modules; record chosen CDN after successful parallel imports.
>   - Apply guarded loading during editor initialization and show fallback message on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67a9603596d83ba448934f0c9eca0c6da9c927b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->