### PR TITLE
Fix grafana annotation test failure

### DIFF
--- a/remediation_manager.py
+++ b/remediation_manager.py
@@ -28,6 +28,13 @@ try:  # optional dependency
 except Exception:  # pragma: no cover
     _http_request = None  # type: ignore
 
+# Prefer a module-level 'requests' attribute so tests can monkeypatch it easily.
+# Import is optional; tests can override 'requests' on this module regardless.
+try:  # optional dependency in runtime; present in project requirements
+    import requests  # type: ignore
+except Exception:  # pragma: no cover
+    requests = None  # type: ignore
+
 def _emit_event(event: str, severity: str = "info", **fields) -> None:
     """Dynamic event emitter to honor test-time monkeypatching.
 
@@ -123,14 +130,34 @@ def _read_incidents(limit: Optional[int] = None) -> List[Dict[str, Any]]:
 def _grafana_annotate(text: str) -> None:
     base = os.getenv("GRAFANA_URL")
     token = os.getenv("GRAFANA_API_TOKEN")
-    if not base or not token or _http_request is None:
+    if not base or not token:
         return
+    url = base.rstrip("/") + "/api/annotations"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {
+        "time": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "tags": ["codebot", "incident"],
+        "text": text,
+    }
+
+    # Best-effort: prefer module-level 'requests' so tests can stub it easily.
     try:
-        url = base.rstrip("/") + "/api/annotations"
-        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-        payload = {"time": int(datetime.now(timezone.utc).timestamp() * 1000), "tags": ["codebot", "incident"], "text": text}
-        _http_request('POST', url, json=payload, headers=headers, timeout=5)
+        req = globals().get("requests", None)
+        if req is not None and hasattr(req, "post"):
+            try:
+                req.post(url, json=payload, headers=headers, timeout=5)
+                return
+            except Exception:
+                # Fall back to http_sync on failure
+                pass
+        # Fallback to pooled http client if available
+        if _http_request is not None:
+            try:
+                _http_request('POST', url, json=payload, headers=headers, timeout=5)
+            except Exception:
+                pass
     except Exception:
+        # Never raise from annotation path
         pass
 
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-366848e1-1437-45ef-a1d9-36a288a9d70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-366848e1-1437-45ef-a1d9-36a288a9d70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Grafana annotation to prefer optional module-level requests with http_sync fallback and safer no-raise behavior.
> 
> - **Grafana annotations**:
>   - Prefer module-level `requests.post` for `/_api/annotations` calls; fallback to `_http_request` if available; never raise on failures.
>   - Remove requirement on `_http_request` presence to attempt annotation.
>   - Add optional module-level `requests` import to ease test monkeypatching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad1151ba56a7822b99cbf16214b81e80af8205c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->