### PR TITLE
Fix conversation handler cancel fallback test

### DIFF
--- a/main.py
+++ b/main.py
@@ -1727,7 +1727,10 @@ class CodeKeeperBot:
             pass
 
         # Add conversation handler
-        conversation_handler = get_save_conversation_handler(db)
+        conversation_handler = get_save_conversation_handler(
+            db,
+            callback_query_handler_cls=CallbackQueryHandler,
+        )
         self.application.add_handler(conversation_handler)
         logger.info("ConversationHandler נוסף")
         try:
@@ -3660,6 +3663,10 @@ async def setup_bot_data(application: Application) -> None:  # noqa: D401
     try:
         async def _predictive_sampler_job(context: ContextTypes.DEFAULT_TYPE):  # noqa: ARG001
             try:
+                if os.getenv("PYTEST_CURRENT_TEST"):
+                    allow_in_tests = str(os.getenv("PREDICTIVE_SAMPLER_RUN_IN_TESTS", "false")).lower()
+                    if allow_in_tests not in {"1", "true", "yes", "on"}:
+                        return
                 # Feature flag: allow disabling explicitly
                 if str(os.getenv("PREDICTIVE_SAMPLER_ENABLED", "true")).lower() not in {"1", "true", "yes", "on"}:
                     return


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקנתי את הטסט `test_conversation_fallbacks_include_cancel` שנכשל עקב חוסר יכולת לזהות את תבנית ה־`cancel` ב־fallbacks, על ידי הזרקת מחלקת `CallbackQueryHandler` לטובת בדיקות.
- מנעתי אזהרות "Unclosed client session" בטסטים על ידי השבתת משימת ה־Predictive Sampler כאשר `pytest` רץ.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- ב־`conversation_handlers.py`, הפונקציה `get_save_conversation_handler` מקבלת כעת פרמטר אופציונלי `callback_query_handler_cls` המאפשר להזריק מחלקה חלופית עבור `CallbackQueryHandler` ב־fallbacks.
- ב־`main.py`, העברתי את `CallbackQueryHandler` המקורי לפונקציה `get_save_conversation_handler` כדי לשמר את ההתנהגות בפרודקשן.
- ב־`main.py`, הוספתי בדיקה למשתנה הסביבה `PYTEST_CURRENT_TEST` בתוך משימת ה־`_predictive_sampler_job`, כדי למנוע את הרצתה במהלך בדיקות (אלא אם כן `PREDICTIVE_SAMPLER_RUN_IN_TESTS` מוגדר במפורש ל־`true`).

## 🧪 בדיקות
- השינויים נועדו לתקן את הטסט `test_conversation_fallbacks_include_cancel` ולמנוע אזהרות "Unclosed client session" במהלך הרצת טסטים. נדרשת הרצת `pytest` מלאה לוודא שהטסטים עוברים כעת.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (דורש אימות ב-CI)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים (דורש אימות ב-CI)
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: אין השפעה צפויה על פרודקשן. השינויים מיועדים בעיקר לשיפור סביבת הבדיקות.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: החזרה לגרסה קודמת של הקבצים `main.py` ו־`conversation_handlers.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6abb7680-d77e-4d79-8fec-8e6dae1d4433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6abb7680-d77e-4d79-8fec-8e6dae1d4433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow injecting `CallbackQueryHandler` for conversation fallbacks and skip the predictive sampler during tests unless explicitly enabled.
> 
> - **Bot / Conversations**:
>   - `get_save_conversation_handler` accepts optional `callback_query_handler_cls` to construct fallback `CallbackQueryHandler`s (`cancel` and generic).
>   - `main.py` passes the real `CallbackQueryHandler` to preserve production behavior.
> - **Background jobs**:
>   - `_predictive_sampler_job` now no-ops under `PYTEST_CURRENT_TEST` unless `PREDICTIVE_SAMPLER_RUN_IN_TESTS` is truthy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8968ad134ec21918231f336ceccbbfa2587a362. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->