### PR TITLE
Implement fake find_one_and_update for tests

### DIFF
--- a/tests/test_collections_manager_smart.py
+++ b/tests/test_collections_manager_smart.py
@@ -55,11 +55,12 @@ class FakeColl:
                 str(d.get("_id")) == str(flt.get("_id"))
                 and str(d.get("user_id")) == str(flt.get("user_id"))
             ):
+                original = dict(d)
                 if "$set" in upd and isinstance(upd["$set"], dict):
                     for k, v in upd["$set"].items():
                         d[k] = v
-                # החזר עותק מעודכן (כמו במסדי נתונים אמיתיים)
-                return dict(d)
+                # בהתאם להתנהגות MongoDB: כשהדגל False מחזירים את המסמך הישן
+                return dict(d) if return_document else original
         return None
 
 


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-f21b7f15-4d94-4617-8da7-0b8d419aa5cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f21b7f15-4d94-4617-8da7-0b8d419aa5cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add FakeColl.find_one_and_update to test double for in-memory update and return of the modified document.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a0dc27b0773a99bf1fb29f038e00190cbe043dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->