### PR TITLE
Fix google drive client id attribute error

### DIFF
--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -89,9 +89,9 @@ def poll_device_token(device_code: str) -> Optional[Dict[str, Any]]:
     """
     client_id = getattr(config, "GOOGLE_CLIENT_ID", None)
     if not client_id:
-        logging.getLogger(__name__).warning("Drive OAuth client id missing; continuing with empty id")
+        raise RuntimeError("GOOGLE_CLIENT_ID is not set")
     payload = {
-        "client_id": client_id or "",
+        "client_id": client_id,
         "device_code": device_code,
         "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
     }

--- a/tests/test_google_drive_service.py
+++ b/tests/test_google_drive_service.py
@@ -75,6 +75,7 @@ def test_compute_friendly_name_increments_and_flags(monkeypatch):
 
 def test_poll_device_token_pending_error_and_success(monkeypatch):
     gds = _import_module_fresh("services.google_drive_service")
+    gds.config.GOOGLE_CLIENT_ID = "cid"
 
     # pending path
     monkeypatch.setattr(gds, "requests", SimpleNamespace(post=lambda *a, **k: _fake_response(400, {"error": "authorization_pending"})))


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-c685ef72-9e6b-4434-adb6-2af1be2283b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c685ef72-9e6b-4434-adb6-2af1be2283b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely access Google OAuth client credentials via getattr and add fallbacks/warnings in device flow and credential creation.
> 
> - **Google Drive OAuth** (`services/google_drive_service.py`):
>   - **Device Authorization**: Read `config.GOOGLE_CLIENT_ID` via `getattr`, validate presence, and use local `client_id` in payload.
>   - **Token Polling**: Use optional `client_id` (warn if missing) and allow empty value in payload; continue including `client_secret` when configured.
>   - **Credentials Construction**: Build `Credentials` with optional `client_id`/`client_secret` fetched via `getattr`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b08987d3994d6275d5d975e374dfd0aa648443ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->