### PR TITLE
Address github issue 1333

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -1345,11 +1345,7 @@ function attachColorSwatches(root){
       token.dataset.mdColor = trimmed;
       token.title = trimmed;
       token.textContent = trimmed;
-      try {
-        token.style.setProperty('--md-color-swatch', trimmed);
-      } catch(_) {
-        token.style.setProperty('--md-color-swatch', trimmed);
-      }
+      token.style.setProperty('--md-color-swatch', trimmed);
       frag.appendChild(token);
       cursor = safeIndex + rawMatch.length;
     }


### PR DESCRIPTION
<ul>
  <li><strong>What</strong>: הוספת זיהוי אוטומטי לערכי צבע במארקדאון והצגת ריבוע צבע קטן לידם בממשק התצוגה.</li>
  <li><strong>Why</strong>: כדי שסוקרים יוכלו להבין מיד איך נראה הצבע בלי להעתיק אותו לכלי חיצוני, בדיוק כמו בגיטהאב.</li>
  <li><strong>Tests</strong>: לא הרצתי בדיקות אוטומטיות (השינוי בצד ה־Frontend בלבד).</li>
  <li><strong>Docs</strong>: טרם יצרתי עמוד תיעוד חדש; אם זה חשוב נוכל להוסיף דף קצר באתר. עיינתי ב־<a href="https://amirbiron.github.io/CodeBot/">CodeBot – Project Docs</a> לצורך התאמה למדיניות.</li>
</ul>


<a href="https://cursor.com/background-agent?bcId=bc-8e7f9f46-5709-4525-b30d-8ed887cd6d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e7f9f46-5709-4525-b30d-8ed887cd6d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects color tokens in rendered Markdown and wraps them with inline swatches for quick visual reference.
> 
> - **Markdown Preview (`webapp/templates/md_preview.html`)**:
>   - **Color token visualization**:
>     - Adds `attachColorSwatches()` to scan rendered content for color values (hex/rgb/hsl) outside `pre`/skipped tags and wrap them in `span.md-color-token` with a CSS-driven swatch.
>     - Exposes function on `window` and invokes it after initial Markdown render.
>   - **Styles**:
>     - Introduces CSS for `.md-color-token` and size tweaks when inside `code` to render the inline color swatch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e295bf5c2a1cfb54aa902c0e1bcb17fc3a33d59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->