### PR TITLE
Fix alertmanager config loading error

### DIFF
--- a/docker/alertmanager/entrypoint.sh
+++ b/docker/alertmanager/entrypoint.sh
@@ -20,8 +20,8 @@ esac
 
 # Render config from template by replacing the placeholder with the actual URL
 tmp_cfg="$(mktemp)"
-# Escape characters that are special for sed replacement (&)
-escaped_url=$(printf '%s' "$ALERT_WEBHOOK_URL" | sed -e 's/[&]/\\&/g')
+# Escape characters that are special for sed replacement: &, | (delimiter), and \
+escaped_url=$(printf '%s' "$ALERT_WEBHOOK_URL" | sed -e 's/[\\&|]/\\&/g')
 sed 's|${ALERT_WEBHOOK_URL}|'"$escaped_url"'|g' /etc/alertmanager/alertmanager.render.yml > "$tmp_cfg"
 
 exec /bin/alertmanager \


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון כשלון Alertmanager עם השגיאה "unsupported scheme "" for URL". הבעיה נבעה מכך ש-Alertmanager אינו מרחיב משתני סביבה בקובץ ה-YAML שלו. הפתרון הוא לרנדר את קובץ הקונפיגורציה באמצעות `sed` ב-entrypoint לפני הפעלת השירות.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [X] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עדכון `docker/alertmanager/entrypoint.sh` לרנדור דינמי של `alertmanager.render.yml` עם משתנה הסביבה `ALERT_WEBHOOK_URL`.
- הוספת ולידציה ב-entrypoint לוודא ש-`ALERT_WEBHOOK_URL` קיים ותקין.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [X] Manual
הבעיה אומתה באמצעות לוגים של Render. הפתרון נבדק לוגית על בסיס הבנת אופן פעולת Alertmanager ו-shell scripting. נדרש Deploy ידני ב-Render לאימות מלא.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- 🧪 Unit Tests (3.11)
- 🧪 Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [X] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [X] אין סודות/מפתחות בקוד
- [X] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [X] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  השינוי אמור לתקן את כשלון ה-Alertmanager. אין סיכונים ביצועיים או אבטחתיים משמעותיים מעבר לשינוי התצורה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  החזרה לאחור לגרסה הקודמת של `docker/alertmanager/entrypoint.sh`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd1ce99-08ce-4b6a-b8e7-ec7489e6c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6dd1ce99-08ce-4b6a-b8e7-ec7489e6c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Entry point now validates `ALERT_WEBHOOK_URL`, renders `alertmanager.render.yml` with it into a temp file, and starts Alertmanager using that config (with default `PORT`).
> 
> - **Alertmanager Entrypoint (`docker/alertmanager/entrypoint.sh`)**:
>   - Validate presence and scheme of `ALERT_WEBHOOK_URL`.
>   - Render `/etc/alertmanager/alertmanager.render.yml` by substituting `${ALERT_WEBHOOK_URL}` via `sed` into a temp file.
>   - Start Alertmanager with the rendered config and default `PORT` fallback (`9093`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 300d6ff4727e4b88e304540c8517cec707d99b42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->