### PR TITLE
Fix metrics view error event emission

### DIFF
--- a/services/webserver.py
+++ b/services/webserver.py
@@ -146,9 +146,24 @@ def create_app() -> web.Application:
             return web.Response(body=payload, headers={"Content-Type": metrics_content_type()})
         except Exception as e:
             logger.error(f"metrics_view error: {e}")
-            # Emit a structured event that tests can monkeypatch easily
+            # Emit a structured event that tests can monkeypatch easily while
+            # still honoring dynamic replacement of observability.emit_event
             try:
-                emit_event("metrics_view_error", "error", error=str(e))  # type: ignore
+                import sys as _sys
+                chosen_emit = None
+                obs = _sys.modules.get("observability")
+                if obs is not None:
+                    cand = getattr(obs, "emit_event", None)
+                    if callable(cand):
+                        chosen_emit = cand
+                if chosen_emit is None:
+                    chosen_emit = emit_event  # type: ignore
+                chosen_emit(
+                    "metrics_view_error",
+                    severity="error",
+                    error_code="E_METRICS_VIEW",
+                    error=str(e),
+                )  # type: ignore
             except Exception:
                 pass
             try:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ae74d3e5-0cbe-49be-a9f2-87eb90270a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae74d3e5-0cbe-49be-a9f2-87eb90270a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces complex dynamic emission logic in metrics_view with a single structured emit_event call while preserving error metrics and 500 response.
> 
> - **Metrics endpoint (`services/webserver.py`)**:
>   - Simplifies error handling in `metrics_view` by removing dynamic emitter selection and calling `emit_event("metrics_view_error", "error", error=...)` directly.
>   - Retains incrementing `errors_total` and returning `500` on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634dd403a3f268847f2a391d46acf801822d1c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->