### PR TITLE
Address codebot github issue 1319

### DIFF
--- a/webapp/static/css/collections.css
+++ b/webapp/static/css/collections.css
@@ -38,7 +38,9 @@
 .share-controls{display:flex;align-items:center;gap:.4rem;background:#f8fafc;border:1px solid #e5e7eb;border-radius:8px;padding:.25rem .5rem}
 .share-controls .share-toggle{display:flex;align-items:center;gap:.25rem;font-size:.85rem;white-space:nowrap}
 .share-controls .share-toggle input{margin:0}
-.share-controls .share-copy{padding:.25rem .5rem;font-size:.85rem}
+.share-controls .share-divider{color:#94a3b8;font-size:.85rem;line-height:1}
+.share-controls .share-copy{display:inline-flex;align-items:center;gap:.2rem;padding:.25rem .5rem;font-size:.85rem;white-space:nowrap}
+.share-controls .share-copy__text{line-height:1}
 .collection-item{
   display:flex;
   align-items:flex-start;
@@ -72,11 +74,14 @@
 
 @media(max-width:640px){
   .collection-header{grid-template-columns:1fr;justify-items:stretch}
-  .collection-header .title,
-  .collection-header .share-controls,
-  .collection-header .actions{justify-self:stretch}
-  .collection-header .share-controls{justify-content:space-between}
-  .collection-header .actions{justify-content:flex-start}
+  .collection-header .title{justify-self:stretch}
+  .collection-header .share-controls{justify-self:flex-start;justify-content:flex-start;padding:.2rem .4rem;gap:.3rem;max-width:100%}
+  .collection-header .actions{justify-self:stretch;justify-content:flex-start}
+}
+@media(max-width:480px){
+  .collection-header .share-controls{padding:.18rem .35rem;gap:.25rem}
+  .collection-header .share-copy{padding:.2rem .4rem;font-size:.8rem}
+  .collection-header .share-divider{font-size:.8rem}
 }
 .collection-item{cursor:pointer}
 .collection-item .drag{cursor:grab}

--- a/webapp/static/js/collections.js
+++ b/webapp/static/js/collections.js
@@ -42,7 +42,10 @@
     },
   };
 
-  const ALLOWED_ICONS = ["📂","📘","🎨","🧩","🐛","⚙️","📝","🧪","💡","⭐","🔖","🚀"];
+  const ALLOWED_ICONS = [
+    "📂","📘","🎨","🧩","🐛","⚙️","📝","🧪","💡","⭐","🔖","🚀",
+    "🖥️","💼","🖱️","⌨️","📱","💻","🖨️","📊","📈","📉","🔧","🛠️"
+  ];
 
   const resolvedFileIdCache = new Map();
 
@@ -376,30 +379,33 @@
             <button class="remove" title="הסר">✕</button>
           </div>
         `).join('');
-        const iconChar = (col.icon && ALLOWED_ICONS.includes(col.icon)) ? col.icon : (ALLOWED_ICONS[0] || '📂');
-        const share = col.share || {};
-        const shareEnabled = !!share.enabled;
-        const shareUrl = resolvePublicUrl(col);
-        container.innerHTML = `
-          <div class="collection-header">
-            <div class="title">
-              <button class="collection-icon-btn" type="button" aria-label="בחר אייקון" title="בחר אייקון">${escapeHtml(iconChar)}</button>
-              <div class="name" title="${escapeHtml(col.name || 'ללא שם')}">${escapeHtml(col.name || 'ללא שם')}</div>
+          const iconChar = (col.icon && ALLOWED_ICONS.includes(col.icon)) ? col.icon : (ALLOWED_ICONS[0] || '📂');
+          const share = col.share || {};
+          const shareEnabled = !!share.enabled;
+          const shareUrl = resolvePublicUrl(col);
+          container.innerHTML = `
+            <div class="collection-header">
+              <div class="title">
+                <button class="collection-icon-btn" type="button" aria-label="בחר אייקון" title="בחר אייקון">${escapeHtml(iconChar)}</button>
+                <div class="name" title="${escapeHtml(col.name || 'ללא שם')}">${escapeHtml(col.name || 'ללא שם')}</div>
+              </div>
+              <div class="share-controls" data-enabled="${shareEnabled ? '1' : '0'}">
+                <label class="share-toggle">
+                  <input type="checkbox" class="share-enabled" ${shareEnabled ? 'checked' : ''}>
+                  <span class="share-toggle__text">שיתוף</span>
+                </label>
+                <span class="share-divider" aria-hidden="true">|</span>
+                <button class="btn btn-secondary btn-sm share-copy" ${shareEnabled && shareUrl ? '' : 'disabled'} data-url="${shareUrl ? escapeHtml(shareUrl) : ''}" title="העתק קישור לשיתוף" aria-label="העתק קישור לשיתוף">
+                  <span class="share-copy__text">העתק</span>
+                </button>
+              </div>
+              <div class="actions">
+                <button class="btn btn-secondary rename">שנה שם</button>
+                <button class="btn btn-danger delete">מחק</button>
+              </div>
             </div>
-            <div class="share-controls" data-enabled="${shareEnabled ? '1' : '0'}">
-              <label class="share-toggle">
-                <input type="checkbox" class="share-enabled" ${shareEnabled ? 'checked' : ''}>
-                <span>שיתוף</span>
-              </label>
-              <button class="btn btn-secondary btn-sm share-copy" ${shareEnabled && shareUrl ? '' : 'disabled'} data-url="${shareUrl ? escapeHtml(shareUrl) : ''}">העתק קישור</button>
-            </div>
-            <div class="actions">
-              <button class="btn btn-secondary rename">שנה שם</button>
-              <button class="btn btn-danger delete">מחק</button>
-            </div>
-          </div>
-          <div class="collection-items" id="collectionItems">${itemsHtml || '<div class="empty">אין פריטים</div>'}</div>
-        `;
+            <div class="collection-items" id="collectionItems">${itemsHtml || '<div class="empty">אין פריטים</div>'}</div>
+          `;
 
         const iconBtn = container.querySelector('.collection-icon-btn');
         if (iconBtn) {
@@ -421,13 +427,14 @@
             }
           });
         }
-
-        const shareControls = container.querySelector('.share-controls');
-        const shareToggleEl = shareControls ? shareControls.querySelector('.share-enabled') : null;
-        const shareCopyBtn = shareControls ? shareControls.querySelector('.share-copy') : null;
-        if (shareCopyBtn && !shareCopyBtn.dataset.label) {
-          shareCopyBtn.dataset.label = shareCopyBtn.textContent || 'העתק קישור';
-        }
+          const shareControls = container.querySelector('.share-controls');
+          const shareToggleEl = shareControls ? shareControls.querySelector('.share-enabled') : null;
+          const shareCopyBtn = shareControls ? shareControls.querySelector('.share-copy') : null;
+          const shareCopyLabel = shareCopyBtn ? shareCopyBtn.querySelector('.share-copy__text') : null;
+          if (shareCopyBtn && !shareCopyBtn.dataset.label) {
+            const labelText = shareCopyLabel ? shareCopyLabel.textContent : shareCopyBtn.textContent;
+            shareCopyBtn.dataset.label = labelText && labelText.trim() ? labelText.trim() : 'העתק';
+          }
         setShareControlsBusy(shareToggleEl, shareCopyBtn, false);
 
         if (shareCopyBtn) {
@@ -437,24 +444,40 @@
               alert('אין קישור שיתוף פעיל');
               return;
             }
-            const original = shareCopyBtn.dataset.label || shareCopyBtn.textContent || 'העתק קישור';
+            const original = shareCopyBtn.dataset.label || (shareCopyLabel ? shareCopyLabel.textContent : '') || 'העתק';
             try {
               if (navigator.clipboard && navigator.clipboard.writeText) {
                 await navigator.clipboard.writeText(url);
               } else {
                 throw new Error('clipboard_unavailable');
               }
-              shareCopyBtn.textContent = 'הועתק!';
+              if (shareCopyLabel) {
+                shareCopyLabel.textContent = 'הועתק!';
+              } else {
+                shareCopyBtn.textContent = 'הועתק!';
+              }
               setTimeout(() => {
-                shareCopyBtn.textContent = original;
+                if (shareCopyLabel) {
+                  shareCopyLabel.textContent = original;
+                } else {
+                  shareCopyBtn.textContent = original;
+                }
               }, 1600);
             } catch (_err) {
               try {
                 const manual = prompt('העתק את הקישור הבא:', url);
                 if (manual !== null) {
-                  shareCopyBtn.textContent = 'הועתק!';
+                  if (shareCopyLabel) {
+                    shareCopyLabel.textContent = 'הועתק!';
+                  } else {
+                    shareCopyBtn.textContent = 'הועתק!';
+                  }
                   setTimeout(() => {
-                    shareCopyBtn.textContent = original;
+                    if (shareCopyLabel) {
+                      shareCopyLabel.textContent = original;
+                    } else {
+                      shareCopyBtn.textContent = original;
+                    }
                   }, 1600);
                 }
               } catch (_) {


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>הבטחת יצירה אוטומטית של אוסף “שולחן עבודה” לכל משתמש קיים או חדש, כולל ניקוי קאש רלוונטי בעת יצירה.</li>
  <li>רענון Endpoint רשימת האוספים כדי שיוודא קיום האוסף ויעקוף תגובות מקאש ישן (החלפת prefix ל־collections_list:v2).</li>
  <li>שיפור כפתור “שיתוף | העתק” ב־UI: טקסט מלא גם במובייל, מבנה חוזר עם מחיצה אנכית, ורוחב קומפקטי במסכים צרים.</li>
  <li>הרחבת מערך האייקונים בצד ה־frontend כך שיתאם לרשימת ALLOWED_ICONS שבשרת.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>משתמשים קיימים לא קיבלו את אוסף “שולחן עבודה” לאחר הדפלוי הראשון, בגלל קאש ישן ורישום חד־פעמי במהלך ההתחברות בלבד.</li>
  <li>כפתור השיתוף איבד את הטקסט “העתק” והיה רחב מדי בנייד, מה שפגע בשימושיות.</li>
  <li>ה־PR הקודם הרחיב את רשימת האייקונים בשרת בלבד, ולכן הבחירה ב־UI לא עודכנה בהתאם.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>❌ <code>python3 -m pytest</code> – נכשל כי המודול pytest לא מותקן בסביבה (‎<code>No module named pytest</code>)</li>
</ul>

<p>קראתי את התיעוד ב-<a href="https://amirbiron.github.io/CodeBot/" target="_blank" rel="noopener noreferrer">CodeBot – Project Docs</a>.</p>

<a href="https://cursor.com/background-agent?bcId=bc-65715e21-046f-40a9-8502-7c4bb1446084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65715e21-046f-40a9-8502-7c4bb1446084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-creates the default “שולחן עבודה” collection, migrates collections list caching to v2 with proper invalidation, and polishes share controls UI/responsiveness while expanding allowed icons.
> 
> - **Backend**:
>   - **Default collection bootstrap**: `CollectionsManager.ensure_default_collections` now returns `bool` and, on creation, invalidates related caches (`collections_list`, `collections_list:v2`, `collections_detail`, `collections_items`).
>   - **Collections list caching**: `GET /api/collections` switches to `@dynamic_cache` key prefix `collections_list:v2`; create/update/delete endpoints now also invalidate `collections_list:v2`.
>   - **Auto-create workspace on list**: `list_collections` ensures the default "שולחן עבודה" exists (retry if missing) before returning results; attaches `public_url`/`public_api_url` when share is enabled.
> - **Frontend/UI**:
>   - **Share controls**: Refined markup and copy behavior (inline label, divider, ARIA labels, disabled states, resilient clipboard fallback).
>   - **Responsive tweaks**: Improved layout for `.collection-header .share-controls` on small screens.
>   - **Icons**: Expanded `ALLOWED_ICONS` with additional tech/workspace emojis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3761d36bcb9154513e235f950f6aac3894ed596d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->