### PR TITLE
Investigate web app log error

### DIFF
--- a/http_sync.py
+++ b/http_sync.py
@@ -54,6 +54,9 @@ def _create_session() -> requests.Session:
         try:
             retry = Retry(
                 total=retries,
+                connect=retries,
+                read=0,  # do not retry read timeouts to avoid long hangs
+                status=retries,
                 backoff_factor=backoff,
                 status_forcelist=status_forcelist,
                 allowed_methods=allowed,
@@ -63,6 +66,9 @@ def _create_session() -> requests.Session:
             # Older urllib3 uses method_whitelist
             retry = Retry(
                 total=retries,
+                connect=retries,
+                read=0,  # do not retry read timeouts to avoid long hangs
+                status=retries,
                 backoff_factor=backoff,
                 status_forcelist=status_forcelist,
                 method_whitelist=allowed,  # type: ignore[arg-type]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -993,7 +993,8 @@ def _fetch_uptime_from_uptimerobot() -> Optional[Dict[str, Any]]:
             api_key_is_monitor_specific = False
         if UPTIME_MONITOR_ID and not api_key_is_monitor_specific:
             payload['monitors'] = UPTIME_MONITOR_ID
-        resp = http_request('POST', url, data=payload, timeout=10)
+        # שמירה על זמן תגובה קצר בעמוד הבית – timeout אגרסיבי כדי לא לחסום את ה-WSGI
+        resp = http_request('POST', url, data=payload, timeout=3)
         if resp.status_code != 200:
             return None
         body = resp.json() if resp.content else {}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-a765dd64-ad41-4f70-aeea-591d33c222cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a765dd64-ad41-4f70-aeea-591d33c222cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts HTTP retries (no read retries; explicit connect/status retries) and shortens UptimeRobot request timeout to 3s to avoid blocking.
> 
> - **HTTP client (`http_sync.py`)**:
>   - Configure `Retry` with explicit `connect=retries`, `status=retries`, and `read=0` to disable read-timeout retries and reduce hangs (both `allowed_methods` and legacy `method_whitelist` branches).
> - **Web app (`webapp/app.py`)**:
>   - Decrease UptimeRobot API call timeout in `_fetch_uptime_from_uptimerobot` from `10` to `3` seconds to keep homepage responsive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd1ba2993d98fad0e7a9d4684afc4b848784a9b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->