### PR TITLE
Fix test for callback query attribute

### DIFF
--- a/handlers/drive/menu.py
+++ b/handlers/drive/menu.py
@@ -920,14 +920,14 @@ class GoogleDriveMenuHandler:
                     try:
                         now_dt = datetime.now(timezone.utc)
                         now_iso = now_dt.isoformat()
-                        update = {"last_backup_at": now_iso, "last_full_backup_at": now_iso}
+                        prefs_update = {"last_backup_at": now_iso, "last_full_backup_at": now_iso}
                         prefs = db.get_drive_prefs(user_id) or {}
                         key = prefs.get("schedule")
                         if key:
                             seconds = self._interval_seconds(str(key))
                             next_dt = now_dt + timedelta(seconds=seconds)
-                            update["schedule_next_at"] = next_dt.isoformat()
-                        db.save_drive_prefs(user_id, update)
+                            prefs_update["schedule_next_at"] = next_dt.isoformat()
+                        db.save_drive_prefs(user_id, prefs_update)
                         if key:
                             await self._ensure_schedule_job(context, user_id, str(key))
                     except Exception:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-bbe23309-19d3-4812-9e78-239bde271964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bbe23309-19d3-4812-9e78-239bde271964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the local preferences update dict and updates its usage when saving Drive backup timestamps and next schedule after a full backup upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21f133408ebe986f8ebbe471e730442af3ceed60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->