### PR TITLE
Fix unclickable files in collections

### DIFF
--- a/webapp/static/css/collections.css
+++ b/webapp/static/css/collections.css
@@ -14,7 +14,10 @@
 .collection-item{display:flex;align-items:center;gap:.5rem;border:1px dashed rgba(255,255,255,.2);border-radius:8px;padding:.4rem .6rem;background:rgba(255,255,255,.05)}
 .collection-item .drag{cursor:grab;opacity:.7}
 .collection-item.dragging{opacity:.5}
-.collection-item .file{flex:1;overflow:hidden;text-overflow:ellipsis}
+.collection-item .file{flex:1;overflow:hidden;text-overflow:ellipsis;color:#aad;cursor:pointer;text-decoration:underline}
+.collection-item{cursor:pointer}
+.collection-item .drag{cursor:grab}
+.collection-item .remove{cursor:pointer}
 .collection-item .remove{background:none;border:1px solid var(--glass-border);border-radius:6px;color:#fff;padding:.2rem .5rem;cursor:pointer}
 .loading,.empty,.error{opacity:.85}
 @media(max-width:900px){.collections-layout{grid-template-columns:1fr}}

--- a/webapp/static/js/collections.js
+++ b/webapp/static/js/collections.js
@@ -114,25 +114,41 @@
           const res = await api.removeItems(cid, [{source, file_name: name}]);
           if (!res || !res.ok) return alert(res && res.error || 'שגיאה במחיקה');
           row.remove();
+          return;
         }
         // פתיחת קובץ בלחיצה על שם הקובץ
         const link = ev.target.closest('a.file[data-open]');
         if (link) {
           ev.preventDefault();
           const fname = link.getAttribute('data-open') || '';
-          try {
-            const r = await fetch(`/api/files/resolve?name=${encodeURIComponent(fname)}`);
-            const j = await r.json();
-            if (j && j.ok && j.id) {
-              window.location.href = `/file/${encodeURIComponent(j.id)}`;
-            } else {
-              alert('הקובץ לא נמצא לצפייה');
-            }
-          } catch(_e){ alert('שגיאה בפתיחת הקובץ'); }
+          await openFileByName(fname);
+          return;
+        }
+        // פתיחת קובץ בלחיצה על כל השורה (מלבד כפתור הסרה/ידית גרירה)
+        if (row && !ev.target.closest('.drag')) {
+          const fname = row.getAttribute('data-name') || '';
+          await openFileByName(fname);
         }
       });
     } catch (e) {
       container.innerHTML = '<div class="error">שגיאה בטעינת פריטים</div>';
+    }
+  }
+
+  // פתיחת קובץ לפי שם הקובץ (שימושי גם ללחיצה על כל השורה)
+  async function openFileByName(fname){
+    const name = String(fname || '').trim();
+    if (!name) return;
+    try {
+      const r = await fetch(`/api/files/resolve?name=${encodeURIComponent(name)}`);
+      const j = await r.json();
+      if (j && j.ok && j.id) {
+        window.location.href = `/file/${encodeURIComponent(j.id)}`;
+      } else {
+        alert('הקובץ לא נמצא לצפייה');
+      }
+    } catch(_e){
+      alert('שגיאה בפתיחת הקובץ');
     }
   }
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו באג שבו קבצים באוספים לא היו לחיצים ולא נראו ככאלה. כעת כל שורת קובץ לחיצה ופותחת את הקובץ, והעיצוב עודכן כדי להדגיש זאת.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הפיכת כל שורת קובץ באוסף ללחיצה (למעט כפתורי הסרה/גרירה).
- עדכון עיצוב ה-CSS כדי להדגיש ששם הקובץ והשורה כולה לחיצים (צבע, קו תחתון, סמן עכבר).
- ריפקטור לוגיקת פתיחת הקובץ לפונקציה נפרדת (`openFileByName`) לשימוש חוזר.

## 🧪 בדיקות
בדקתי ידנית בדפדפן:
- לחיצה על שם הקובץ פותחת אותו.
- לחיצה על כל שורת הקובץ (לא על כפתור הסרה/גרירה) פותחת אותו.
- כפתור ההסרה וידית הגרירה עדיין עובדים כרגיל.
- העיצוב משקף את יכולת הלחיצה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [x] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שיפור חווית משתמש בלבד, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback על ידי החזרת הקבצים `webapp/static/js/collections.js` ו-`webapp/static/css/collections.css` לגרסתם הקודמת.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b8680f7-dd69-4a25-992b-4e69a34212ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b8680f7-dd69-4a25-992b-4e69a34212ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable opening files by clicking the file name or the entire row (excluding drag/remove), refactor file-open logic, and update styles to indicate clickability.
> 
> - **Frontend UI**
>   - **JS (`webapp/static/js/collections.js`)**:
>     - Add row click-to-open for `.collection-item` (ignores `.drag` and `.remove`).
>     - Extract `openFileByName` and reuse for link and row clicks.
>     - Early return after item removal to avoid unintended actions.
>   - **CSS (`webapp/static/css/collections.css`)**:
>     - Style `.collection-item .file` as a clickable link (`color:#aad`, underline, pointer).
>     - Make entire `.collection-item` show pointer cursor; ensure `.drag` uses grab; `.remove` shows pointer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a06c0946728bdbad5f8a013bf4c2a2ab2148142f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->