### PR TITLE
Investigate failing test case

### DIFF
--- a/services/snippet_library_service.py
+++ b/services/snippet_library_service.py
@@ -899,10 +899,6 @@ def list_public_snippets(
     except Exception:
         per_page_int = 30
 
-    # חשב Built-ins תואמים
-    builtins = _filtered_builtins(q, language)
-    bt_title_keys = {str((it.get("title") or "")).strip().lower() for it in builtins}
-
     repo = None
     try:
         candidate = _db._get_repo()
@@ -910,6 +906,13 @@ def list_public_snippets(
             repo = candidate
     except Exception:
         repo = None
+
+    if repo is None:
+        return [], 0
+
+    # חשב Built-ins תואמים
+    builtins = _filtered_builtins(q, language)
+    bt_title_keys = {str((it.get("title") or "")).strip().lower() for it in builtins}
 
     # שלוף ספירת DB (total) בקריאה קלה
     db_total = 0


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג ב-`list_public_snippets` שגרם להחזרת Built-ins גם כאשר ה-repo נכשל. כעת, במקרה של כשל בגישה ל-repo, הפונקציה תחזיר רשימה ריקה וספירה אפס, כצפוי בבדיקה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- העברת בדיקת `repo is None` ב-`list_public_snippets` למיקום מוקדם יותר, לפני חישוב ה-Built-ins, כדי להבטיח טיפול נכון בשגיאות גישה ל-repo.

## 🧪 בדיקות
- הבדיקה `tests/test_snippet_service_errors.py::test_service_handles_repo_exceptions` נכשלה לפני השינוי. השינוי נועד לתקן את ההתנהגות כך שהבדיקה תעבור.
- [ ] Unit (יתבצע ב-CI)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (יתבצעו ב-CI)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על יציבות השירות במקרה של כשל בגישה ל-DB, מונע החזרת נתונים שגויים. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ריוורט פשוט של הקומיט.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7a7a589-2eda-42d8-b84e-1ee2bfac84b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7a7a589-2eda-42d8-b84e-1ee2bfac84b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Short-circuits `list_public_snippets` to `([], 0)` if repo access is unavailable, moving Built-ins computation after the repo check to avoid returning Built-ins on repo failure.
> 
> - **Backend**:
>   - **Error handling in `services/snippet_library_service.py::list_public_snippets`**:
>     - Return `([], 0)` early when `repo` is `None`.
>     - Compute Built-ins only after confirming `repo` availability to prevent returning Built-ins on repo failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd002358c44028bcc96b5993a38ba4321f877acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->