### PR TITLE
Address github issue 1282 and comments

### DIFF
--- a/database/collections_manager.py
+++ b/database/collections_manager.py
@@ -44,7 +44,8 @@ except Exception:  # pragma: no cover
 
 
 ALLOWED_ICONS: List[str] = [
-    "📂","📘","🎨","🧩","🐛","⚙️","📝","🧪","💡","⭐","🔖","🚀"
+    "📂","📘","🎨","🧩","🐛","⚙️","📝","🧪","💡","⭐","🔖","🚀",
+    "🖥️","💼","🖱️","⌨️","📱","💻","🖨️","📊","📈","📉","🔧","🛠️"
 ]
 COLLECTION_COLORS: List[str] = [
     "blue","green","purple","orange","red","teal","pink","yellow"
@@ -119,6 +120,38 @@ class CollectionsManager:
                 IndexModel([("collection_id", ASCENDING), ("custom_order", ASCENDING), ("pinned", DESCENDING)], name="order_pin"),
                 IndexModel([("user_id", ASCENDING)], name="by_user"),
             ])
+        except Exception:
+            pass
+
+    def ensure_default_collections(self, user_id: int) -> None:
+        """מאבטח יצירה של אוספים מובנים עבור משתמש חדש."""
+        try:
+            uid = int(user_id)
+        except Exception:
+            return
+
+        try:
+            existing = self.collections.find_one({
+                "user_id": uid,
+                "name": "שולחן עבודה",
+            })
+        except Exception:
+            existing = None
+
+        if existing:
+            return
+
+        try:
+            self.create_collection(
+                user_id=uid,
+                name="שולחן עבודה",
+                description="קבצים שאני עובד עליהם כרגע",
+                mode="manual",
+                icon="🖥️",
+                color="purple",
+                is_favorite=True,
+                sort_order=-1,
+            )
         except Exception:
             pass
 

--- a/scripts/migrate_workspace_collections.py
+++ b/scripts/migrate_workspace_collections.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""מיגרציה: יצירת אוסף "שולחן עבודה" לכל משתמש קיים.
+
+הרצה:
+    python scripts/migrate_workspace_collections.py
+
+הסקריפט בטוח להרצה מספר פעמים – הוא מדלג על משתמשים שכבר יש להם את האוסף.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from database.collections_manager import CollectionsManager
+
+
+log = logging.getLogger(__name__)
+
+
+def migrate_existing_users() -> None:
+    """יוצר אוסף "שולחן עבודה" לכל המשתמשים שחסר להם."""
+    try:
+        from webapp.app import get_db  # import מקומי כדי להימנע מתלות מעגלית בזמן build
+    except Exception as exc:  # pragma: no cover - קלט שגוי במיגרציה
+        raise RuntimeError("לא ניתן לייבא את get_db מ-webapp.app") from exc
+
+    db = get_db()
+    manager = CollectionsManager(db)
+
+    users_cursor = db.users.find({}, {"user_id": 1})  # type: ignore[attr-defined]
+    created_count = 0
+    checked_count = 0
+
+    for raw_user in users_cursor:
+        user_id = _safe_int((raw_user or {}).get("user_id"))
+        if user_id is None:
+            continue
+        checked_count += 1
+
+        existing = db.user_collections.find_one({  # type: ignore[attr-defined]
+            "user_id": user_id,
+            "name": "שולחן עבודה",
+        })
+        if existing:
+            continue
+
+        result = manager.create_collection(
+            user_id=user_id,
+            name="שולחן עבודה",
+            description="קבצים שאני עובד עליהם כרגע",
+            mode="manual",
+            icon="🖥️",
+            color="purple",
+            is_favorite=True,
+            sort_order=-1,
+        )
+
+        if result.get("ok"):
+            created_count += 1
+            log.info("✓ נוצר אוסף שולחן עבודה למשתמש %s", user_id)
+        else:
+            log.warning(
+                "✗ כשל ביצירת אוסף למשתמש %s: %s",
+                user_id,
+                result.get("error", "unknown error"),
+            )
+
+    log.info("✅ מיגרציה הושלמה: נוצרו %s אוספים חדשים (מתוך %s משתמשים)", created_count, checked_count)
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        migrate_existing_users()
+    except Exception as exc:
+        log.exception("❌ המיגרציה נכשלה")
+        raise SystemExit(1) from exc
+    raise SystemExit(0)

