### PR TITLE
Fix missing files for monitoring service setup

### DIFF
--- a/docker/alertmanager/Dockerfile
+++ b/docker/alertmanager/Dockerfile
@@ -1,9 +1,9 @@
 # Alertmanager for Render
 FROM prom/alertmanager:latest
 
-# Copy config template and entrypoint
-COPY alertmanager.render.yml /etc/alertmanager/alertmanager.render.yml
-COPY entrypoint.sh /entrypoint.sh
+# Copy config template and entrypoint from repo root (Render build context is repo root)
+COPY docker/alertmanager/alertmanager.render.yml /etc/alertmanager/alertmanager.render.yml
+COPY docker/alertmanager/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,12 +1,12 @@
 # Prometheus for Render
 FROM prom/prometheus:latest
 
-# Copy configuration templates
-COPY prometheus.render.yml /etc/prometheus/prometheus.render.yml
-COPY ../prometheus/alerts.yml /etc/prometheus/alerts.yml
+# Copy configuration templates from repo root (Render build context is repo root)
+COPY docker/prometheus/prometheus.render.yml /etc/prometheus/prometheus.render.yml
+COPY docker/prometheus/alerts.yml /etc/prometheus/alerts.yml
 
-# Copy entrypoint
-COPY entrypoint.sh /entrypoint.sh
+# Copy entrypoint from repo root
+COPY docker/prometheus/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Prometheus will be started by entrypoint with dynamic listen port


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-e2f51cc2-818b-4770-be45-928bf2faab22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2f51cc2-818b-4770-be45-928bf2faab22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Alertmanager and Prometheus Dockerfiles to copy config and entrypoint files from repo-root `docker/...` paths to match Render build context.
> 
> - **Docker**:
>   - **Alertmanager (`docker/alertmanager/Dockerfile`)**:
>     - Point `COPY` to repo-root paths: `docker/alertmanager/alertmanager.render.yml` and `docker/alertmanager/entrypoint.sh`.
>   - **Prometheus (`docker/prometheus/Dockerfile`)**:
>     - Point `COPY` to repo-root paths: `docker/prometheus/prometheus.render.yml`, `docker/prometheus/alerts.yml`, and `docker/prometheus/entrypoint.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d017116bdad542cf551d25f3bd25b0510ca4b99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->