### PR TITLE
Fix pymongo not implemented error

### DIFF
--- a/database/manager.py
+++ b/database/manager.py
@@ -210,6 +210,10 @@ class DatabaseManager:
             if not _MONGO_MONITORING_REGISTERED:
                 try:
                     class _SlowMongoListener(_pymongo_monitoring.CommandListener):  # type: ignore[attr-defined]
+                        def started(self, event):  # type: ignore[override]
+                            # מאזין חובה ב-PyMongo; לא נדרש לנו כלום בשלב ההתחלה
+                            return None
+
                         def succeeded(self, event):  # type: ignore[override]
                             try:
                                 dur_ms = float(getattr(event, 'duration_micros', 0) or 0) / 1000.0
@@ -229,6 +233,10 @@ class DatabaseManager:
                                         pass
                             except Exception:
                                 pass
+
+                        def failed(self, event):  # type: ignore[override]
+                            # מאזין חובה ב-PyMongo; איננו מדווחים כאן כדי להימנע מספאם לוגים
+                            return None
                     _pymongo_monitoring.register(_SlowMongoListener())  # type: ignore[attr-defined]
                     _MONGO_MONITORING_REGISTERED = True
                 except Exception:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-a71028b4-f851-4045-a18f-4ca11744b063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a71028b4-f851-4045-a18f-4ca11744b063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add no-op `started` and `failed` handlers to the `_SlowMongoListener` in `database/manager.py` to satisfy PyMongo’s `CommandListener` interface and avoid NotImplementedError while retaining slow-command logging in `succeeded`.
> 
> - **Database (Mongo monitoring)**:
>   - Update `_SlowMongoListener` in `database/manager.py`:
>     - Add no-op `started(event)` and `failed(event)` to satisfy `CommandListener` requirements and avoid runtime errors/log spam.
>     - Preserve slow-command logging in `succeeded(event)` and one-time listener registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b3d4377cdedeaa4facc96df11fb649f58b835be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->