### PR TITLE
Fix/span attrs validation

### DIFF
--- a/services/code_service.py
+++ b/services/code_service.py
@@ -126,7 +126,10 @@ def validate_code_input(code: str, file_name: str, user_id: int) -> Tuple[bool, 
             - cleaned_code: הקוד המנוקה
             - error_message: הודעת שגיאה (אם יש)
     """
-    code_length = int(len(code or ""))
+    try:
+        code_length = int(len(code or ""))
+    except TypeError:
+        code_length = 0
     try:
         set_current_span_attributes({
             "code.length": code_length,
@@ -145,13 +148,18 @@ def validate_code_input(code: str, file_name: str, user_id: int) -> Tuple[bool, 
     # אין לבצע נרמול חוזר שעלול לקצץ רווחי סוף שורה במסמכי Markdown.
     # אם בפועל נדרש נרמול נוסף בעתיד, יש להעביר דגלים תואמים לסוג הקובץ.
     try:
+        try:
+            cleaned_length = int(len(cleaned or ""))
+        except TypeError:
+            cleaned_length = 0
         span_attrs = {
             "validation.ok": bool(ok),
             "status": "ok" if ok else "error",
-            "cleaned.length": int(len(cleaned or "")),
+            "cleaned.length": cleaned_length,
             "code.length.original": code_length,
-            "file_name": str(file_name or ""),
         }
+        if file_name:
+            span_attrs["file_name"] = str(file_name)
         if msg:
             span_attrs["error.message"] = str(msg)
         set_current_span_attributes(span_attrs)

--- a/tests/test_code_service_tracing.py
+++ b/tests/test_code_service_tracing.py
@@ -14,3 +14,29 @@ def test_validate_code_input_records_span(monkeypatch):
     assert ok
     assert cleaned.startswith("print")
     assert any(attrs.get("status") == "ok" for attrs in recorded)
+
+
+def test_validate_code_input_handles_non_string_input(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    def _record(attrs: dict[str, object]) -> None:
+        recorded.append(dict(attrs))
+
+    class DummyProcessor:
+        def validate_code_input(self, code, file_name, user_id):
+            return False, "", "קלט קוד לא תקין או ריק"
+
+    monkeypatch.setattr(code_service, "set_current_span_attributes", _record, raising=False)
+    monkeypatch.setattr(code_service, "code_processor", DummyProcessor(), raising=False)
+
+    ok, cleaned, msg = code_service.validate_code_input(123, "demo.py", 123)
+
+    assert not ok
+    assert cleaned == ""
+    assert msg == "קלט קוד לא תקין או ריק"
+
+    span_records = [attrs for attrs in recorded if "status" in attrs]
+    assert span_records, "ציפינו לסטטוס span"
+    assert any(attrs.get("status") == "error" for attrs in span_records)
+    assert any(attrs.get("code.length.original") == 0 for attrs in span_records)
+    assert any("error.message" in attrs for attrs in span_records)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands tracing data in `validate_code_input` and ensures the fallback path records instrumentation by avoiding early return.
> 
> - **Observability/Tracing**:
>   - In `services/code_service.py::validate_code_input`, add richer span attributes: `status`, `cleaned.length`, `code.length.original`, `file_name`, and conditional `error.message`, alongside `validation.ok`.
>   - Compute `code_length` once and reuse for span attributes.
> - **Fallback Behavior**:
>   - Replace early return when `code_processor` is `None` with setting `ok/cleaned/msg` and proceeding, ensuring span attributes are recorded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30528805ab7045ffa2760020c6a97453d2e66fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->