### PR TITLE
Fix collections manager reorder items function

### DIFF
--- a/database/collections_manager.py
+++ b/database/collections_manager.py
@@ -482,11 +482,13 @@ class CollectionsManager:
         pos = 1
         for it in new_items:
             try:
-                self.items.update_one(
+                res = self.items.update_one(
                     {"collection_id": cid, "user_id": user_id, "source": it["source"], "file_name": it["file_name"]},
                     {"$set": {"custom_order": pos, "updated_at": _now()}},
                 )
-                pos += 1
+                # advance position only if an item was actually matched/updated
+                if int(getattr(res, "matched_count", 0) or 0) > 0:
+                    pos += 1
             except Exception:
                 continue
 


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-832fccc1-b0fd-46eb-a29c-742b54a9c7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-832fccc1-b0fd-46eb-a29c-742b54a9c7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reimplements `reorder_items` to normalize input, set per-item `custom_order`, and persist the ordered `items` list and `items_count` on the collection without bulk ops.
> 
> - **Collections Manager (`database/collections_manager.py`)**:
>   - **`reorder_items`**:
>     - Normalize incoming `order` into a clean list of `{source, file_name}`.
>     - Update each item's `custom_order` sequentially (no bulk/update_many).
>     - Update collection doc to store ordered `items` and `items_count`; keep `updated_at`.
>     - Return `{ok, updated=len(new_items), items=new_items}` and emit event with the updated count.
>     - Add docstring detailing constraints (FakeDB-compatible, no bulk).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5988bcd746a78c147979b5e79ec82e08c49f2126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->