### PR TITLE
Fix google drive scope formatting in test

### DIFF
--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -52,7 +52,14 @@ def start_device_authorization(user_id: int) -> Dict[str, Any]:
         raise RuntimeError("GOOGLE_CLIENT_ID is not set")
     scopes = getattr(config, "GOOGLE_OAUTH_SCOPES", DEFAULT_GOOGLE_OAUTH_SCOPES) or DEFAULT_GOOGLE_OAUTH_SCOPES
     if isinstance(scopes, (list, tuple, set)):
-        scope_str = " ".join(str(s).strip() for s in scopes if str(s).strip()) or DEFAULT_GOOGLE_OAUTH_SCOPES
+        cleaned_scopes = []
+        for scope in scopes:
+            if scope is None:
+                continue
+            scope_text = str(scope).strip()
+            if scope_text:
+                cleaned_scopes.append(scope_text)
+        scope_str = " ".join(cleaned_scopes) or DEFAULT_GOOGLE_OAUTH_SCOPES
     else:
         scope_str = str(scopes).strip() or DEFAULT_GOOGLE_OAUTH_SCOPES
     payload = {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-e848fd7c-5a93-43be-a09b-2dee22fe7dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e848fd7c-5a93-43be-a09b-2dee22fe7dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden scope string construction in `services/google_drive_service.py` to ignore `None` and empty entries when building Google OAuth Device flow payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29d2f00949d4fc6c5751c64633b5c426244e2510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->