### PR TITLE
Debug unreadable file and cache errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -847,7 +847,7 @@ class CodeKeeperBot:
             notify_admins=notify_admins,
             get_reporter=lambda: reporter,
             log_user_activity=log_user_activity,
-            encodings_to_try=ENCODINGS_TO_TRY,
+            encodings_to_try=lambda: ENCODINGS_TO_TRY,
             emit_event=emit_event,
             errors_total=errors_total,
         )


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1614e484-dec3-49d4-af31-a9dca1c35b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1614e484-dec3-49d4-af31-a9dca1c35b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `DocumentHandler` to resolve encodings dynamically with better normalization, tracking, and logging; wire it from `main.py` via a provider lambda.
> 
> - **Documents handling (`handlers/documents.py`)**:
>   - Add dynamic encodings provider: `encodings_to_try` now accepts `Sequence[str] | Callable[[], Sequence[str]]`.
>   - Introduce helpers: `_normalize_encodings(...)` and `_current_encodings()`; track `_last_encodings_attempted`.
>   - Update `_decode_bytes` to fetch current encodings per call and record attempts.
>   - Improve diagnostics: log and user messages now list actually attempted encodings; event payloads use resolved attempts.
>   - Minor typing import: add `Iterable`.
> - **Wiring (`main.py`)**:
>   - Pass provider `lambda: ENCODINGS_TO_TRY` to `DocumentHandler` instead of a static list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5171528a80231376d18c8f38bd436eece765c783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->