### PR TITLE
Fix/circuit breaker rlock

### DIFF
--- a/integrations_sentry.py
+++ b/integrations_sentry.py
@@ -53,9 +53,9 @@ async def _get(path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         for req_kwargs in attempts:
             try:
                 async with async_request("GET", url, **req_kwargs) as resp:
-                    if resp.status != 200:
-                        return None
-                    return await resp.json()
+                    if resp.status == 200:
+                        return await resp.json()
+                    # אם הסטטוס לא 200 נמשיך לנסות ורק אם אין עוד ניסיונות נחזיר None
             except TypeError:
                 # פקודת המוקים בטסט לא מקבלת service/endpoint – ננסה בלי.
                 continue


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes Sentry `_get` retry without `service`/`endpoint` kwargs on TypeError, improving compatibility with http_async mocks while preserving behavior.
> 
> - **Sentry integration (`integrations_sentry.py`)**:
>   - Update `_get` to build `base_kwargs` and attempt request with `service="sentry"`/`endpoint="api_get"`, then retry without those kwargs on `TypeError`.
>   - Preserve behavior: return `None` on non-200 or failures; unchanged headers/params handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b06e07ac9f91085764515db7e88d3d4a1611f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->