### PR TITLE
Revert pr and remove settings button

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -485,6 +485,7 @@
             transition: all 0.25s ease;
             z-index: 1000;
             display: flex;
+            direction: ltr; /* שמירה על סדר פריטים משמאל לימין גם ב-RTL */
             gap: .25rem;
             padding: .4rem;
             max-width: calc(100vw - 24px); /* אין גלילה אופקית */
@@ -591,6 +592,7 @@
               position: absolute; top: 100%; right: 0; left: auto; transform: none;
               display: grid; grid-template-columns: repeat(4, 44px); gap: .25rem; padding: .4rem;
               max-width: calc(100vw - 16px);
+              direction: ltr; /* במובייל גם, מניעת היפוך סדר ב-RTL */
             }
         }
 


### PR DESCRIPTION
## ✨ תיאור קצר
החזרנו לאחור את שינויי העיצוב והמיקום של חלונית "פקודות מהירות" (quick-access-dropdown) שהוצגו ב-PR #1076, עקב בעיות תצוגה. במקביל, שמרנו על הסרת כפתור ה"הגדרות" מתוך החלונית, כך שההגדרות נגישות רק מהתפריט הראשי.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- שוחזרו הגדרות ה-CSS הקודמות עבור `.quick-access-dropdown`, `.quick-access-toggle`, `.quick-access-item` ואנימציית `@keyframes slideDown` ב-`webapp/templates/base.html`.
- בוטלו התאמות ה-CSS למסכים קטנים (media queries) ששונו ב-PR #1076 עבור חלונית הגישה המהירה.
- הוסר כפתור ה"הגדרות" מתוך מבנה ה-HTML של חלונית הגישה המהירה.

## 🧪 בדיקות
- [ ] Unit
- [ ] Integration
- [x] Manual - נבדק ויזואלית שהחלונית מופיעה במיקום ובסגנון המצופה, ושכפתור ההגדרות אינו מופיע בה.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (למעט כשל לא קשור בקאש)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: תיקון רגרסיה בתצוגת UI, צפוי לשפר את חווית המשתמש.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
    - PR #1076: https://github.com/amirbiron/CodeBot/pull/1076
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע revert ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d07883a-4434-4587-9cc8-954ad1dc5dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d07883a-4434-4587-9cc8-954ad1dc5dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts recent CSS for the quick-access menu (positioning, sizing, animation, mobile grid) and keeps the settings button removed from the menu.
> 
> - **Frontend (webapp/templates/base.html)**:
>   - **Quick-access menu CSS reverted**:
>     - `quick-access-toggle.active`: restore translucent background state.
>     - `quick-access-dropdown`: restore left alignment under toggle, original offsets, z-index, and flex layout; remove new transform/overflow tweaks.
>     - `@keyframes slideDown`: restore scale + translate animation.
>     - **Mobile**: restore grid with 40px columns and original positioning.
>     - `quick-access-item`: restore 40x40 size and 8px radius.
>   - **HTML**:
>     - Settings button remains removed from `quick-access-dropdown` (comment updated/retained).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332501753c22dabe6f8e7fd66d789b4a1b8b4b3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->