### PR TITLE
Fix test for command handler instrumentation

### DIFF
--- a/tests/_telegram_stubs.py
+++ b/tests/_telegram_stubs.py
@@ -89,10 +89,24 @@ class CommandHandler:
         # Accept both (command, callback) and (callback) shapes
         if callback is None and callable(command):
             self.callback = command
+            self.commands = tuple()
             self.command = None
+            return
+
+        self.callback = callback or kwargs.get('callback')
+        cmds = command if command is not None else kwargs.get('command')
+        if cmds is None:
+            commands_tuple = tuple()
+        elif isinstance(cmds, str):
+            commands_tuple = (cmds,)
         else:
-            self.command = command
-            self.callback = callback or kwargs.get('callback')
+            try:
+                commands_tuple = tuple(cmds)
+            except TypeError:
+                commands_tuple = (cmds,)
+        filtered = tuple(c for c in commands_tuple if c)
+        self.commands = filtered
+        self.command = filtered[0] if filtered else None
 
 class MessageHandler:
     def __init__(self, filters, callback, *args, **kwargs):


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את הסטאב של `CommandHandler` בבדיקות כדי שיתאים להתנהגות האמיתית של הספרייה. זה פותר כשל בבדיקה `test_instrument_command_handlers_wraps_existing_handlers` שנובע מאי-הגדרה נכונה של שדות `command` ו־`commands` בסטאב.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- עדכון הסטאב `tests/_telegram_stubs.py::CommandHandler` כדי שיאחסן נכון את שדות `command` (הפקודה הראשונה) ו־`commands` (כל הפקודות כ־tuple).
- הסטאב תומך כעת בקבלת פקודות כמחרוזת, רשימה או דרך `command=` ב־kwargs, ומנקה ערכים ריקים.

## 🧪 בדיקות
- הרצתי את הבדיקה הספציפית `python3 -m pytest tests/test_observability_stage6.py -k instrument_command`. הבדיקה עוברת כעת בהצלחה.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: אין, השינוי הוא בקוד בדיקות בלבד (סטאב).

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: אין סיכון, שינוי בסטאב בדיקות בלבד. ניתן לבטל את הקומיט.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea257213-5dab-422f-8384-3fd009f4f132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea257213-5dab-422f-8384-3fd009f4f132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CommandHandler test stub to correctly set `command`/`commands` and support multiple input shapes.
> 
> - **Tests**:
>   - Update `tests/_telegram_stubs.py::CommandHandler`:
>     - Support both `(callback)` and `(command, callback)` signatures.
>     - Normalize `command` from string/iterable/`command=` kwarg, dropping empty values.
>     - Populate `self.commands` as a tuple and `self.command` as the first command or `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452c00cb312d7c7dc4fabf8afbf65723803f4e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->