### PR TITLE
Fix attribute error in github gist integration

### DIFF
--- a/integrations.py
+++ b/integrations.py
@@ -21,15 +21,27 @@ from config import config
 
 logger = logging.getLogger(__name__)
 
+
+def _get_github_token() -> Optional[str]:
+    """השג את טוקן ה-GitHub בצורה חסינה גם כשאין שדה על האובייקט."""
+
+    token = getattr(config, "GITHUB_TOKEN", None)
+    if token:
+        return token
+    # תאימות לאחור: ייתכן שטסטים מזריקים רק משתני סביבה ללא שדה בקונפיג
+    return os.getenv("GITHUB_TOKEN")
+
+
 class GitHubGistIntegration:
     """אינטגרציה עם GitHub Gist"""
     
     def __init__(self):
         self.github = None
         self.user = None
-        if config.GITHUB_TOKEN:
+        token = _get_github_token()
+        if token:
             try:
-                self.github = Github(config.GITHUB_TOKEN)
+                self.github = Github(token)
                 self.user = self.github.get_user()
                 logger.info(f"התחבר ל-GitHub בתור: {self.user.login}")
             except GithubException as e:
@@ -477,9 +489,10 @@ class GitRepositoryIntegration:
     
     def __init__(self):
         self.github = None
-        if config.GITHUB_TOKEN:
+        token = _get_github_token()
+        if token:
             try:
-                self.github = Github(config.GITHUB_TOKEN)
+                self.github = Github(token)
             except Exception as e:
                 logger.error(f"שגיאה בהתחברות ל-GitHub: {e}")
     


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-426101c1-1e46-4b74-95e8-64bc6f49e575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-426101c1-1e46-4b74-95e8-64bc6f49e575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a safe `_get_github_token` and use it in Gist and Git repository integrations to prevent attribute errors and support env var fallback.
> 
> - **Integrations**:
>   - **Token handling**:
>     - Add `_get_github_token` to retrieve `GITHUB_TOKEN` from `config` or `os.getenv` as fallback.
>   - **GitHub Gist**:
>     - Update `GitHubGistIntegration.__init__` to use `_get_github_token` instead of directly accessing `config.GITHUB_TOKEN`.
>   - **Git Repositories**:
>     - Update `GitRepositoryIntegration.__init__` to use `_get_github_token` for initializing `Github` client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c96d7290a9cfaf2b8d793da8fb22b0e6819c0987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->