### PR TITLE
Address codebot github issue 1186

### DIFF
--- a/webapp/static/css/multi-select.css
+++ b/webapp/static/css/multi-select.css
@@ -500,6 +500,10 @@
         border-radius: 15px;
         max-width: calc(100% - 2rem);
     }
+
+    body.multi-select-active .file-card {
+        padding-left: 3.25rem;
+    }
     
     .bulk-actions-toolbar.hidden {
         transform: translateY(150px);
@@ -543,6 +547,12 @@
     }
     
     /* במובייל נשמור על אותה לוגיקה של מצב מרובה */
+}
+
+@media (max-width: 1024px) and (min-width: 769px) {
+    body.multi-select-active .file-card {
+        padding-left: 3rem;
+    }
 }
 
 /* הבטחה שכפתור הטוגל "בחירה מרובה" לא יחרוג שמאלה */

--- a/webapp/static/js/collections.js
+++ b/webapp/static/js/collections.js
@@ -155,11 +155,11 @@
         await renderCollectionItems(cid);
       });
       if (deleteBtn) deleteBtn.addEventListener('click', async () => {
-        if (!confirm('למחוק את האוסף? פעולה זו תסיר גם את הפריטים המשויכים.')) return;
+        if (!confirm('למחוק את האוסף? הפעולה תסיר את האוסף ואת הקישורים שבו, אבל הקבצים עצמם יישארו זמינים בבוט ובקבצים.')) return;
         const res = await api.deleteCollection(cid);
         if (!res || !res.ok) return alert((res && res.error) || 'שגיאה במחיקה');
         ensureCollectionsSidebar();
-        container.innerHTML = '<div class="empty">האוסף נמחק</div>';
+        container.innerHTML = '<div class="empty">האוסף נמחק. הקבצים נשארים זמינים בבוט ובמסך הקבצים.</div>';
       });
 
       // Items actions (remove, open, pin)
@@ -172,9 +172,13 @@
         // Remove item
         const rm = ev.target.closest('.remove');
         if (rm) {
+          if (!confirm('להסיר את הפריט מהאוסף? הקובץ עצמו יישאר זמין בבוט ובמסך הקבצים.')) return;
           const res = await api.removeItems(cid, [{source, file_name: name}]);
           if (!res || !res.ok) return alert((res && res.error) || 'שגיאה במחיקה');
           row.remove();
+          if (!itemsContainer.querySelector('.collection-item')) {
+            itemsContainer.innerHTML = '<div class="empty">אין פריטים</div>';
+          }
           return;
         }
 

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -205,38 +205,45 @@
 }
 #md-content .md-copy-btn {
   position: absolute;
-  top: 12px;
-  left: 12px;
-  padding: 8px 10px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  top: 10px;
+  left: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.95);
+  color: #1f2937;
+  border: 1px solid rgba(209, 213, 219, 0.9);
   border-radius: 6px;
   cursor: pointer;
-  transition: all 0.2s ease;
-  backdrop-filter: blur(8px);
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
   z-index: 2;
 }
 #md-content .md-copy-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.4);
+  background: #f6f8fa;
+  border-color: rgba(148, 163, 184, 0.9);
+  transform: translateY(-1px);
 }
 #md-content .md-copy-btn.copied {
-  background: rgba(76, 175, 80, 0.3);
-  border-color: rgba(76, 175, 80, 0.6);
+  background: #28a745;
+  border-color: #28a745;
+  color: #ffffff;
 }
 #md-content .md-copy-btn.copy-error {
-  background: rgba(220, 38, 38, 0.25);
-  border-color: rgba(220, 38, 38, 0.55);
+  background: #fee2e2;
+  border-color: #ef4444;
+  color: #991b1b;
 }
 #md-content .md-copy-btn::before {
-  content: "";
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2'%3E%3Crect x='9' y='9' width='13' height='13' rx='2'/%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-  vertical-align: middle;
+  content: none;
+}
+#md-content .md-copy-btn .copy-icon {
+  font-size: 1rem;
+}
+#md-content .md-copy-btn .copied-text {
+  font-weight: 500;
 }
 #md-content code:not(pre code) {
   background: #f3f4f6;            /* אפור בהיר עם ניגודיות טובה על לבן */

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -121,6 +121,14 @@
     flex: 1;
 }
 
+.file-description {
+    margin: 1rem 0;
+    opacity: 0.9;
+    font-size: 1.1rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+}
+
 .file-actions {
     display: flex;
     gap: 1rem;
@@ -224,6 +232,27 @@
         flex-direction: column;
     }
 
+    .file-title {
+        font-size: clamp(1.05rem, 6vw, 1.35rem);
+        white-space: normal;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+
+    .file-description {
+        font-size: clamp(0.95rem, 4.8vw, 1.05rem);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+
     .file-actions {
         width: 100%;
         justify-content: stretch;
@@ -239,7 +268,6 @@
         padding: 0.75rem !important;
     }
     .file-icon { font-size: 2rem; }
-    .file-title { font-size: 1.25rem; }
     .highlighttable td.linenos { width: 2.8rem; }
     .main-content > .container { padding-left: 10px; padding-right: 10px; }
 }
@@ -285,7 +313,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
         </div>
         
         {% if file.description %}
-        <p style="margin: 1rem 0; opacity: 0.9; font-size: 1.1rem;">{{ file.description }}</p>
+        <p class="file-description">{{ file.description }}</p>
         {% endif %}
         
         {% if file.tags %}


### PR DESCRIPTION
<ul>
  <li>עדכון ההודעות והאישורים במסך "האוספים שלי" כך שמחיקת אוסף או פריט תבהיר שהקבצים נשארים זמינים בבוט ובמסך הקבצים.</li>
  <li>החזרת עיצוב כפתורי "העתק" בבלוקי קוד לעיצוב הפשוט והבהיר שהתקיים בעבר.</li>
  <li>הוספת ריווח נוסף לכרטיסי הקבצים במצב בחירה מרובה, כדי שכפתורי הפעולה לא ייכנסו מתחת לצ׳קבוקסים בטאבלט.</li>
  <li>התאמת תצוגת כותרת ותיאור הקובץ במסך "צפה בקוד" במובייל: כיווץ אוטומטי ושתי שורות לכל היותר ללא גלישה.</li>
</ul>


---
<a href="https://cursor.com/background-agent?bcId=bc-0c0d4026-f625-4868-b12b-8d442b2f6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c0d4026-f625-4868-b12b-8d442b2f6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves collections interactions and messages, modernizes the Markdown copy button styling, and enhances mobile/tablet layouts for file view and multi-select.
> 
> - **UI/UX**:
>   - **Collections (`webapp/static/js/collections.js`)**:
>     - Clarify delete/remove confirmations (files remain available) and empty-state after last item removal.
>     - Enable opening a file by clicking item name/row; add `openFileByName` helper.
>   - **Markdown Preview (`webapp/templates/md_preview.html`)**:
>     - Restyle `.md-copy-btn` (layout, colors, hover/active/error states); switch from `::before` icon to inline `.copy-icon`/`.copied-text` spans.
>   - **File View (`webapp/templates/view_file.html`)**:
>     - Add `.file-description` class and use it instead of inline style; mobile truncation for title/description.
>   - **Multi-select CSS (`webapp/static/css/multi-select.css`)**:
>     - Add left padding to `.file-card` in multi-select mode on mobile/tablet breakpoints for checkbox space.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 090c5ceb9cc890260384b4df1e546e2893fd2267. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->