### PR TITLE
Add temporary debug for config and blueprint

### DIFF
--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -3,21 +3,13 @@ import pytest
 
 import importlib, sys
 
-print("\n[DEBUG] ---- בדיקת טעינת config ו־Blueprint ----")
+print("\n[DEBUG] ---- בדיקת טעינת config ----")
 
 try:
     from config import config as cfg
     print("[DEBUG] config נטען בהצלחה | FEATURE_MY_COLLECTIONS =", getattr(cfg, "FEATURE_MY_COLLECTIONS", "לא קיים"))
 except Exception as e:
     print("[DEBUG] כשל בייבוא config:", type(e).__name__, str(e))
-
-try:
-    app_mod = importlib.import_module("webapp.app")
-    app = app_mod.app
-    routes = [str(r) for r in app.url_map.iter_rules() if "collections" in str(r)]
-    print("[DEBUG] נתיבים רשומים:", routes)
-except Exception as e:
-    print("[DEBUG] שגיאה בגישה ל־app או ל־routes:", type(e).__name__, str(e))
 
 print("[DEBUG] -------------------------------------------\n")
 
@@ -105,6 +97,14 @@ def app_client(monkeypatch):
         pass
     app_mod = importlib.import_module('webapp.app')
     app = app_mod.app
+    # דיבאג: הדפסת נתיבי collections רק ב-CI או כש-PYTEST_DEBUG_COLLECTIONS=1
+    import os as _os
+    if _os.environ.get("PYTEST_DEBUG_COLLECTIONS") == "1" or _os.environ.get("GITHUB_ACTIONS") == "true":
+        try:
+            routes = [str(r) for r in app.url_map.iter_rules() if "collections" in str(r)]
+            print("[DEBUG] נתיבים רשומים:", routes)
+        except Exception as e:
+            print("[DEBUG] שגיאה בגישה ל־routes:", type(e).__name__, str(e))
     # החלפת get_manager בפייק
     import webapp.collections_api as api
     fake = FakeManager()


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספתי בלוק דיבאג זמני בתחילת `tests/test_collections_api.py`. מטרתו לוודא שקובץ ה־`config` נטען כראוי, שדגל `FEATURE_MY_COLLECTIONS` פעיל, ושה־Blueprint של `/api/collections` נרשם בהצלחה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת קוד דיבאג ב־`tests/test_collections_api.py` לבדיקת טעינת `config` ורישום Blueprint.
- בדיקת ערך `FEATURE_MY_COLLECTIONS` והנתיבים הרשומים עבור "collections".

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [x] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

### דוגמאות Conventional Commits

| סוג | דוגמה להודעה | מתי להשתמש |
| --- | --- | --- |
| feat | feat: הוספת מסך הגדרות | פיצ'ר חדש למשתמש |
| fix | fix: תיקון קריסה בעת התחברות | תיקון באג מול משתמשים/פרודקשן |
| chore | chore: שדרוג Gradle ל-8.9 | תחזוקה, כלי פיתוח, housekeeping |
| docs | docs: עדכון README עם הוראות התקנה | שינויי תיעוד בלבד |
| refactor | refactor: חילוץ Repository ל-UseCases | שינוי מבני ללא שינוי התנהגות |
| test | test: הוספת בדיקות ל-LoginViewModel | הוספת/עדכון בדיקות |
| build | build: הוספת flavor staging ל-CI | שינויים בבילד/תלויות/תצורה |

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - אין השפעה על לוגיקת היישום. הבלוק נועד להדפיס מידע דיבאג ללוגים של בדיקות (pytest/GitHub Actions).

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - מחיקת בלוק הדיבאג שהוסף.

---
<a href="https://cursor.com/background-agent?bcId=bc-276461e5-0775-4e14-93f1-3a1ea8a1ee8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-276461e5-0775-4e14-93f1-3a1ea8a1ee8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a temporary debug block in tests to print config load status, FEATURE_MY_COLLECTIONS value, and registered /api/collections routes.
> 
> - **Tests**:
>   - Add temporary debug in `tests/test_collections_api.py` to:
>     - Import and print `config` load status and `FEATURE_MY_COLLECTIONS` value.
>     - Import `webapp.app` and print registered routes containing `collections`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0e1d468c9335142719f369d9de6a7d6fdd08104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->