### PR TITLE
Respond to github issue in hebrew

### DIFF
--- a/services/community_library_service.py
+++ b/services/community_library_service.py
@@ -211,7 +211,8 @@ def list_public(q: Optional[str] = None, page: int = 1, per_page: int = 30, tags
                 "title": r.get("title"),
                 "description": r.get("description"),
                 "url": r.get("url"),
-                "logo_url": None,  # future: build from file_id if a proxy endpoint is added
+                # Expose proxy URL for logo if a Telegram file_id is present
+                "logo_url": (f"/api/community-library/logo/{r.get('logo_file_id')}" if r.get("logo_file_id") else None),
                 "tags": r.get("tags") or [],
                 "featured": bool(r.get("featured", False)),
                 "approved_at": r.get("approved_at"),

--- a/webapp/community_library_api.py
+++ b/webapp/community_library_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, Response
+import os
+from http_sync import request as http_request
 from typing import Any, Dict, List, Optional, Tuple
 import logging
 
@@ -48,3 +50,50 @@ def get_public_items():
         except Exception:
             pass
         return jsonify({'ok': False, 'error': 'internal_error'}), 500
+
+
+@community_lib_bp.route('/logo/<path:file_id>', methods=['GET'])
+def get_logo(file_id: str):
+    """Proxy a Telegram file by file_id without exposing the bot token.
+
+    Caches are handled by clients via Cache-Control; upstream requests use short timeouts.
+    """
+    try:
+        token = os.getenv('BOT_TOKEN', '')
+        if not token or not file_id:
+            return Response(status=404)
+        # Resolve file_path from file_id
+        meta_resp = http_request(
+            'GET',
+            f'https://api.telegram.org/bot{token}/getFile',
+            params={'file_id': file_id},
+            timeout=5,
+        )
+        if int(getattr(meta_resp, 'status_code', 0) or 0) != 200:
+            return Response(status=404)
+        try:
+            body = meta_resp.json() if getattr(meta_resp, 'content', None) is not None else {}
+            file_path = ((body or {}).get('result') or {}).get('file_path')
+        except Exception:
+            file_path = None
+        if not file_path:
+            return Response(status=404)
+        # Fetch the actual file bytes
+        file_resp = http_request(
+            'GET',
+            f'https://api.telegram.org/file/bot{token}/{file_path}',
+            timeout=8,
+        )
+        if int(getattr(file_resp, 'status_code', 0) or 0) != 200:
+            return Response(status=404)
+        content_type = None
+        try:
+            content_type = (file_resp.headers or {}).get('Content-Type')
+        except Exception:
+            content_type = None
+        headers = {'Cache-Control': 'public, max-age=86400'}
+        if content_type:
+            headers['Content-Type'] = content_type
+        return Response(file_resp.content, headers=headers)
+    except Exception:
+        return Response(status=404)

--- a/webapp/static/css/community_library.css
+++ b/webapp/static/css/community_library.css
@@ -14,13 +14,18 @@
 @media(max-width:600px){.community-grid{grid-template-columns:1fr}}
 
 .card{border:1px solid #eee;border-radius:12px;padding:14px;display:flex;gap:12px;align-items:flex-start;background:#fff}
-.logo{width:48px;height:48px;border-radius:50%;background:#f2f2f2;display:flex;align-items:center;justify-content:center;font-size:20px}
+/* Logo as a square thumbnail (64x64) with cover fit */
+.logo{width:64px;height:64px;border-radius:10px;background:#f2f2f2;display:flex;align-items:center;justify-content:center;font-size:22px;overflow:hidden}
+.logo img{width:100%;height:100%;object-fit:cover;display:block}
 .card .title{font-weight:600}
 .card .desc{color:#555;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .tags{display:flex;gap:6px;flex-wrap:wrap;margin:8px 0}
 .tag{background:#f0f4f8;color:#2b6cb0;border-radius:999px;padding:4px 8px;font-size:12px}
 .card .actions{display:flex;gap:8px;margin-top:8px}
-.card .actions .btn{padding:8px 10px;border:1px solid #ddd;border-radius:8px;background:#fafafa;text-decoration:none}
+/* Align buttons style with 'My Collections' */
+.card .actions .btn{padding:8px 10px;border:1px solid #e5e7eb;border-radius:6px;background:#f8fafc;color:#374151;text-decoration:none;cursor:pointer;transition:background .2s,border-color .2s,transform .2s}
+.card .actions .btn:hover{background:#eef2ff;border-color:#c7d2fe;transform:translateY(-1px)}
+.card .actions .btn:disabled{background:#e2e8f0;border-color:#cbd5f5;color:#64748b;opacity:.8;cursor:not-allowed}
 
 .empty-state{display:flex;flex-direction:column;align-items:center;gap:10px;margin:48px 0}
 .empty-state .icon{font-size:42px}

--- a/webapp/static/js/community_library.js
+++ b/webapp/static/js/community_library.js
@@ -2,26 +2,43 @@
   const grid = document.getElementById('grid');
   const empty = document.getElementById('empty');
   const search = document.getElementById('search');
-  const clearBtn = document.getElementById('clearBtn');
 
   function createCard(item){
     const el = document.createElement('div');
     el.className = 'card';
+
+    // Logo container (supports image or fallback emoji)
     const logo = document.createElement('div');
     logo.className = 'logo';
-    logo.textContent = '🤖';
+    if (item.logo_url) {
+      const img = document.createElement('img');
+      img.src = item.logo_url;
+      img.alt = (item.title || 'logo');
+      img.loading = 'lazy';
+      logo.appendChild(img);
+    } else {
+      logo.textContent = '🤖';
+    }
+
     const body = document.createElement('div');
     const title = document.createElement('div'); title.className='title'; title.textContent = item.title || '';
     const desc = document.createElement('div'); desc.className='desc'; desc.textContent = item.description || '';
     const tags = document.createElement('div'); tags.className='tags';
     (item.tags||[]).slice(0,5).forEach(t=>{const s=document.createElement('span');s.className='tag';s.textContent=t;tags.appendChild(s)});
+
     const actions = document.createElement('div'); actions.className='actions';
     const openBtn = document.createElement('a'); openBtn.className='btn'; openBtn.textContent='פתח'; openBtn.href=item.url; openBtn.target='_blank';
     const shareBtn = document.createElement('button'); shareBtn.className='btn'; shareBtn.textContent='שתף';
-    shareBtn.onclick = ()=>{try{navigator.clipboard.writeText(item.url)}catch(e){} };
+    shareBtn.onclick = ()=>{try{navigator.clipboard.writeText(item.url)}catch(e){}};
     actions.appendChild(openBtn); actions.appendChild(shareBtn);
-    body.appendChild(title); body.appendChild(desc); body.appendChild(tags); body.appendChild(actions);
-    el.appendChild(logo); el.appendChild(body);
+
+    body.appendChild(title);
+    body.appendChild(desc);
+    body.appendChild(tags);
+    body.appendChild(actions);
+
+    el.appendChild(logo);
+    el.appendChild(body);
     return el;
   }
 
@@ -37,7 +54,7 @@
     data.items.forEach(it=> grid.appendChild(createCard(it)));
   }
 
-  clearBtn.addEventListener('click', ()=>{ search.value=''; load(); });
+  // Load on input change (including clearing the field)
   search.addEventListener('input', ()=>{ const v=search.value||''; if(v.length===0 || v.length>2){ load(); }});
   load();
 })();

--- a/webapp/templates/community_library.html
+++ b/webapp/templates/community_library.html
@@ -19,7 +19,6 @@
   <select id="category" disabled>
     <option>קטגוריה (בקרוב)</option>
   </select>
-  <button id="clearBtn" class="btn">נקה</button>
 </div>
 
 <div id="grid" class="community-grid"></div>


### PR DESCRIPTION
## ✨ תיאור קצר
- הסרת כפתור "נקה" ממסך ספריית הקהילה ועיצוב מחדש של תצוגת המוצרים בכרטיסים מלבניים.
- איחוד עיצוב כפתורי "פתח | שתף" עם סגנון "אוספים שלי" והוספת תצוגת לוגו ממוזער (64x64) למוצרים עם תמונה, או פלייסהולדר 🤖 אחרת.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הסרת כפתור "נקה" מ-`webapp/templates/community_library.html` ומלוגיקת ה-JS ב-`webapp/static/js/community_library.js`.
- עדכון `webapp/static/css/community_library.css` לעיצוב כרטיסים מלבניים, לוגו מרובע (64x64) עם `object-fit: cover`, ועיצוב כפתורים אחיד התואם ל"אוספים שלי".
- עדכון `webapp/static/js/community_library.js` ליצירת כרטיסים, הצגת לוגו (אם קיים) או פלייסהולדר, והסרת לוגיקת כפתור ה"נקה".
- הוספת שדה `logo_url` ב-`services/community_library_service.py` המצביע על פרוקסי חדש.
- מימוש נקודת קצה חדשה ב-`webapp/community_library_api.py` (`/api/community-library/logo/<file_id>`) המשמשת כפרוקסי מאובטח לתמונות מטלגרם, ללא חשיפת טוקן.

## 🧪 בדיקות
- נבדק ידנית במסך ספריית הקהילה: תצוגת כרטיסים, כפתורים, לוגו (עם ובלי תמונה), ופונקציונליות חיפוש.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שיפור חווית המשתמש במסך ספריית הקהילה.
- הוספת נקודת קצה חדשה ל-API לטעינת תמונות, עם טיפול ב-caching.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לגרסה קודמת של הקוד. השינויים הם בעיקר UI/API חדש, כך שרולבק אמור להיות פשוט.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f76d4ef-f9f6-4a0e-8fa8-315df12c14fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f76d4ef-f9f6-4a0e-8fa8-315df12c14fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Telegram logo proxy and shows 64x64 thumbnails in community library, updates card/button styles, and removes the clear button.
> 
> - **Backend**:
>   - Add proxy endpoint `GET /api/community-library/logo/<file_id>` in `webapp/community_library_api.py` to fetch Telegram files via bot token with caching headers.
>   - Expose `logo_url` in `services/community_library_service.list_public` when `logo_file_id` exists.
> - **Frontend**:
>   - `webapp/static/js/community_library.js`: render logo image from `logo_url` (fallback emoji), tidy card assembly, trigger search on input (no clear button logic).
>   - `webapp/templates/community_library.html`: remove `נקה` clear button.
>   - `webapp/static/css/community_library.css`: switch to 64x64 square logo thumbnail with `object-fit: cover`; align action button styles with "My Collections".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6973e598bb14cc429c33df6fe8939d196f4d0105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->