### PR TITLE
Address github issue 1334

### DIFF
--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -5764,10 +5764,12 @@ class GitHubMenuHandler:
                                 seen_prs[dedup_key] = self._serialize_seen_pr_timestamp(updated)
                         session["notifications_last"] = session.get("notifications_last", {})
                         now_dt = datetime.now(timezone.utc)
-                        if latest_processed_pr_ts and latest_processed_pr_ts > now_dt:
-                            session["notifications_last"]["pr"] = latest_processed_pr_ts
-                        else:
-                            session["notifications_last"]["pr"] = now_dt
+                        safe_baseline = None
+                        if latest_processed_pr_ts is not None:
+                            safe_baseline = latest_processed_pr_ts
+                            if safe_baseline > now_dt:
+                                safe_baseline = now_dt
+                        session["notifications_last"]["pr"] = safe_baseline or now_dt
                         # הגבלת גודל הזיכרון כדי למנוע צמיחה לא מבוקרת
                         try:
                             if len(seen_prs) > 60:


### PR DESCRIPTION
<ul> <li><strong>What</strong>: התאמת מנגנון ההתראות כדי למנוע כפילויות ב‑PRs – הסף כעת נקבע לפי ההפרש בין זמן העדכון האחרון לבין מקצב ההתראות שנבחר, עם מינימום ברירת־מחדל של ‎30‎ שניות שניתן לכיול, כולל טסט חדש המדמה את חלון הקירור.</li> <li><strong>Why</strong>: התראות על PR עודכן הגיעו מספר פעמים ברצף; הסנכרון בין קצב הבדיקה לבין קצב השליחה מונע ספאם למשתמשים בלי לוותר על העדכונים הדרושים.</li> <li><strong>Docs</strong>: לא בוצע עיון ב־<a href="https://amirbiron.github.io/CodeBot/" target="_blank">CodeBot – Project Docs</a> עבור שינוי זה.</li> <li><strong>Tests</strong>: לא הורץ – סביבת הסוכנים ללא חבילת <code>pytest</code>.</li> </ul>

<a href="https://cursor.com/background-agent?bcId=bc-43df6d7e-42ac-49c7-b018-8e85fd2499e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43df6d7e-42ac-49c7-b018-8e85fd2499e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an env-tunable cooldown and safer timestamp/baseline handling for PR notifications, with dedup and state cleanup refinements plus tests.
> 
> - **Notifications (GitHub PRs)**:
>   - Introduce `_PR_UPDATE_MIN_COOLDOWN_SECONDS` (ENV `GITHUB_NOTIFICATIONS_PR_MIN_COOLDOWN`) and enforce cooldown for "עודכן" PR messages.
>   - Normalize notification settings and interval parsing; compute cooldown as `max(min_cooldown, interval)`.
>   - Improve baseline handling using UTC-aware parsing/serialization; track `latest_processed_pr_ts` vs `now`.
>   - Refine dedup logic using `notifications_seen_prs`; skip updates within cooldown; cap and clean the dedup store.
> - **Issues notifications**:
>   - Maintain existing logic; minor baseline normalization alignment.
> - **Tests**:
>   - Add `_FixedDateTime` shim and `test_notifications_job_pr_update_cooldown` to validate cooldown behavior.
>   - Update/extend tests for dedup cleanup and running-flag handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd9aa163c9a32e5343096c45179180782484c81d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->