### PR TITLE
Fix maintenance mode config test

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -1,10 +1,50 @@
+"""Stub config module לטסטים שמדמה קריאה מה-ENV ללא תלות ב-pydantic."""
+
+from __future__ import annotations
+
+import os
+
+
+_DEFAULT_MAINTENANCE_MESSAGE = (
+    "🚀 אנחנו מעלים עדכון חדש!\nהבוט יחזור לפעול ממש בקרוב (1 - 3 דקות)"
+)
+
+
+def _coerce_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if not normalized:
+        return default
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _coerce_int(value: str | None, default: int) -> int:
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
 class _Cfg:
-    SENTRY_DSN = ""
-    ENVIRONMENT = "test"
-    RECYCLE_TTL_DAYS = 7
-    MAX_CODE_SIZE = 100_000
-    MAINTENANCE_MODE = False
-    MAINTENANCE_MESSAGE = "🚀 אנחנו מעלים עדכון חדש!\nהבוט יחזור לפעול ממש בקרוב (1 - 3 דקות)"
-    MAINTENANCE_AUTO_WARMUP_SECS = 30
+    def __init__(self) -> None:
+        self.SENTRY_DSN = ""
+        self.ENVIRONMENT = os.getenv("ENVIRONMENT", "test")
+        self.RECYCLE_TTL_DAYS = _coerce_int(os.getenv("RECYCLE_TTL_DAYS"), 7)
+        self.MAX_CODE_SIZE = _coerce_int(os.getenv("MAX_CODE_SIZE"), 100_000)
+        self.MAINTENANCE_MODE = _coerce_bool(os.getenv("MAINTENANCE_MODE"), False)
+        self.MAINTENANCE_MESSAGE = os.getenv(
+            "MAINTENANCE_MESSAGE", _DEFAULT_MAINTENANCE_MESSAGE
+        )
+        self.MAINTENANCE_AUTO_WARMUP_SECS = _coerce_int(
+            os.getenv("MAINTENANCE_AUTO_WARMUP_SECS"), 30
+        )
+
 
 config = _Cfg()


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-619bafe6-5856-4658-91c6-3b6c9a967328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-619bafe6-5856-4658-91c6-3b6c9a967328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace static test config with ENV-driven stub using bool/int coercion and a default maintenance message.
> 
> - **Tests**:
>   - **Config stub overhaul (`tests/config.py`)**:
>     - Add `dcoerce_bool` and `dcoerce_int` helpers for robust ENV parsing.
>     - Change `dCfg` to initialize from ENV (`ENVIRONMENT`, `RECYCLE_TTL_DAYS`, `MAX_CODE_SIZE`, `MAINTENANCE_MODE`, `MAINTENANCE_MESSAGE`, `MAINTENANCE_AUTO_WARMUP_SECS`).
>     - Introduce `_DEFAULT_MAINTENANCE_MESSAGE`; set `config = _Cfg()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc982a898a18ebf4216e87a301fd21cbcf41b2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->