### PR TITLE
Fix async await type error in conversation handler

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -1225,7 +1225,7 @@ async def snippet_collect_reject_reason(update: Update, context: ContextTypes.DE
     reason = (update.message.text or '').strip()
     item_id = str(context.user_data.get('sn_reject_id') or '')
     if not item_id:
-        await update.message.reply_text("❌ מזהה לא תקין")
+        await _maybe_await(update.message.reply_text("❌ מזהה לא תקין"))
         return ConversationHandler.END
     ok = False
     try:
@@ -1233,7 +1233,7 @@ async def snippet_collect_reject_reason(update: Update, context: ContextTypes.DE
         ok = _reject(item_id, int(update.effective_user.id), reason or 'rejected')
     except Exception:
         ok = False
-    await update.message.reply_text("🛑 נדחה" if ok else "❌ כשל בדחייה")
+    await _maybe_await(update.message.reply_text("🛑 נדחה" if ok else "❌ כשל בדחייה"))
     context.user_data.pop('sn_reject_id', None)
     return ConversationHandler.END
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את השגיאה `TypeError: object NoneType can't be used in 'await' expression` בפונקציה `snippet_collect_reject_reason`. הבעיה נבעה מקריאה ל-`await` על פונקציית `reply_text` ממוקדת (mocked) בטסט, שהחזירה `None`. הפתרון הוא לעטוף את הקריאות ל-`reply_text` ב-`_maybe_await`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עטיפת קריאות ל-`update.message.reply_text` בפונקציה `_maybe_await` ב-`snippet_collect_reject_reason`.
- זה מבטיח שגם אם `reply_text` מוחלפת בפונקציה סינכרונית (כמו בטסטים), לא תהיה ניסיון לבצע `await` על `None`.

## 🧪 בדיקות
התיקון מטפל ב-`TypeError` שהוצג בטסט `test_snippet_reject_start_and_collect` ב-`tests/test_conversation_handlers_inline_paths.py`.
- [ ] Unit
- [ ] Integration
- [x] Manual (הטסט הספציפי תוקן)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (הטסט הספציפי תוקן)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: אין השפעה שלילית צפויה. השינוי מחזק את הקוד מול פונקציות `reply_text` שאינן אסינכרוניות באופן מובהק (למשל, במוקים של טסטים).

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback פשוט של ה-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ec29601-b6e9-4aad-bca2-2bd550da4bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ec29601-b6e9-4aad-bca2-2bd550da4bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap `update.message.reply_text` calls in `snippet_collect_reject_reason` with `_maybe_await` to prevent awaiting non-awaitable results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7872d2d3ef51e5107497594b28299d8da4f06d1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->