### PR TITLE
Fix pastebin api key attribute error

### DIFF
--- a/integrations.py
+++ b/integrations.py
@@ -32,6 +32,16 @@ def _get_github_token() -> Optional[str]:
     return os.getenv("GITHUB_TOKEN")
 
 
+def _get_pastebin_api_key() -> Optional[str]:
+    """השג את מפתח ה-API של Pastebin גם כשאין שדה ישיר על האובייקט."""
+
+    api_key = getattr(config, "PASTEBIN_API_KEY", None)
+    if api_key:
+        return api_key
+    # תאימות לאחור: תמיכה בטסטים שמגדירים רק משתנה סביבה
+    return os.getenv("PASTEBIN_API_KEY")
+
+
 class GitHubGistIntegration:
     """אינטגרציה עם GitHub Gist"""
     
@@ -230,7 +240,7 @@ class PastebinIntegration:
     """אינטגרציה עם Pastebin"""
     
     def __init__(self):
-        self.api_key = config.PASTEBIN_API_KEY
+        self.api_key = _get_pastebin_api_key()
         self.base_url = "https://pastebin.com/api"
         
     def is_available(self) -> bool:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-08ea7998-980d-4152-8120-9ab5b01d699c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08ea7998-980d-4152-8120-9ab5b01d699c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `_get_pastebin_api_key` with env fallback and switch `PastebinIntegration` to use it to prevent attribute errors.
> 
> - **Integrations**:
>   - **Pastebin**:
>     - Add `_get_pastebin_api_key` to fetch `PASTEBIN_API_KEY` from `config` or `os.environ`.
>     - Update `PastebinIntegration.__init__` to use the new helper instead of direct `config` access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a836750d8f4ac10b6c0898f2276869227190d58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->