### PR TITLE
Fix maintenance handler registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -960,7 +960,16 @@ class CodeKeeperBot:
 
         # Maintenance gate: if enabled, short-circuit most interactions
         # שימוש ב-getattr עבור תאימות לטסטים שמחליפים את config באובייקט מינימלי
-        if getattr(config, "MAINTENANCE_MODE", False):
+        maintenance_flag_raw = getattr(config, "MAINTENANCE_MODE", False)
+        try:
+            if isinstance(maintenance_flag_raw, str):
+                maintenance_flag = maintenance_flag_raw.strip().lower() in {"1", "true", "yes", "on"}
+            else:
+                maintenance_flag = bool(maintenance_flag_raw)
+        except Exception:
+            maintenance_flag = False
+
+        if maintenance_flag:
             # הגדרת חלון זמן פנימי שבו הודעת תחזוקה פעילה, כך שגם אם מחיקת ה-handlers לא תתבצע
             # ההודעה תיכבה אוטומטית לאחר ה-warmup.
             try:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-39a3331a-d3f2-4e12-b218-06d9d2585c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39a3331a-d3f2-4e12-b218-06d9d2585c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parse `MAINTENANCE_MODE` from bool or common string values with safe fallback before enabling maintenance handlers.
> 
> - **Maintenance gate**:
>   - Parse `config.MAINTENANCE_MODE` robustly, accepting bool or strings like `"1"`, `"true"`, `"yes"`, `"on"` (case/whitespace-insensitive), with error-safe fallback to `False`.
>   - Proceed with existing maintenance handler setup and warmup window only when the parsed flag is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc4253c3087ec316ff37111df74cd5c946569e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->