### PR TITLE
Fix github issue 1337

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -867,6 +867,41 @@
             }
         });
         // --- תפריט קיצורי דרך ---
+        function ensureQuickAccessVisible(dropdown) {
+            if (!dropdown) return;
+            const runner = () => {
+                try {
+                    const rect = dropdown.getBoundingClientRect();
+                    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+                    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+                    const needScrollUp = rect.top < 12;
+                    const needScrollDown = rect.bottom > (viewportHeight - 12);
+                    const needVertical = needScrollUp || needScrollDown;
+                    const needHorizontal = rect.left < 12 || rect.right > (viewportWidth - 12);
+
+                    if (typeof dropdown.scrollIntoView === 'function' && (needVertical || needHorizontal)) {
+                        dropdown.scrollIntoView({
+                            behavior: 'smooth',
+                            block: needScrollUp ? 'start' : (needScrollDown ? 'end' : 'nearest'),
+                            inline: needHorizontal ? 'center' : 'nearest'
+                        });
+                        return;
+                    }
+
+                    if (needVertical) {
+                        const delta = needScrollUp ? rect.top - 12 : rect.bottom - (viewportHeight - 12);
+                        window.scrollBy({ top: delta, behavior: 'smooth' });
+                    }
+                } catch (e) {}
+            };
+
+            if (typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(runner);
+            } else {
+                setTimeout(runner, 0);
+            }
+        }
+
         function toggleQuickAccess(ev) {
             try { ev && ev.stopPropagation && ev.stopPropagation(); } catch (e) {}
             const dropdown = document.getElementById('quickAccessDropdown');
@@ -875,6 +910,8 @@
             dropdown.classList.toggle('active');
             toggle.classList.toggle('active');
             if (dropdown.classList.contains('active')) {
+                try { dropdown.scrollTop = 0; } catch (e) {}
+                ensureQuickAccessVisible(dropdown);
                 const closer = function(event) {
                     try {
                         const menu = document.querySelector('.quick-access-menu');


### PR DESCRIPTION
<h2>What</h2>
<ul>
  <li>מגלגל את חלונית קיצורי הדרך כך שתוצג במלואה מיד אחרי לחיצה על כפתור 🚀</li>
  <li>מאפס גלילה פנימית של החלונית כדי למנוע פתיחה במצב מגולגל חלקית</li>
</ul>

<h2>Why</h2>
<ul>
  <li>לפתור את הבעיה שתוארה ב-#1337: חלק מהאייקונים נסתרים ודורשים גלילה ידנית</li>
  <li>שיפור חוויית המשתמש – כל הפעולות זמינות מיד ללא טרחה נוספת</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>לא הורצו טסטים אוטומטיים (שינוי Frontend בלבד); נבדק ידנית בדפדפן מקומי</li>
</ul>

<h2>Docs</h2>
<ul>
  <li>לא עיינתי מחדש ב-<a href="https://amirbiron.github.io/CodeBot/" target="_blank">CodeBot – Project Docs</a> למשימה זו</li>
</ul>

<a href="https://cursor.com/background-agent?bcId=bc-09ccc4d8-07df-4a5a-8df6-a2aabff43927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09ccc4d8-07df-4a5a-8df6-a2aabff43927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-scrolls the quick-access dropdown into view and resets its scroll when opened.
> 
> - **UI — Quick Access Menu**:
>   - Add `ensureQuickAccessVisible(dropdown)` to auto-scroll the dropdown into the viewport (uses `scrollIntoView` with fallbacks).
>   - On open, reset `#quickAccessDropdown` scroll to top and invoke the visibility helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48870aa7016fda7168a1adb2e532bff80fc87f01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->