### PR TITLE
Fix errors command recent errors test

### DIFF
--- a/bot_handlers.py
+++ b/bot_handlers.py
@@ -1335,7 +1335,7 @@ class AdvancedBotHandlers:
         """
         try:
             # Admins only handled by decorator; parse args
-            args = context.args or []
+            args = list(getattr(context, "args", []) or [])
             if len(args) < 2:
                 await update.message.reply_text("ℹ️ שימוש: /silence <name|pattern> <duration> [reason...] [severity=<level>] [--force]")
                 return
@@ -1421,7 +1421,7 @@ class AdvancedBotHandlers:
     async def unsilence_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """/unsilence <id|pattern> – disable active silence(s)."""
         try:
-            args = context.args or []
+            args = list(getattr(context, "args", []) or [])
             if not args:
                 await update.message.reply_text("ℹ️ שימוש: /unsilence <id|pattern>")
                 return
@@ -1522,7 +1522,7 @@ class AdvancedBotHandlers:
                 await update.message.reply_text("❌ פקודה זמינה למנהלים בלבד")
                 return
 
-            args = context.args or []
+            args = list(getattr(context, "args", []) or [])
 
             # Helper: build Sentry query link for a given error_signature
             def _sentry_query_link(signature: str) -> Optional[str]:


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את הפקודות `/errors`, `/silence` ו-`/unsilence` ב-`AdvancedBotHandlers` כדי למנוע `AttributeError` כאשר אובייקט ה-`context` חסר את השדה `args`. זה פותר כשל בטסטים ומאפשר לפקודת `/errors` להציג את רשימת השגיאות כצפוי.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי גישה ל-`context.args` בפקודות `errors`, `silence`, `unsilence` לשימוש ב-`getattr(context, "args", [])` עם ערך ברירת מחדל רשימה ריקה.

## 🧪 בדיקות
התיקון נועד לפתור כשל בטסט `test_errors_command_uses_recent_errors_buffer` ב-`tests/test_chatops_mvp.py`, שנגרם מ-`AttributeError` עקב חוסר ב-`context.args`. התיקון מאפשר לטסט לעבור.
- [x] Unit (התיקון מכוון לטסט יחידה)
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (הבדיקה המקומית נכשלה עקב בעיית סביבה, אך התיקון מטפל בשורש הכשל בטסט)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  אין השפעה שלילית צפויה. השינוי משפר את חוסן הקוד לטיפול באובייקטי `context` חלקיים, במיוחד בסביבות בדיקה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  החזרה לאחור של הקומיט הנוכחי. השינוי קטן וממוקד.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f7b806b-dcb8-4d8d-8690-a19f7dd42048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f7b806b-dcb8-4d8d-8690-a19f7dd42048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely handle missing `context.args` in ChatOps commands to prevent AttributeError and stabilize tests.
> 
> - **Bot handlers (`bot_handlers.py`)**:
>   - Update argument parsing to use `list(getattr(context, "args", []) or [])` for:
>     - `/silence` (`silence_command`)
>     - `/unsilence` (`unsilence_command`)
>     - `/errors` (`errors_command`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b1b76b01425430015e03fa65fa3efc8ad1f41bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->