### PR TITLE
Handle reorder items update errors

### DIFF
--- a/database/collections_manager.py
+++ b/database/collections_manager.py
@@ -527,7 +527,9 @@ class CollectionsManager:
                 error=str(first_error_message or "update_one failed"),
                 handled=True,
             )
-            updated_count = 0
+            # Report how many actually succeeded: pos starts at 1 and
+            # increments only on successful matched updates
+            updated_count = max(0, int(pos - 1))
         else:
             updated_count = len(new_items)
 


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-3c0a7f11-a18a-42d7-811b-e646c960ef79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c0a7f11-a18a-42d7-811b-e646c960ef79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorder now tolerates per-item update failures, emitting `collections_reorder_error` and returning `updated=0`; otherwise emits `collections_reorder` with the actual updated count.
> 
> - **Collections Manager (`database/collections_manager.py`)**:
>   - **Reorder behavior**:
>     - Track per-item `update_one` failures (`had_update_error`, first error message) while continuing updates.
>     - On any failure: emit `collections_reorder_error` with context and set `updated=0`.
>     - On success: set `updated=len(new_items)`.
>     - Always emit `collections_reorder` with the final `updated_count`.
>   - **Resilience**:
>     - Keep best-effort update of collection doc (`items`, `items_count`) without crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1450f94ec66497ed4ad4fb8b0e77721ca3b2043d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->