### PR TITLE
Fix PWA shortcuts and icons

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -16,8 +16,8 @@
           {% if cdn_sri and cdn_sri.fa %}integrity="{{ cdn_sri.fa }}" crossorigin="anonymous" referrerpolicy="no-referrer"{% endif %} />
     <meta id="uiFont" data-scale="{{ '%.2f' % ui_font_scale }}">
 
-    <!-- PWA Manifest -->
-    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <!-- PWA Manifest (cache-busted) -->
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}?v={{ static_version }}">
     <!-- iOS Home Screen Icon -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='icons/apple-touch-icon-180.png') }}">
 


### PR DESCRIPTION
## ✨ תיאור קצר
יישמנו מנגנון cache-busting לקובץ ה-PWA manifest. זה נועד לוודא שעדכונים לקיצורי דרך ואייקונים של PWA (כמו תיקון הנתיב ל-/upload והוספת קיצורים חדשים) יוחלו כראוי בדפדפנים, לאחר שעדכונים קודמים לא נכנסו לתוקף עקב שמירה בקאש.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת לוגיקה ב-`webapp/app.py` לחישוב `static_version` ייחודי (מבוסס משתני סביבה, האש של המניפסט, או חותמת זמן).
- הזרקת `static_version` לכל התבניות דרך `inject_globals`.
- עדכון הקישור ל-`manifest.json` ב-`webapp/templates/base.html` לכלול את `?v={{ static_version }}`.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
  - נדרשת בדיקה ידנית: רענון קשה של ה-PWA בדפדפן (Application > Manifest > Update, או הסרת האפליקציה והתקנה מחדש) כדי לוודא שהקיצורים והאייקונים המעודכנים מופיעים.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: סיכון נמוך. השינוי נועד לשפר את אמינות עדכוני ה-PWA.

## 🔗 קישורים
- Issues קשורים: #
- מסמכים/מפרטים רלוונטיים:
  - ניסיון קודם לתיקון PWA: https://github.com/amirbiron/CodeBot/pull/1098#issue-3561782766

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיטים ב-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-b11aa83b-45c4-4a24-a438-231a2e1f6da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b11aa83b-45c4-4a24-a438-231a2e1f6da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements cache-busting for the PWA manifest by computing a `static_version` (env/app version, manifest hash, or hourly timestamp) and appending it to `manifest.json` URL.
> 
> - **Backend**:
>   - Add `webapp/app.py` helpers `_compute_static_version()` and `_STATIC_VERSION` to derive a short static asset version from `ASSET_VERSION`/`APP_VERSION`, SHA1 of `static/manifest.json`, or an hourly timestamp.
>   - Inject `static_version` into all templates via `inject_globals`.
> - **Templates**:
>   - Update `webapp/templates/base.html` to append `?v={{ static_version }}` to the PWA `manifest.json` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11f50f45fd5d9f6692b09230133bd2b4f2053087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->