--- a/tests/test_collections_manager_unit.py
+++ b/tests/test_collections_manager_unit.py
@@ -143,6 +143,25 @@ def mgr() -> CollectionsManager:
     return CollectionsManager(FakeDB())
 
 
+def test_ensure_default_collections_creates_once(mgr: CollectionsManager):
+    mgr.ensure_default_collections(42)
+    first = mgr.list_collections(42)
+    assert first["ok"]
+    collections = first["collections"]
+    assert any(col["name"] == "שולחן עבודה" for col in collections)
+    workspace = next(col for col in collections if col["name"] == "שולחן עבודה")
+    assert workspace["is_favorite"] is True
+    assert workspace["sort_order"] == -1
+    assert workspace["icon"] == "🖥️"
+    assert workspace["color"] == "purple"
+
+    count_before = len(collections)
+    mgr.ensure_default_collections(42)
+    second = mgr.list_collections(42)
+    assert second["ok"]
+    assert len(second["collections"]) == count_before
+
+
 def test_create_update_delete_list_get_collection(mgr: CollectionsManager):
     # create
     res = mgr.create_collection(user_id=1, name="Favorites", description="desc", mode="manual")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2284,6 +2284,11 @@ def telegram_auth():
             )
         except Exception:
             pass
+        try:
+            from database.collections_manager import CollectionsManager
+            CollectionsManager(db).ensure_default_collections(user_id)
+        except Exception:
+            pass
     session['user_id'] = user_id
     session['user_data'] = {
         'id': user_id,
@@ -2356,6 +2361,11 @@ def token_auth():
                 },
                 upsert=True,
             )
+        except Exception:
+            pass
+        try:
+            from database.collections_manager import CollectionsManager
+            CollectionsManager(db).ensure_default_collections(int(user_id))
         except Exception:
             pass
         

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -267,6 +267,49 @@
         .btn-secondary:hover {
             background: rgba(255, 255, 255, 0.2);
         }
+
+        .workspace-btn {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border: none;
+            position: relative;
+            color: white;
+        }
+
+        .workspace-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+        }
+
+        .collection-option {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin: 0.25rem 0;
+        }
+
+        .collection-option input[type="radio"] {
+            flex: 0 0 auto;
+        }
+
+        .workspace-collection-option {
+            margin: 0.5rem 0;
+            padding: 0.5rem;
+            background: rgba(102, 126, 234, 0.1);
+            border-radius: 8px;
+            border: 1px solid rgba(102, 126, 234, 0.3);
+        }
+
+        .workspace-collection-option span {
+            font-weight: 600;
+        }
+
+        .collection-option-divider {
+            margin: 0.75rem 0 0.5rem;
+            font-size: 0.85rem;
+            color: #666;
+            border-top: 1px solid #ddd;
+            padding-top: 0.5rem;
+        }
         
         .btn-icon {
             display: inline-flex;
@@ -928,6 +971,29 @@
             if (modal) modal.remove();
         }
 
