### PR TITLE
Fix snippet reject reason test failure

### DIFF
--- a/conversation_handlers.py
+++ b/conversation_handlers.py
@@ -1392,11 +1392,14 @@ async def snippet_reject_start(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def snippet_collect_reject_reason(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    reason_text = (update.message.text or '').strip()
+    message = getattr(update, 'message', None)
+    raw_text = getattr(message, 'text', None) if message is not None else None
+    reason_text = (raw_text or '').strip()
     reason = reason_text if reason_text else None
     item_id = str(context.user_data.get('sn_reject_id') or '')
     if not item_id:
-        await _maybe_await(update.message.reply_text("❌ מזהה לא תקין"))
+        if message is not None and hasattr(message, 'reply_text'):
+            await _maybe_await(message.reply_text("❌ מזהה לא תקין"))
         return ConversationHandler.END
     ok = False
     try:
@@ -1427,8 +1430,8 @@ async def snippet_collect_reject_reason(update: Update, context: ContextTypes.DE
                 except Exception:
                     pass
     # שלח הודעת הצלחה רק במקרה של כשל – כדי למנוע כפילות מול ההודעה הידידותית שנשלחה למשתמש
-    if not ok:
-        await _maybe_await(update.message.reply_text("❌ כשל בדחייה"))
+    if not ok and message is not None and hasattr(message, 'reply_text'):
+        await _maybe_await(message.reply_text("❌ כשל בדחייה"))
     context.user_data.pop('sn_reject_id', None)
     return ConversationHandler.END
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את הפונקציה `snippet_collect_reject_reason` כך שתטפל במקרים שבהם אובייקט ההודעה (update.message) או שדה הטקסט (update.message.text) אינם קיימים. זה פותר `AttributeError` שגרם לכשל בטסט `test_snippet_reject_reason_failure_branch`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- שימוש ב-`getattr` לבדיקה בטוחה של קיום `update.message` ו-`update.message.text`.
- הוספת בדיקות קיום לאובייקט `message` ולמתודה `reply_text` לפני קריאה לפונקציות תגובה.

## 🧪 בדיקות
- הטסט `tests/test_snippet_reject_flow_message.py::test_snippet_reject_reason_failure_branch` נכשל לפני השינוי ועובר אחריו.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- מונע קריסה פוטנציאלית במקרה של עדכון ללא אובייקט `message` או שדה `text`, מה שמשפר את יציבות הבוט.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לקומיט הקודם. השינוי מבודד ובעל סיכון נמוך.

---
<a href="https://cursor.com/background-agent?bcId=bc-19e3f9d6-2cb2-4ce0-beb0-585bc97608a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19e3f9d6-2cb2-4ce0-beb0-585bc97608a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden `snippet_collect_reject_reason` to safely handle missing `update.message`/`text` and conditionally send replies, preventing AttributeError in edge cases.
> 
> - **Backend**
>   - **Snippet rejection flow**: Make `snippet_collect_reject_reason` resilient by using safe access to `update.message`/`text` (`getattr`) and sending replies only when `message.reply_text` exists.
>   - Avoid unconditional replies on failure; keep logic intact while preventing crashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4e71d9fcea4d51186e53f7b2cc49905474de00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->