### PR TITLE
Fix maintenance mode config in tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -890,7 +890,8 @@ class CodeKeeperBot:
         """הגדרת כל ה-handlers של הבוט בסדר הנכון"""
 
         # Maintenance gate: if enabled, short-circuit most interactions
-        if config.MAINTENANCE_MODE:
+        # שימוש ב-getattr עבור תאימות לטסטים שמחליפים את config באובייקט מינימלי
+        if getattr(config, "MAINTENANCE_MODE", False):
             # הגדרת חלון זמן פנימי שבו הודעת תחזוקה פעילה, כך שגם אם מחיקת ה-handlers לא תתבצע
             # ההודעה תיכבה אוטומטית לאחר ה-warmup.
             try:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-df08d334-a5c5-4506-a337-e2679c6682a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df08d334-a5c5-4506-a337-e2679c6682a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces direct access to config.MAINTENANCE_MODE with getattr in main.py to avoid errors with minimal test configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee5590845cea67dc4b0c15a7393dc3264916f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->