### PR TITLE
Fix/asyncio resilient event loop policy

### DIFF
--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -367,7 +367,7 @@ def _sanitize_drive_filename_component(text: str) -> str:
         if not isinstance(text, str):
             text = str(text)
         # Replace forbidden/suspicious characters with underscore
-        safe = re.sub(r"[\\/<>:\\"|?*\n\r\t]+", "_", text)
+        safe = re.sub(r'[\\/<>:"|?*\n\r\t]+', "_", text)
         # Collapse consecutive underscores and trim spaces
         safe = re.sub(r"_+", "_", safe).strip().strip("._ ")
         return safe or "file"


### PR DESCRIPTION

טיפלתי בכשל בטסט projections:

מה הבעיה

הטסט מחליף את gds.db ל־SimpleNamespace ללא get_user_files, ובהמשך מזריק sys.modules['database'] = types.SimpleNamespace(db=fake_db). הוא מצפה שהפונקציה תפתור את ה־DB בזמן ריצה דרך import מקומי.
מה שיניתי

הוספתי פונקציה _db_runtime() ב־services/google_drive_service.py שמחזירה את ה־DB בצורה דינמית:
אם gds.db כולל get_user_files – משתמשים בו.
אחרת, מייבא בזמן ריצה את המודול database ולוקח ממנו db (מכבד monkeypatch ב־sys.modules).
עדכנתי את:
create_repo_grouped_zip_bytes להשתמש ב־_db_runtime() ולאסוף קבצים.
create_full_backup_zip_bytes להשתמש ב־_db_runtime() גם ל־get_user_files וגם ל־get_user_large_files.
השארתי את פרוקסי ה־zipfile המקומי כדי למנוע רקורסיה ב־monkeypatch.
השארתי fallback לשם ידידותי אם compute_friendly_name נכשל.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve DB accessor at runtime in Drive service and make ZIP generation resilient with safe fallbacks.
> 
> - **services/google_drive_service.py**:
>   - **DB resolution**: Add `_db_runtime()` to dynamically obtain `db` (prefers module-level `db`, falls back to `database.db`), enabling test monkeypatching.
>   - **Repo ZIPs**: `create_repo_grouped_zip_bytes` now uses `_db_runtime()` to fetch files; adds try/fallback for `compute_friendly_name` to a simple name on error.
>   - **Full backups**: `create_full_backup_zip_bytes` uses `_db_runtime()` for `get_user_files` and `get_user_large_files` with guarded try/except; writes metadata and returns ZIP as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 071f323e1ba5964d6b555948e460487ea8183a46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->