### PR TITLE
Fix conversation handler cancel fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -1813,6 +1813,12 @@ class CodeKeeperBot:
         # הגדר conversation handler להעלאת קבצים
         from github_menu_handler import FILE_UPLOAD, REPO_SELECT, FOLDER_SELECT
         async def _upload_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
+            try:
+                cq = getattr(update, "callback_query", None)
+                if cq is not None:
+                    await cq.answer("העלאה בוטלה", show_alert=False)
+            except Exception:
+                pass
             return ConversationHandler.END
 
         upload_conv_handler = ConversationHandler(
@@ -1830,7 +1836,10 @@ class CodeKeeperBot:
                     MessageHandler(filters.TEXT & ~filters.COMMAND, github_handler.handle_text_input)
                 ]
             },
-            fallbacks=[CommandHandler('cancel', _upload_cancel)]
+            fallbacks=[
+                CommandHandler('cancel', _upload_cancel),
+                CallbackQueryHandler(_upload_cancel, pattern=r'^cancel$')
+            ]
         )
         
         self.application.add_handler(upload_conv_handler)


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי טסט נכשל (`test_conversation_fallbacks_include_cancel`) על ידי הוספת `CallbackQueryHandler` ל-fallbacks של ה-`ConversationHandler` של העלאת קבצים. בנוסף, עדכנתי את פונקציית הביטול (`_upload_cancel`) כדי שתטפל גם בקריאות `callback_query` ותענה להן בנימוס.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `CallbackQueryHandler` עם pattern `r'^cancel$'` לרשימת ה-fallbacks של `upload_conv_handler`.
- עדכון פונקציית `_upload_cancel` לבדוק אם קיימת `callback_query` ולענות לה לפני סיום ה-conversation.

## 🧪 בדיקות
- הטסט `test_conversation_fallbacks_include_cancel` נכשל לפני השינוי בגלל היעדר ה-pattern `^cancel$` ברשימת ה-fallbacks. השינוי נועד לתקן את הטסט. לא הצלחתי להריץ `pytest` מקומית.
- [ ] Unit
- [ ] Integration
- [x] Manual (בדיקה שהשינוי מתייחס לבעיה בטסט)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (צריך לאמת ב-CI)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש בעת ביטול העלאת קבצים באמצעות כפתור, מונע שגיאות טלגרם. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: # (לא קיים issue ספציפי, אך מתקן טסט נכשל)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיט.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0f2a624-a72e-464d-84ba-02f6a6b4b913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0f2a624-a72e-464d-84ba-02f6a6b4b913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `CallbackQueryHandler('^cancel$')` fallback to the upload `ConversationHandler` and updates `_upload_cancel` to answer callback queries.
> 
> - **Handlers (GitHub upload flow)**:
>   - **Fallbacks**: Add `CallbackQueryHandler(_upload_cancel, pattern='^cancel$')` to `upload_conv_handler` fallbacks alongside `CommandHandler('cancel', ...)`.
>   - **Cancel behavior**: Update `_upload_cancel` to detect `callback_query` and `answer("העלאה בוטלה")` before ending the conversation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50f639d2bb3c5843a22b9cb6a13a8b2f188e991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->