### PR TITLE
Restore sticky note pinning behavior and button color

### DIFF
--- a/webapp/static/js/sticky-notes.js
+++ b/webapp/static/js/sticky-notes.js
@@ -174,7 +174,6 @@
       try {
         const isMobile = (typeof window !== 'undefined') && ((window.matchMedia && window.matchMedia('(max-width: 480px)').matches) || (window.innerWidth <= 480));
         const currentLine = this._currentVisibleLine();
-        const nearest = this._nearestAnchor();
         const payload = {
           content: '',
           // הנחתה קלה למובייל כדי למנוע קפיצה עם הופעת מקלדת
@@ -182,8 +181,9 @@
           size: { width: isMobile ? 200 : 260, height: isMobile ? 160 : 200 },
           color: '#FFFFCC',
           line_start: Number.isInteger(currentLine) ? currentLine : null,
-          anchor_id: (currentLine ? '' : (nearest && nearest.id ? nearest.id : undefined)),
-          anchor_text: (currentLine ? undefined : (nearest && nearest.text ? nearest.text : undefined))
+          // חזרה להתנהגות הישנה: ללא עיגון לכותרות כברירת מחדל
+          anchor_id: '',
+          anchor_text: undefined
         };
         const resp = await fetch(`/api/sticky-notes/${encodeURIComponent(this.fileId)}`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload)
@@ -488,36 +488,11 @@
     _toggleAnchor(el){
       try {
         if (!el) return;
-        const entry = this._getEntry(el);
-        const data = entry && entry.data;
-        const isPinned = this._isPinned(el);
-        const hasHeaderAnchor = data && data.anchor_id && data.anchor_id !== PIN_SENTINEL;
-        if (isPinned) {
+        if (this._isPinned(el)) {
           this._unpinNote(el);
           return;
         }
-        if (hasHeaderAnchor) {
-          // remove header anchoring -> floating
-          data.anchor_id = '';
-          data.anchor_text = '';
-          if (el.dataset) { delete el.dataset.anchorId; }
-          this._applyPositionMode(el, data, { reflow: true });
-          this._queueSave(el, { anchor_id: null, anchor_text: null });
-          this._flushFor(el);
-          return;
-        }
-        // try anchor to nearest header
-        const nearest = this._nearestAnchor();
-        if (nearest && nearest.id) {
-          data.anchor_id = String(nearest.id);
-          data.anchor_text = String(nearest.text || '');
-          this._applyPositionMode(el, data, { reflow: false });
-          this._updateAnchoredNotePosition(el, data);
-          this._queueSave(el, { anchor_id: data.anchor_id, anchor_text: data.anchor_text });
-          this._flushFor(el);
-          return;
-        }
-        // fallback: pin to absolute position
+        // חזרה להתנהגות הישנה: נעיצה מיידית למיקום מוחלט
         this._pinNote(el);
       } catch(e) {
         console.warn('sticky note: toggle pin failed', e);


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-b2572ee1-ebdb-49ad-92f3-9a563c424b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2572ee1-ebdb-49ad-92f3-9a563c424b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores legacy sticky-note behavior: new notes aren’t header-anchored by default, and pin toggle immediately pins/unpins to absolute position.
> 
> - **Frontend (`webapp/static/js/sticky-notes.js`)**:
>   - **Note creation**: Remove nearest-header anchoring; set `anchor_id: ''` and `anchor_text: undefined` by default.
>   - **Pin toggle**: Simplify `_toggleAnchor` to only unpin if already pinned, otherwise pin to absolute via `_pinNote`; remove header-anchoring flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06cb664356ac28de3b27cb1ba991cff84b442713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->