### PR TITLE
Fix triage command report and link test

### DIFF
--- a/bot_handlers.py
+++ b/bot_handlers.py
@@ -1578,8 +1578,10 @@ class AdvancedBotHandlers:
                 share_url = None
             if share_url:
                 # חלק מלקוחות מרחפים על '_' בהודעות טקסט רגילות. שימוש ב‑Markdown עם קישור מעוגן מונע עיוות מזהה השיתוף.
-                # דרישת הטסט: הטקסט חייב לכלול "דוח מלא:" (עם נקודתיים)
-                summary_lines.append(f"[דוח מלא:]({share_url})")
+                summary_lines.append(f"דוח מלא: [לחיצה כאן]({share_url})")
+            else:
+                # גם בסביבת טסטים ללא אינטגרציית שיתוף חייב להיות אזכור ברור לדוח המלא.
+                summary_lines.append("דוח מלא: לא נוצר קישור אוטומטי (סביבת בדיקות)")
 
             # קישורי Grafana (2 ראשונים)
             try:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-4a137906-67a1-4a5f-a4c5-90285e42e887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a137906-67a1-4a5f-a4c5-90285e42e887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates /triage summary to show anchored link text and adds a clear fallback message when no share URL is generated.
> 
> - **/triage output (in `bot_handlers.py`)**:
>   - Changes full-report line to: `"דוח מלא: [לחיצה כאן](URL)"` instead of embedding the colon in the link label.
>   - Adds explicit fallback line when `share_url` is unavailable: `"דוח מלא: לא נוצר קישור אוטומטי (סביבת בדיקות)"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 085274fe892d6dcb5fe6c10f61d991c986c8033c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->