### PR TITLE
Fix pagination test for snippets repository

### DIFF
--- a/database/repository.py
+++ b/database/repository.py
@@ -1913,8 +1913,30 @@ class Repository:
                 total = 0
             skip = (page - 1) * per_page
             try:
-                cursor = coll.find(match, sort=[("approved_at", -1)]).skip(skip).limit(per_page)
-                rows = list(cursor)
+                cursor = coll.find(match, sort=[("approved_at", -1)])
+                applied_skip = False
+                applied_limit = False
+
+                if isinstance(cursor, list):
+                    rows_candidate = list(cursor)
+                else:
+                    try:
+                        cursor = cursor.skip(skip)
+                        applied_skip = True
+                    except Exception:
+                        pass
+                    try:
+                        cursor = cursor.limit(per_page)
+                        applied_limit = True
+                    except Exception:
+                        pass
+                    rows_candidate = list(cursor)
+
+                rows = rows_candidate
+                if not applied_skip:
+                    rows = rows[skip:]
+                if not applied_limit:
+                    rows = rows[:per_page]
             except Exception:
                 rows = []
             out: List[Dict[str, Any]] = []


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את לוגיקת הדפדוף בפונקציה `list_public_snippets` כך שתתמוך גם במקרים בהם אובייקט ה-cursor אינו תומך ישירות ב-`skip` ו-`limit` (כמו במקרה של רשימות מדומה בבדיקות). כעת, אם `skip`/`limit` נכשלים, הפונקציה מבצעת חיתוך ידני של הרשימה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שיניתי את אופן הטיפול ב-cursor בפונקציה `list_public_snippets`.
- הוספתי בדיקה האם ה-cursor הוא רשימה, ובמקרה כזה או אם `skip`/`limit` נכשלים, מבוצע חיתוך ידני של התוצאות לצורך דפדוף.

## 🧪 בדיקות
- בדקתי באופן ידני את הבדיקה `test_public_snippets_filters_and_pagination` שהייתה נכשלת. הבדיקה עוברת כעת.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: הסיכון נמוך, השינוי משפר את יציבות הדפדוף ואינו צפוי להשפיע לרעה על ביצועים.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: החזרה לגרסה קודמת של הקובץ `database/repository.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-02ed9cd8-a8b4-45fd-9048-81c39e979c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02ed9cd8-a8b4-45fd-9048-81c39e979c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes pagination in `list_public_snippets` robust by attempting `skip`/`limit` on the cursor and falling back to Python slicing when unsupported (e.g., list/mocks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2c9bf7ca02ed8af5fab41ec928ea3a6fac62d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->