### PR TITLE
Fix webapp login test failure

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -299,24 +299,27 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     user_stats.log_user(user_id, username)
     # אם המשתמש הגיע עם פרמטר webapp_login — צור ושלח קישור התחברות אישי ל-Web App
     if _is_webapp_login_requested(update, context):
-        payload = _build_webapp_login_payload(db, user_id, username)
-        if payload is not None:
-            message = getattr(update, "message", None)
-            reply_fn = getattr(message, "reply_text", None) if message is not None else None
-            if callable(reply_fn):
-                reply_markup = _build_webapp_login_markup(payload["webapp_url"], payload["login_url"])
-                await reply_fn(
-                    "🔐 <b>קישור התחברות אישי ל-Web App</b>\n\n"
-                    "לחץ על הכפתור למטה כדי להתחבר:\n\n"
-                    "⚠️ <i>הקישור תקף ל-5 דקות בלבד מטעמי אבטחה</i>",
-                    reply_markup=reply_markup,
-                    parse_mode=ParseMode.HTML,
-                )
-                try:
-                    reporter.report_activity(user_id)
-                except Exception:
-                    pass
-                return ConversationHandler.END
+        try:
+            payload = _build_webapp_login_payload(db, user_id, username)
+            if payload is not None:
+                message = getattr(update, "message", None)
+                reply_fn = getattr(message, "reply_text", None) if message is not None else None
+                if callable(reply_fn):
+                    reply_markup = _build_webapp_login_markup(payload["webapp_url"], payload["login_url"])
+                    await reply_fn(
+                        "🔐 <b>קישור התחברות אישי ל-Web App</b>\n\n"
+                        "לחץ על הכפתור למטה כדי להתחבר:\n\n"
+                        "⚠️ <i>הקישור תקף ל-5 דקות בלבד מטעמי אבטחה</i>",
+                        reply_markup=reply_markup,
+                        parse_mode=ParseMode.HTML,
+                    )
+                    try:
+                        reporter.report_activity(user_id)
+                    except Exception:
+                        pass
+                    return ConversationHandler.END
+        except Exception:
+            logger.exception("webapp_login_flow_failed", exc_info=True)
     safe_user_name = html_escape(user_name) if user_name else ""
     from i18n.strings_he import MESSAGES
     welcome_text = MESSAGES["welcome"].format(name=safe_user_name)


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-2d416151-24ae-472b-9f59-888ddb79c762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d416151-24ae-472b-9f59-888ddb79c762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors WebApp login handling in `start_command` to use new helper utilities for detecting requests, generating/persisting short-lived tokens, and sending login markup.
> 
> - **WebApp login flow (Telegram bot)**:
>   - Add helpers: `_coerce_command_args`, `_is_webapp_login_requested`, `_persist_webapp_login_token`, `_build_webapp_login_payload`, `_build_webapp_login_markup`.
>   - Generate SHA-256 auth token with multiple secret fallbacks; persist to `db.webapp_tokens` with 5‑minute expiry; construct `login_url`/`webapp_url` using `_resolve_webapp_base_url`.
>   - Update `start_command` to use helpers for detecting `webapp_login`, replying with inline buttons, and reporting activity.
>   - Minor: import `hashlib`, `time`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5c2089b9c909ebc71c9d4846af2dc541ff87688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->