### PR TITLE
Add fallback rate limiting and improve admin bypass

### DIFF
--- a/main.py
+++ b/main.py
@@ -992,6 +992,8 @@ class CodeKeeperBot:
                         limit_val = int(getattr(getattr(self, '_rate_limiter', object()), 'max_per_minute', 30) or 30)
                         if not isinstance(local, dict) or (now_ts - float(local.get('start_ts', 0.0) or 0.0)) >= 60.0:
                             local = {'start_ts': now_ts, 'count': 0}
+                            # שמור מיידית את תחילת החלון החדש כדי לא לאבד state גם אם תתרחש חסימה בבקשה הנוכחית
+                            udata['_rl_local'] = local
                         # ספר את הקריאה הנוכחית בחלון הנוכחי
                         next_count = int(local.get('count', 0)) + 1
                         if next_count > limit_val:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a per-user local 60s fallback rate limiter that complements the primary limiter, preserves admin bypass, and refines blocking/warning flow with minor logging/format tweaks.
> 
> - **Rate limiting gate (`main.py`)**:
>   - Add per-user local fallback counter (60s window via `context.user_data`), enforcing `max_per_minute` when primary limiter fails or undercounts.
>   - Preserve and clarify admin bypass; early return for admins.
>   - Combine decisions: `should_block = (not allowed) or blocked_by_local`; send concise block/warn messages.
>   - Adjust advanced limiter shadow-mode logging (no blocking in shadow mode).
>   - Small refactors: safer user extraction, minor comment/log formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4736226886488fce47e9de43e1f76f4715c6fada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->