### PR TITLE
Fix unclosed client session and add async plugin

### DIFF
--- a/tests/test_snippet_handlers_reject.py
+++ b/tests/test_snippet_handlers_reject.py
@@ -1,5 +1,7 @@
 import types
 
+import pytest
+
 import conversation_handlers as ch
 
 
@@ -12,6 +14,7 @@ class _Msg:
         self.texts.append(t)
 
 
+@pytest.mark.asyncio
 async def test_snippet_collect_reject_reason(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו טסט אסינכרוני שנכשל עקב חוסר תמיכה מובנית ב-`async def` ב-pytest, והוספנו fixture לסגירה נכונה של סשני `aiohttp` כדי למנוע אזהרות "Unclosed client session".

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `@pytest.mark.asyncio` לטסט `test_snippet_collect_reject_reason` ב-`tests/test_snippet_handlers_reject.py`.
- הוספת fixture ברמת סשן (`_close_http_async_session_after_session`) ל-`conftest.py` שאחראי לסגור את סשן `aiohttp` הגלובלי בסיום הרצת הטסטים.

## 🧪 בדיקות
הטסטים הרלוונטיים הורצו באופן ידני ועברו בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על יציבות סביבת הבדיקות. אין השפעה צפויה על פרודקשן.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback על ידי היפוך השינויים בשני הקבצים: `conftest.py` ו-`tests/test_snippet_handlers_reject.py`. הסיכון נמוך מאוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-10fa04fe-1066-4e5e-9a23-80ab8ae15c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10fa04fe-1066-4e5e-9a23-80ab8ae15c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a session-scoped fixture to close the global aiohttp session and marks the async snippet rejection test with pytest.mark.asyncio.
> 
> - **Pytest fixtures**:
>   - Add session-scoped `/_close_http_async_session_after_session/` in `conftest.py` to close global `aiohttp` session, handling existing/new event loops.
> - **Tests**:
>   - Mark `tests/test_snippet_handlers_reject.py::test_snippet_collect_reject_reason` with `@pytest.mark.asyncio` and import `pytest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbf93059faec00bec52e2a25cbf539707193be57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->