### PR TITLE
Fix session instrumentation attribute error

### DIFF
--- a/http_async.py
+++ b/http_async.py
@@ -106,7 +106,10 @@ def _instrument_session(session: "aiohttp.ClientSession") -> None:  # type: igno
     if getattr(session, "_codebot_ctx_headers", False):
         return
 
-    original_request = session._request  # type: ignore[attr-defined]
+    original_request = getattr(session, "_request", None)  # type: ignore[attr-defined]
+    if original_request is None or not callable(original_request):
+        # אין לנו מה לעטוף אם המופע לא תומך ב-request פנימי (במוקים מסוימים)
+        return
 
     async def _request(method: str, url: str, **kwargs):  # type: ignore[override]
         try:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-f2240cd0-993d-4a3a-bb9a-3e7a77c8a014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2240cd0-993d-4a3a-bb9a-3e7a77c8a014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make aiohttp session instrumentation robust by safely accessing `_request` and skipping wrapping when unavailable to avoid attribute errors.
> 
> - **http_async.py**:
>   - Instrumentation: use `getattr(session, "_request", None)` and check `callable` before wrapping; early-return if unavailable.
>   - Prevents errors when sessions/mocks lack internal `'_request'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d30e9243db7bef9989f601fcbff427e5ad5ad2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->