### PR TITLE
Fix silence creation test failure

### DIFF
--- a/monitoring/silences.py
+++ b/monitoring/silences.py
@@ -28,9 +28,12 @@ def _is_true(val: Optional[str]) -> bool:
 
 
 def _enabled() -> bool:
+    # Explicit enables override the global disable flag used by the test harness
+    if _is_true(os.getenv("ALERTS_DB_ENABLED")) or _is_true(os.getenv("METRICS_DB_ENABLED")):
+        return True
     if _is_true(os.getenv("DISABLE_DB")):
         return False
-    return _is_true(os.getenv("ALERTS_DB_ENABLED")) or _is_true(os.getenv("METRICS_DB_ENABLED"))
+    return False
 
 
 _client = None  # type: ignore


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-8f1a168c-92b8-4d07-b807-ebd916cfbb7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f1a168c-92b8-4d07-b807-ebd916cfbb7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes explicit DB enable flags, allows MongoClient init without MONGODB_URL (with localhost fallback), and adds a `severity` index for `alerts_silences`.
> 
> - **Monitoring/ChatOps silences (`monitoring/silences.py`)**:
>   - **DB enable logic**: Explicit `ALERTS_DB_ENABLED`/`METRICS_DB_ENABLED` now override `DISABLE_DB`; default disabled unless explicitly enabled.
>   - **Mongo init**: Support client creation without `MONGODB_URL` (fallback to default/localhost) with unified `client_kwargs`, improving testability and resilience.
>   - **Indexes**: Add `severity` index alongside TTL on `until_ts`, `pattern`, and `active`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 995eec9b00d20f3a8764b1c67637c81f77fdce88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->