+        async function navigateToWorkspace() {
+            try {
+                const res = await fetch('/api/collections?limit=100');
+                if (!res.ok) {
+                    throw new Error('HTTP ' + res.status);
+                }
+                const data = await res.json();
+                if (!data || !data.ok) {
+                    throw new Error((data && data.error) || 'שגיאה בטעינת אוספים');
+                }
+                const collections = Array.isArray(data.collections) ? data.collections : [];
+                const workspace = collections.find(c => c && c.name === 'שולחן עבודה');
+                if (workspace && workspace.id) {
+                    window.location.href = `/collections/${workspace.id}`;
+                    return;
+                }
+                alert('אוסף שולחן עבודה לא נמצא');
+            } catch (err) {
+                console.error('Error navigating to workspace:', err);
+                alert('שגיאה בטעינת שולחן העבודה');
+            }
+        }
+
         function getFileIcon(language) {
             const icons = {
                 'python': '🐍',
@@ -1009,6 +1075,40 @@
         // Add to Collection modal helpers
         function getLastCollectionId(){ try { return localStorage.getItem('last_collection_id') || ''; } catch(_) { return ''; } }
         function setLastCollectionId(id){ try { localStorage.setItem('last_collection_id', String(id||'')); } catch(_) {} }
+        function renderCollectionOptions(collections, lastSelected){
+            const list = Array.isArray(collections) ? collections : [];
+            const lastIdStr = String(lastSelected || '').trim();
+            const hasLast = lastIdStr && list.some(c => c && c.id !== undefined && String(c.id) === lastIdStr);
+            const workspace = list.find(c => c && c.name === 'שולחן עבודה' && c.id);
+            const others = list.filter(c => c && c.name !== 'שולחן עבודה' && c.id);
+
+            let selected = hasLast ? lastIdStr : '';
+            if (!selected && workspace && workspace.id) {
+                selected = String(workspace.id);
+            }
+
+            let html = '';
+            if (workspace && workspace.id) {
+                const isSelected = selected === String(workspace.id);
+                html += `<label class="collection-option workspace-collection-option"><input type="radio" name="collectionId" value="${workspace.id}" ${isSelected ? 'checked' : ''}><span>🖥️ ${escapeHtml(workspace.name || '')}</span></label>`;
+                if (others.length > 0) {
+                    html += '<div class="collection-option-divider">אוספים אחרים:</div>';
+                }
+            }
+
+            html += others.map(col => {
+                if (!col || col.id === undefined) {
+                    return '';
+                }
+                const isSelected = selected === String(col.id);
+                return `<label class="collection-option"><input type="radio" name="collectionId" value="${col.id}" ${isSelected ? 'checked' : ''}><span>${escapeHtml(col.name || '')}</span></label>`;
+            }).join('');
+
+            if (!html) {
+                return '<div class="empty">אין אוספים. צור אוסף חדש במסך "האוספים שלי"</div>';
+            }
+            return html;
+        }
         window.openAddToCollectionModal = async function(fileName){
             const modal = document.getElementById('addToCollectionModal');
             const body = document.getElementById('addToCollectionBody');
@@ -1019,8 +1119,7 @@
               const data = await res.json();
               if (!data || !data.ok) throw new Error(data && data.error || 'שגיאה');
               const last = getLastCollectionId();
-              const items = (data.collections||[]).map(c => `<label style="display:flex;align-items:center;gap:.5rem;margin:.25rem 0;"><input type="radio" name="collectionId" value="${c.id}" ${String(c.id)===String(last)?'checked':''}><span>${escapeHtml(c.name||'')}</span></label>`).join('');
-              body.innerHTML = items || '<div class="empty">אין אוספים. צור אוסף חדש במסך "האוספים שלי"</div>';
+              body.innerHTML = renderCollectionOptions(data.collections, last);
             } catch (e) {
               body.innerHTML = '<div class="error">שגיאה בטעינת אוספים</div>';
             }
@@ -1037,8 +1136,7 @@
               const data = await res.json();
               if (!data || !data.ok) throw new Error(data && data.error || 'שגיאה');
               const last = getLastCollectionId();
-              const items = (data.collections||[]).map(c => `<label style="display:flex;align-items:center;gap:.5rem;margin:.25rem 0;"><input type="radio" name="collectionId" value="${c.id}" ${String(c.id)===String(last)?'checked':''}><span>${escapeHtml(c.name||'')}</span></label>`).join('');
-              body.innerHTML = items || '<div class="empty">אין אוספים. צור אוסף חדש במסך "האוספים שלי"</div>';
+              body.innerHTML = renderCollectionOptions(data.collections, last);
             } catch (e) {
               body.innerHTML = '<div class="error">שגיאה בטעינת אוספים</div>';
             }

--- a/webapp/templates/collections.html
+++ b/webapp/templates/collections.html
@@ -7,13 +7,13 @@
 {% endblock %}
 
 {% block content %}
-<div class="collections-layout">
-  <aside class="collections-sidebar">
-    <div id="collectionsSidebar"></div>
-  </aside>
-  <section class="collections-content" id="collectionsContent">
-    <div class="empty">בחר אוסף בצד שמאל כדי לצפות בפריטים</div>
-  </section>
+  <div class="collections-layout">
+    <aside class="collections-sidebar">
+      <div id="collectionsSidebar"></div>
+    </aside>
+    <section class="collections-content" id="collectionsContent">
+      <div class="empty">בחר אוסף כדי לצפות בפריטים</div>
+    </section>
 </div>
 {% endblock %}
 

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -135,6 +135,10 @@
         <i class="fas fa-star"></i>
         מועדפים
     </a>
+      <a href="#" onclick="navigateToWorkspace(); return false;" class="btn btn-secondary btn-icon workspace-btn">
+          <i class="fas fa-desktop"></i>
+          שולחן עבודה
+      </a>
     <a href="/files?category=large#results" class="btn {% if category_filter == 'large' %}btn-primary{% else %}btn-secondary{% endif %} btn-icon">
         <i class="fas fa-weight-hanging"></i>
         קבצים גדולים


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>הרחבת <code>ALLOWED_ICONS</code> והוספת <code>ensure_default_collections</code> כך שאוסף "שולחן עבודה" ייווצר אוטומטית לכל משתמש חדש (כולל איקון 🖥️, צבע <code>purple</code>, <code>is_favorite</code> ו-<code>sort_order=-1</code>).</li>
  <li>קריאה ל-<code>ensure_default_collections</code> במסלולי ההתחברות (Telegram/token) כדי להבטיח יצירה גם בקוד הצד השרת.</li>
  <li>עדכון ממשק הווב: כפתור קבוע ל"שולחן עבודה", הדגשת האוסף במודלים “הוסף לאוסף”/“הוסף לאוסף (מרובה)”, ועיצוב יעודי ב-CSS.</li>
  <li>שינוי הטקסט במסך “האוספים שלי” ל“בחר אוסף כדי לצפות בפריטים”.</li>
  <li>סקריפט מיגרציה חדש (<code>scripts/migrate_workspace_collections.py</code>) ליצירת האוסף למשתמשים קיימים.</li>
  <li>טסט יחידה חדש שמוודא שהאוסף המובנה נוצר פעם אחת בלבד ושומר על מאפייניו.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>האישו ביקש אוסף קבוע, מודגש ונגיש, כדי לאפשר למשתמשים לסמן במהירות קבצים פעילים (“שולחן עבודה”).</li>
  <li>התגובות דרשו להסיר Badge מהכפתור ולהחליף את ההנחיה במסך “האוספים שלי” – העדכונים הללו נכנסו בהתאם.</li>
  <li>הסקריפט מאפשר ליישר קו עם משתמשים קיימים בלי פעולה ידנית.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>לא הורצו טסטים בסביבה הנוכחית – <code>python3 -m pytest tests/test_collections_manager_unit.py</code> נכשל כי pytest לא מותקן במכונה. מומלץ להריץ לוקלית לאחר התקנת <code>pytest</code>.</li>
</ul>

<h2>Docs</h2>
<ul>
  <li>עיינתי ב-<a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a>.</li>
  <li>שקול להוסיף עמוד תיעוד קצר על האוסף החדש במידת הצורך (לא בוצע במסגרת PR זה).</li>
</ul>

<a href="https://cursor.com/background-agent?bcId=bc-e3593f1f-bc5e-45d1-ba91-80e103c99eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3593f1f-bc5e-45d1-ba91-80e103c99eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a default “Workspace” collection per user (created on login and via migration), expands icons, and updates UI for quick navigation and smarter add-to-collection selection, with unit tests.
> 
> - **Collections/Backend**:
>   - Add `CollectionsManager.ensure_default_collections(user_id)` to create a built-in `"שולחן עבודה"` collection (favorite, sort `-1`, icon `🖥️`, color `purple`).
>   - Call on auth flows in `webapp/app.py` to auto-provision for new logins.
>   - Expand `ALLOWED_ICONS` with additional device/tool emojis.
> - **Migration**:
>   - New script `scripts/migrate_workspace_collections.py` to backfill the `"שולחן עבודה"` collection for existing users (idempotent).
> - **UI**:
>   - Add `navigateToWorkspace()` in `webapp/templates/base.html` and a "שולחן עבודה" button in `webapp/templates/files.html` for quick access.
>   - Improve "Add to Collection" modal: highlight/select Workspace first via `renderCollectionOptions` and new styles.
>   - Minor copy tweak in `webapp/templates/collections.html`.
> - **Tests**:
>   - Add unit test `test_ensure_default_collections_creates_once` in `tests/test_collections_manager_unit.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ed2f9cf4fe5a3c5aa47cec67b6fb544111b911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->