### PR TITLE
Fix snippet inline reject type error

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import asyncio
+import inspect
 import hashlib
 import secrets
 import time
@@ -222,6 +223,12 @@ async def _safe_edit_message_text(query, text: str, reply_markup=None, parse_mod
             return
         raise
 
+
+async def _maybe_await(result):
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
 def _truncate_middle(text: str, max_len: int) -> str:
     """מקצר מחרוזת באמצע עם אליפסיס אם חורגת מאורך נתון."""
     if max_len <= 0:
@@ -365,7 +372,7 @@ async def community_catalog_menu(update: Update, context: ContextTypes.DEFAULT_T
         [InlineKeyboardButton("➕ הוסף מוצר משלך", callback_data="community_submit")],
         [InlineKeyboardButton("↩️ חזרה", callback_data="files")],
     ]
-    await _safe_edit_message_text(query, "📳 ממשקי משתמשים", InlineKeyboardMarkup(keyboard))
+    await _maybe_await(_safe_edit_message_text(query, "📳 ממשקי משתמשים", InlineKeyboardMarkup(keyboard)))
     return ConversationHandler.END
 
 
@@ -379,7 +386,7 @@ async def snippets_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         [InlineKeyboardButton("➕ הוסף סניפט משלך", callback_data="snippet_submit")],
         [InlineKeyboardButton("↩️ חזרה", callback_data="files")],
     ]
-    await _safe_edit_message_text(query, "📃 ספריית סניפטים", InlineKeyboardMarkup(keyboard))
+    await _maybe_await(_safe_edit_message_text(query, "📃 ספריית סניפטים", InlineKeyboardMarkup(keyboard)))
     return ConversationHandler.END
 
 HELP_PAGES = [
@@ -1090,11 +1097,11 @@ async def snippet_submit_start(update: Update, context: ContextTypes.DEFAULT_TYP
     query = update.callback_query
     await TelegramUtils.safe_answer(query)
     context.user_data['sn_item'] = {}
-    await _safe_edit_message_text(
+    await _maybe_await(_safe_edit_message_text(
         query,
         "🧩 נתחיל בהוספת סניפט\n\nשלח/י כותרת (3–180 תווים)",
         InlineKeyboardMarkup([[InlineKeyboardButton("❌ ביטול", callback_data="files")]])
-    )
+    ))
     return SN_COLLECT_TITLE
 
 
@@ -1190,12 +1197,12 @@ async def snippet_inline_approve(update: Update, context: ContextTypes.DEFAULT_T
             ok = _approve(item_id, int(update.effective_user.id))
         except Exception:
             ok = False
-        await _safe_edit_message_text(query, "עודכן." if ok else "שגיאה.")
+        await _maybe_await(_safe_edit_message_text(query, "עודכן." if ok else "שגיאה."))
         return ConversationHandler.END
     if action == 'snippet_reject':
         # עבור לדיאלוג איסוף סיבת דחייה
         context.user_data['sn_reject_id'] = item_id
-        await _safe_edit_message_text(query, "נא לציין סיבת דחייה לסניפט זה:" )
+        await _maybe_await(_safe_edit_message_text(query, "נא לציין סיבת דחייה לסניפט זה:"))
         return SN_REJECT_REASON
     return ConversationHandler.END
 
@@ -1210,7 +1217,7 @@ async def snippet_reject_start(update: Update, context: ContextTypes.DEFAULT_TYP
     except ValueError:
         return ConversationHandler.END
     context.user_data['sn_reject_id'] = item_id
-    await _safe_edit_message_text(query, "נא לציין סיבת דחייה לסניפט זה:")
+    await _maybe_await(_safe_edit_message_text(query, "נא לציין סיבת דחייה לסניפט זה:"))
     return SN_REJECT_REASON
 
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו `TypeError` שהתרחש בטסט `test_snippet_inline_reject_transitions_to_reason` כאשר פונקציה אסינכרונית הוחלפה בסינכרונית בבדיקה. הוספנו פונקציית עזר `_maybe_await` שבודקת אם התוצאה היא awaitable לפני שמנסה לבצע עליה `await`, ובכך הבטחנו שהקוד יעבוד גם עם פונקציות סינכרוניות שהוזרקו בבדיקות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת פונקציה `_maybe_await` ב-`conversation_handlers.py` שבודקת אם אובייקט הוא awaitable וממתינה לו במידת הצורך.
- עדכון כל הקריאות ל-`_safe_edit_message_text` לעבור דרך `_maybe_await` כדי לתמוך בהחלפות סינכרוניות בבדיקות.

## 🧪 בדיקות
- הטסט `test_snippet_inline_reject_transitions_to_reason` נכשל לפני השינוי עם `TypeError`. השינוי פותר את הבעיה ומאפשר לטסט לעבור.
- [ ] Unit
- [ ] Integration
- [x] Manual (הטסט הספציפי)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (הטסט הספציפי)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: אין השפעה שלילית צפויה. השינוי מחזק את עמידות הקוד בפני החלפות פונקציות בבדיקות ומוודא התנהגות עקבית.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיט. השינוי קטן וממוקד.

---
<a href="https://cursor.com/background-agent?bcId=bc-99ecfca3-4de5-4238-9e33-ad60f7c6a502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99ecfca3-4de5-4238-9e33-ad60f7c6a502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `_maybe_await` and wrap `_safe_edit_message_text` usages to support both async and sync replacements, resolving TypeError in snippet reject flow.
> 
> - **Bot (Telegram handlers)**
>   - **Utility**: Add `_maybe_await` to conditionally `await` results when awaitable.
>   - **Handlers updated**: Wrap calls to `_safe_edit_message_text` with `_maybe_await` in:
>     - `community_catalog_menu`, `snippets_menu`
>     - `snippet_submit_start`
>     - `snippet_inline_approve` (approve/reject branches)
>     - `snippet_reject_start`
>   - Import `inspect` for awaitable detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eadc08e8ea42eaa5c1e2a95d277eb626bbe77470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->