### PR TITLE
Test db and telegram error recovery

### DIFF
--- a/monitoring/log_analyzer.py
+++ b/monitoring/log_analyzer.py
@@ -125,6 +125,19 @@ class LogEventAggregator:
         if g is None:
             g = _Group(category=category, count=0, first_ts=t, last_ts=t)
             self._groups[fp] = g
+        # If the previous alert is in the past and we have lines that arrived during the cooldown,
+        # reset the series so a fresh window starts after cooldown. This prevents a stale first_ts
+        # (set during cooldown) from blocking a new emission after cooldown has elapsed.
+        try:
+            cooldown_sec = max(1, int(self.alerts_cfg.get("cooldown_minutes", 10) or 10)) * 60
+        except Exception:
+            cooldown_sec = 600
+        cooldown_end = (g.last_alert_ts or 0.0) + float(cooldown_sec)
+        if g.last_alert_ts and t >= cooldown_end and g.count > 0 and g.first_ts < cooldown_end:
+            # Drop accumulated state from within the cooldown window
+            g.count = 0
+            g.first_ts = 0.0
+            g.samples.clear()
         # When a new series starts (after previous alert), reset the first_ts to track a fresh window
         if g.count == 0:
             g.first_ts = t


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את הלוגיקה של `LogEventAggregator` כך שלאחר סיום תקופת ה-cooldown, חלון צבירת האירועים יתאפס. זה פותר באג שבו שורות לוג שהגיעו במהלך ה-cooldown "זיהמו" את המונה ומנעו פליטת התראה חדשה גם לאחר שה-cooldown הסתיים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- ב-`monitoring/log_analyzer.py`, נוספה בדיקה לפני הגדלת המונה: אם עבר ה-cooldown מאז ההתראה האחרונה, והחלון הנוכחי התחיל בתוך ה-cooldown, מאפסים את `count`, `first_ts` ו-`samples` כדי להתחיל סדרה חדשה.

## 🧪 בדיקות
- הרצתי ידנית את הטסט `test_aggregator_grouping_and_cooldown` מתוך `tests/test_error_signatures_and_aggregator.py`, והוא עובר כעת.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

### דוגמאות Conventional Commits

| סוג | דוגמה להודעה | מתי להשתמש |
| --- | --- | --- |
| feat | feat: הוספת מסך הגדרות | פיצ'ר חדש למשתמש |
| fix | fix: תיקון קריסה בעת התחברות | תיקון באג מול משתמשים/פרודקשן |
| chore | chore: שדרוג Gradle ל-8.9 | תחזוקה, כלי פיתוח, housekeeping |
| docs | docs: עדכון README עם הוראות התקנה | שינויי תיעוד בלבד |
| refactor | refactor: חילוץ Repository ל-UseCases | שינוי מבני ללא שינוי התנהגות |
| test | test: הוספת בדיקות ל-LoginViewModel | הוספת/עדכון בדיקות |
| build | build: הוספת flavor staging ל-CI | שינויים בבילד/תלויות/תצורה |

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אין סודות/מפתחות בקוד
- [ ] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: הסיכון נמוך. התיקון מתקן התנהגות שגויה של אגרגציה, ויוביל לפליטת התראות כנדרש לאחר סיום cooldown, מה שעשוי להגדיל את כמות ההתראות במקרים ספציפיים בהם הבאג מנע אותן.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע revert לקומיט.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b2bb16f-ebb4-4115-97ed-8c5950b94cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b2bb16f-ebb4-4115-97ed-8c5950b94cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets per-fingerprint series after cooldown so a fresh window starts and alerts can emit again.
> 
> - **Backend — log aggregation (`monitoring/log_analyzer.py`)**:
>   - **Cooldown handling**:
>     - When cooldown has elapsed and the current series started within the cooldown, reset `count`, `first_ts`, and `samples` for the fingerprint to start a fresh window.
>     - Parse `cooldown_minutes` defensively; default to 600s on error.
>   - No API changes; behavior only affects `LogEventAggregator.analyze_line` decision flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b26a907f12653e22c36c7e4ef8c1016b99a3ca6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->