### PR TITLE
test: align webapp button text expectation

### DIFF
--- a/tests/test_conversation_handlers_extra.py
+++ b/tests/test_conversation_handlers_extra.py
@@ -144,7 +144,7 @@ async def test_file_menu_includes_webapp_button(monkeypatch):
     rm = captured.get('reply_markup')
     assert isinstance(rm, _Markup)
     web_btn = rm.keyboard[1][0]
-    assert web_btn.text == "?? ????? ?WebApp"
+    assert web_btn.text == "🌐 צפייה בWebApp"
     assert web_btn.url == "https://code-keeper-webapp.onrender.com/file/OID42"
 
 
@@ -179,5 +179,5 @@ async def test_file_menu_webapp_button_search_fallback(monkeypatch):
     rm = captured.get('reply_markup')
     assert isinstance(rm, _Markup)
     web_btn = rm.keyboard[1][0]
-    assert web_btn.text == "?? ????? ?WebApp"
+    assert web_btn.text == "🌐 צפייה בWebApp"
     assert web_btn.url == "https://code-keeper-webapp.onrender.com/files?q=noid.txt#results"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update tests to expect the WebApp button label "🌐 צפייה בWebApp".
> 
> - **Tests**:
>   - Update expected `web_btn.text` to "🌐 צפייה בWebApp" in `tests/test_conversation_handlers_extra.py` for:
>     - `test_file_menu_includes_webapp_button`
>     - `test_file_menu_webapp_button_search_fallback`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e182f23db30da72d0e4a697d52d4aa6ca12e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->