### PR TITLE
Complete remaining connection pooling tasks

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,6 +81,16 @@ class BotConfig(BaseSettings):
     MONGODB_APPNAME: Optional[str] = Field(
         default=None, description="MongoDB appName client metadata"
     )
+    MONGODB_COMPRESSORS: Optional[str] = Field(
+        default=None,
+        description="Comma-separated compressor names supported by server (e.g., zstd,snappy,zlib)",
+    )
+    MONGODB_HEARTBEAT_FREQUENCY_MS: int = Field(
+        default=10_000,
+        ge=1000,
+        le=600_000,
+        description="Server monitor heartbeat frequency in milliseconds",
+    )
 
     # Cache/Redis
     REDIS_URL: Optional[str] = Field(default=None, description="Redis URL")
@@ -114,6 +124,44 @@ class BotConfig(BaseSettings):
         ge=1,
         le=300,
         description="Default total timeout (seconds) for aiohttp client sessions",
+    )
+    AIOHTTP_LIMIT_PER_HOST: int = Field(
+        default=25,
+        ge=0,
+        le=10_000,
+        description="Per-host connection limit for aiohttp TCPConnector (0 = unlimited)",
+    )
+
+    # HTTP client pooling/timeouts (requests)
+    REQUESTS_POOL_CONNECTIONS: int = Field(
+        default=20,
+        ge=1,
+        le=10_000,
+        description="HTTPAdapter pool_connections for requests.Session",
+    )
+    REQUESTS_POOL_MAXSIZE: int = Field(
+        default=100,
+        ge=1,
+        le=100_000,
+        description="HTTPAdapter pool_maxsize for requests.Session",
+    )
+    REQUESTS_TIMEOUT: float = Field(
+        default=8.0,
+        ge=0.1,
+        le=600.0,
+        description="Default timeout (seconds) for requests.Session operations",
+    )
+    REQUESTS_RETRIES: int = Field(
+        default=2,
+        ge=0,
+        le=10,
+        description="Number of retry attempts for transient HTTP errors (if supported)",
+    )
+    REQUESTS_RETRY_BACKOFF: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=60.0,
+        description="Exponential backoff factor between retries for requests",
     )
 
     # Rate limiting

--- a/database/manager.py
+++ b/database/manager.py
@@ -260,6 +260,27 @@ class DatabaseManager:
             if appname:
                 kwargs["appname"] = appname
 
+            # דחיסה (compressors) — רשימת קומפרסורים מופרדת בפסיקים
+            try:
+                compressors_raw = (
+                    getattr(config, "MONGODB_COMPRESSORS", None)
+                    or os.getenv("MONGODB_COMPRESSORS", "")
+                )
+                if compressors_raw:
+                    compressors_list = [c.strip() for c in str(compressors_raw).split(",") if c and str(c).strip()]
+                    if compressors_list:
+                        kwargs["compressors"] = compressors_list
+            except Exception:
+                pass
+
+            # heartbeatFrequencyMS — תדירות דופק השרת
+            try:
+                hb = int(getattr(config, "MONGODB_HEARTBEAT_FREQUENCY_MS", 10_000))
+                if hb and hb > 0:
+                    kwargs["heartbeatFrequencyMS"] = hb
+            except Exception:
+                pass
+
             mongo_url = getattr(config, "MONGODB_URL", None) or os.getenv("MONGODB_URL")
             if not mongo_url:
                 raise RuntimeError("MONGODB_URL is not configured")

--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -112,8 +112,8 @@ def poll_device_token(device_code: str) -> Optional[Dict[str, Any]]:
     # Include client_secret if configured to satisfy clients that require it
     if getattr(config, "GOOGLE_CLIENT_SECRET", None):
         payload["client_secret"] = config.GOOGLE_CLIENT_SECRET  # type: ignore[index]
-    # Use module-level requests so tests can monkeypatch gds.requests.post
-    resp = requests.post(TOKEN_URL, data=payload, timeout=20)
+    # Use pooled HTTP client (http_sync); tests can monkeypatch gds.http_request
+    resp = http_request('POST', TOKEN_URL, data=payload, timeout=20)
     if resp.status_code >= 400:
         # Try to parse structured OAuth error
         try:

--- a/tests/test_google_drive_service.py
+++ b/tests/test_google_drive_service.py
@@ -78,19 +78,19 @@ def test_poll_device_token_pending_error_and_success(monkeypatch):
     gds.config.GOOGLE_CLIENT_ID = "cid"
 
     # pending path
-    monkeypatch.setattr(gds, "requests", SimpleNamespace(post=lambda *a, **k: _fake_response(400, {"error": "authorization_pending"})))
+    monkeypatch.setattr(gds, "http_request", lambda method, url, **kw: _fake_response(400, {"error": "authorization_pending"}))
     res = gds.poll_device_token("dc")
     assert res is None
 
     # user-facing error path
-    monkeypatch.setattr(gds, "requests", SimpleNamespace(post=lambda *a, **k: _fake_response(400, {"error": "access_denied", "error_description": "Denied"})))
+    monkeypatch.setattr(gds, "http_request", lambda method, url, **kw: _fake_response(400, {"error": "access_denied", "error_description": "Denied"}))
     res = gds.poll_device_token("dc")
     assert isinstance(res, dict) and res.get("error") == "access_denied"
 
     # success path
     fixed_dt = datetime(2025, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
     monkeypatch.setattr(gds, "_now_utc", lambda: fixed_dt, raising=True)
-    monkeypatch.setattr(gds, "requests", SimpleNamespace(post=lambda *a, **k: _fake_response(200, {"access_token": "x", "expires_in": 3600, "scope": "s"})))
+    monkeypatch.setattr(gds, "http_request", lambda method, url, **kw: _fake_response(200, {"access_token": "x", "expires_in": 3600, "scope": "s"}))
     res = gds.poll_device_token("dc")
     assert isinstance(res, dict) and res.get("access_token") == "x" and "expiry" in res
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ffbdd1f8-2755-4614-9f6b-7a79ead6d3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffbdd1f8-2755-4614-9f6b-7a79ead6d3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds config for MongoDB compressors/heartbeat and HTTP client pooling/retries, wires them into MongoClient, and switches Drive token polling to a pooled HTTP client with tests updated.
> 
> - **Config** (`config.py`):
>   - Add MongoDB options: `MONGODB_COMPRESSORS`, `MONGODB_HEARTBEAT_FREQUENCY_MS`.
>   - Add aiohttp option: `AIOHTTP_LIMIT_PER_HOST`.
>   - Add requests pooling/timeouts/retries: `REQUESTS_POOL_CONNECTIONS`, `REQUESTS_POOL_MAXSIZE`, `REQUESTS_TIMEOUT`, `REQUESTS_RETRIES`, `REQUESTS_RETRY_BACKOFF`.
> - **Database** (`database/manager.py`):
>   - Pass `compressors` and `heartbeatFrequencyMS` to `MongoClient` from config/env.
> - **Google Drive** (`services/google_drive_service.py`):
>   - Switch `poll_device_token` to use pooled `http_sync.request` (`http_request`) instead of `requests.post`.
> - **Tests** (`tests/test_google_drive_service.py`):
>   - Update monkeypatch targets to `http_request` for token polling paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bc3918ac1abbc3072d17b2a9fd75f98f6fdbe7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->