### PR TITLE
Integrate theme assessments into web app

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -786,7 +786,8 @@ def inject_globals():
                 pass
     except Exception:
         pass
-    if theme not in {'classic','ocean','forest','high-contrast'}:
+    if theme not in {'classic','ocean','forest','high-contrast',
+                     'midnight-blue','true-black','tokyo-night','warm-light'}:
         theme = 'classic'
 
     show_welcome_modal = False
@@ -5909,7 +5910,7 @@ def api_ui_prefs():
 
     קלט JSON נתמך:
     - font_scale: float בין 0.85 ל-1.6 (אופציונלי)
-    - theme: אחד מ-{"classic","ocean","forest","high-contrast"} (אופציונלי)
+    - theme: אחד מ-{"classic","ocean","forest","high-contrast","midnight-blue","true-black","tokyo-night","warm-light"} (אופציונלי)
     - editor: "simple" | "codemirror" (אופציונלי)
     - work_state: אובייקט עם מצב עבודה נוכחי (last_url, scroll_y, timestamp)
     """
@@ -5943,7 +5944,8 @@ def api_ui_prefs():
         # עדכון ערכת צבעים במידת הצורך
         if 'theme' in payload:
             theme = (payload.get('theme') or '').strip().lower()
-            if theme in {'classic', 'ocean', 'forest', 'high-contrast'}:
+            if theme in {'classic', 'ocean', 'forest', 'high-contrast',
+                         'midnight-blue', 'true-black', 'tokyo-night', 'warm-light'}:
                 update_fields['ui_prefs.theme'] = theme
                 resp_payload['theme'] = theme
                 theme_cookie_value = theme

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -55,6 +55,87 @@
             --secondary: #22543d;
         }
 
+        /* New themes */
+        :root[data-theme="midnight-blue"] {
+            --bg-primary: #0f1419;
+            --bg-secondary: #1a1f29;
+            --text-primary: #e6edf3;
+            --text-secondary: #8b949e;
+            --accent: #58a6ff;
+            --accent-hover: #79c0ff;
+            /* map to existing tokens */
+            --primary: var(--bg-primary);
+            --secondary: var(--bg-secondary);
+        }
+        :root[data-theme="true-black"] {
+            --bg-primary: #000000;
+            --bg-secondary: #0d0d0d;
+            --text-primary: #ffffff;
+            --text-secondary: #b3b3b3;
+            --accent: #00d9ff;
+            --accent-hover: #00ffff;
+            --primary: var(--bg-primary);
+            --secondary: var(--bg-secondary);
+        }
+        :root[data-theme="tokyo-night"] {
+            --bg-primary: #1a1b26;
+            --bg-secondary: #24283b;
+            --text-primary: #c0caf5;
+            --text-secondary: #9aa5ce;
+            --accent: #7aa2f7;
+            --accent-hover: #bb9af7;
+            --primary: var(--bg-primary);
+            --secondary: var(--bg-secondary);
+        }
+        :root[data-theme="warm-light"] {
+            --bg-primary: #fef6e4;
+            --bg-secondary: #f7ede2;
+            --text-primary: #333333;
+            --text-secondary: #666666;
+            --accent: #f582ae;
+            --accent-hover: #bd4089;
+            --primary: var(--bg-primary);
+            --secondary: var(--bg-secondary);
+        }
+
+        /* Theme-specific text color overrides for better contrast */
+        [data-theme="midnight-blue"] body,
+        [data-theme="true-black"] body,
+        [data-theme="tokyo-night"] body,
+        [data-theme="warm-light"] body { color: var(--text-primary); }
+
+        [data-theme="midnight-blue"] .logo,
+        [data-theme="true-black"] .logo,
+        [data-theme="tokyo-night"] .logo,
+        [data-theme="warm-light"] .logo,
+        [data-theme="midnight-blue"] .nav-link,
+        [data-theme="true-black"] .nav-link,
+        [data-theme="tokyo-night"] .nav-link,
+        [data-theme="warm-light"] .nav-link,
+        [data-theme="midnight-blue"] .quick-access-toggle,
+        [data-theme="true-black"] .quick-access-toggle,
+        [data-theme="tokyo-night"] .quick-access-toggle,
+        [data-theme="warm-light"] .quick-access-toggle,
+        [data-theme="midnight-blue"] .btn-secondary,
+        [data-theme="true-black"] .btn-secondary,
+        [data-theme="tokyo-night"] .btn-secondary,
+        [data-theme="warm-light"] .btn-secondary { color: var(--text-primary); }
+
+        /* Primary button uses accent for new themes */
+        [data-theme="midnight-blue"] .btn-primary,
+        [data-theme="true-black"] .btn-primary,
+        [data-theme="tokyo-night"] .btn-primary,
+        [data-theme="warm-light"] .btn-primary {
+            background: var(--accent);
+            color: #ffffff;
+        }
+        [data-theme="midnight-blue"] .btn-primary:hover,
+        [data-theme="true-black"] .btn-primary:hover,
+        [data-theme="tokyo-night"] .btn-primary:hover,
+        [data-theme="warm-light"] .btn-primary:hover {
+            background: var(--accent-hover);
+        }
+
         * {
             margin: 0;
             padding: 0;

--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -170,6 +170,10 @@
                     <option value="ocean" {% if ui_theme == 'ocean' %}selected{% endif %}>אוקיינוס{% if ui_theme == 'ocean' %} (נוכחית){% endif %}</option>
                     <option value="forest" {% if ui_theme == 'forest' %}selected{% endif %}>יער{% if ui_theme == 'forest' %} (נוכחית){% endif %}</option>
                     <option value="high-contrast" {% if ui_theme == 'high-contrast' %}selected{% endif %}>ניגודיות גבוהה{% if ui_theme == 'high-contrast' %} (נוכחית){% endif %}</option>
+                    <option value="midnight-blue" {% if ui_theme == 'midnight-blue' %}selected{% endif %}>🌙 Midnight Blue{% if ui_theme == 'midnight-blue' %} (נוכחית){% endif %}</option>
+                    <option value="true-black" {% if ui_theme == 'true-black' %}selected{% endif %}>🕶️ True Black (OLED){% if ui_theme == 'true-black' %} (נוכחית){% endif %}</option>
+                    <option value="tokyo-night" {% if ui_theme == 'tokyo-night' %}selected{% endif %}>🌃 Tokyo Night{% if ui_theme == 'tokyo-night' %} (נוכחית){% endif %}</option>
+                    <option value="warm-light" {% if ui_theme == 'warm-light' %}selected{% endif %}>☀️ Warm Light{% if ui_theme == 'warm-light' %} (נוכחית){% endif %}</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
## ✨ תיאור קצר
הוספתי 4 ערכות נושא חדשות לווב-אפ: Midnight Blue, True Black (OLED), Tokyo Night, ו-Warm Light. השינוי מאפשר למשתמשים לבחור ערכת נושא מועדפת מתוך מגוון רחב יותר של אפשרויות תצוגה, ומשפר את חווית המשתמש.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- `webapp/templates/base.html`: הוגדרו משתני CSS עבור 4 ערכות הנושא החדשות (Midnight Blue, True Black, Tokyo Night, Warm Light) ובוצעו התאמות סגנוניות לרכיבים מרכזיים כמו רקע, טקסט וכפתורים.
- `webapp/app.py`: עודכן לכלול את שמות ערכות הנושא החדשות ברשימת הערכות הנתמכות, הן בבדיקת תקינות הערכה והן בשמירת העדפות המשתמש.
- `webapp/templates/settings.html`: נוספו אפשרויות הבחירה לערכות הנושא החדשות בתפריט ההגדרות של המשתמש.

## 🧪 בדיקות
בדקתי ידנית את בחירת כל אחת מערכות הנושא החדשות דרך תפריט ההגדרות. וידאתי שהערכה נטענת נכון, שהצבעים מיושמים כצפוי, ושהבחירה נשמרת לאחר רענון הדף וסגירת הדפדפן (באמצעות קוקי).
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
ההשפעה העיקרית היא על חווית המשתמש (UI). אין השפעה צפויה על ביצועים, אבטחה או לוגיקה עסקית קיימת.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
Rollback קל על ידי ביטול ה-PR (revert) וחזרה לגרסה הקודמת של הקבצים `base.html`, `app.py`, ו-`settings.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c76a1aa4-beeb-4344-876c-283e879a7bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c76a1aa4-beeb-4344-876c-283e879a7bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 4 new UI themes and enables selecting/saving them via settings and the UI prefs API.
> 
> - **Frontend (themes/CSS)**:
>   - Define new palettes in `webapp/templates/base.html` for `"midnight-blue"`, `"true-black"`, `"tokyo-night"`, `"warm-light"`, including background/text/accent tokens and button/contrast overrides.
> - **Settings UI**:
>   - Add the four themes to the theme selector in `webapp/templates/settings.html`.
> - **Backend (preferences)**:
>   - Extend allowed themes in `webapp/app.py` for theme validation in `inject_globals()` and `POST /api/ui_prefs` (accept/ persist cookies and DB fields).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f530cbaee1521766c6fd51ed4610dd5ee6d3b1c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->