### PR TITLE
Fix pinned note jumping behavior

### DIFF
--- a/webapp/static/js/sticky-notes.js
+++ b/webapp/static/js/sticky-notes.js
@@ -173,14 +173,13 @@
     async createNote(){
       try {
         const isMobile = (typeof window !== 'undefined') && ((window.matchMedia && window.matchMedia('(max-width: 480px)').matches) || (window.innerWidth <= 480));
-        const currentLine = this._currentVisibleLine();
         const payload = {
           content: '',
           // הנחתה קלה למובייל כדי למנוע קפיצה עם הופעת מקלדת
           position: { x: isMobile ? 80 : 120, y: window.scrollY + (isMobile ? 80 : 120) },
           size: { width: isMobile ? 200 : 260, height: isMobile ? 160 : 200 },
           color: '#FFFFCC',
-          line_start: Number.isInteger(currentLine) ? currentLine : null,
+          line_start: null,
           // חזרה להתנהגות הישנה: ללא עיגון לכותרות כברירת מחדל
           anchor_id: '',
           anchor_text: undefined
@@ -321,6 +320,8 @@
           el.style.top = targetY + 'px';
           el.dataset.pinned = 'true';
           if (el.dataset && el.dataset.anchorId) { delete el.dataset.anchorId; }
+          if (el.dataset && el.dataset.anchorLine) { delete el.dataset.anchorLine; }
+          if (el.dataset && el.dataset.relYOffset) { delete el.dataset.relYOffset; }
         } else if (isAnchored) {
           el.classList.add('is-pinned');
           el.classList.remove('is-floating');
@@ -378,8 +379,14 @@
       entry.data.size = payload.size;
       entry.data.anchor_id = PIN_SENTINEL;
       entry.data.anchor_text = '';
+      entry.data.line_start = null;
+      entry.data.line_end = null;
+      if (el.dataset) {
+        if (el.dataset.anchorLine) { delete el.dataset.anchorLine; }
+        if (el.dataset.relYOffset) { delete el.dataset.relYOffset; }
+      }
       this._applyPositionMode(el, entry.data, { reflow: false });
-      const requestPayload = Object.assign({}, payload, { anchor_id: PIN_SENTINEL, anchor_text: null });
+      const requestPayload = Object.assign({}, payload, { anchor_id: PIN_SENTINEL, anchor_text: null, line_start: null, line_end: null });
       this._queueSave(el, requestPayload);
       this._flushFor(el);
     }
@@ -392,9 +399,14 @@
       entry.data.size = payload.size;
       entry.data.anchor_id = '';
       entry.data.anchor_text = '';
+      entry.data.line_start = null;
+      entry.data.line_end = null;
       if (el.dataset && el.dataset.pinned) { delete el.dataset.pinned; }
+      if (el.dataset && el.dataset.anchorId) { delete el.dataset.anchorId; }
+      if (el.dataset && el.dataset.anchorLine) { delete el.dataset.anchorLine; }
+      if (el.dataset && el.dataset.relYOffset) { delete el.dataset.relYOffset; }
       this._applyPositionMode(el, entry.data, { reflow: true });
-      this._queueSave(el, Object.assign({}, payload, { anchor_id: null, anchor_text: null }));
+      this._queueSave(el, Object.assign({}, payload, { anchor_id: null, anchor_text: null, line_start: null, line_end: null }));
       this._flushFor(el);
     }
 


### PR DESCRIPTION
<p><strong>What</strong>: מנעתי שליחת <code>line_start</code> כברירת מחדל וודאתי שנעיצה/ביטול נעיצה מאפסים עוגנים כדי שהפתק יישאר במקום שלו.</p>
<p><strong>Why</strong>: לפתור את הקפיצה לראש המסמך אחרי נעיצה ולהחזיר את ההתנהגות הישנה.</p>
<p><strong>Tests</strong>: בדקתי ידנית בדפדפן - נעיצה, ביטול נעיצה וריענון עמוד.</p>
<p><strong>Docs</strong>: לא עיינתי מחדש ב-<a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener">CodeBot – Project Docs</a>.</p>

<a href="https://cursor.com/background-agent?bcId=bc-f7ebabba-ca5c-4130-86d9-49e0eb2c76b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7ebabba-ca5c-4130-86d9-49e0eb2c76b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents pinned notes from jumping by disabling line anchoring on create and clearing anchor-related state on pin/unpin, including updating save payloads.
> 
> - **Sticky Notes (frontend)**:
>   - Disable automatic line anchoring on note creation (`line_start: null`).
>   - When pinning/unpinning:
>     - Clear `line_start`/`line_end` and remove `data-anchorLine`/`data-relYOffset`/`data-anchorId` as appropriate.
>     - Include `line_start: null`/`line_end: null` in save payloads and preserve `anchor_id` semantics.
>   - In position application for pinned notes, remove lingering anchor-related dataset fields to avoid jumpy behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82286daccfff31457f863a1c2fd2910f94f9d277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->