### PR TITLE
Respond to github message in hebrew

### DIFF
--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -80,6 +80,8 @@
                 {% endif %}
               {% endfor %}
             </select>
+            <!-- שבירת שורה יזומה: העבר את תיבת 'שפה' לשורה הבאה -->
+            <div class="w-100 d-none d-lg-block"></div>
             <div class="language-filter" style="position:relative;">
               <button type="button" id="languageFilterBtn" class="btn btn-secondary btn-icon" aria-expanded="false" aria-haspopup="true" title="סינון לפי שפה">
                 <i class="fas fa-language"></i>
@@ -610,7 +612,7 @@
         } catch(_) {}
     })();
 
-    // שחזור פרמטרים אחרונים של חיפוש/פילטרים בעמוד הקבצים
+    // שחזור חלקי של פרמטרים (ללא ניווט אוטומטי) בעמוד הקבצים
     (function restoreFilesFilters(){
         const KEY = 'files_last_filters';
         function load(){ try { return JSON.parse(localStorage.getItem(KEY) || '{}'); } catch(_) { return {}; } }
@@ -629,23 +631,8 @@
             } catch(_) {}
         }
 
-        // בעת טעינה – אם אין פרמטרים ב-URL, אבל יש state אחרון – ננווט עם אותם פרמטרים
-        try {
-            const hasParams = !!(window.location.search && window.location.search.length > 1);
-            const st = load();
-            if (!hasParams && st && (st.q || st.lang || st.category || st.sort)) {
-                const p = new URLSearchParams();
-                if (st.q) p.set('q', st.q);
-                if (st.lang) p.set('lang', st.lang);
-                if (st.category) p.set('category', st.category);
-                if (st.sort) p.set('sort', st.sort);
-                const url = '/files' + (p.toString() ? ('?' + p.toString()) : '');
-                if (url !== window.location.pathname + window.location.search + window.location.hash) {
-                    window.location.replace(url);
-                    return;
-                }
-            }
-        } catch(_) {}
+        // ביטול ניווט אוטומטי: העמוד ייפתח נקי גם אם נשמרו פרמטרים קודמים
+        // נשמור רק בעת אינטראקציה, ללא שינוי מיידי של ה-URL בעת טעינה
 
         // בעת אינטראקציה: שמור state
         window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## ✨ תיאור קצר
העברתי את תיבת ה"שפה" בחיפוש הגלובלי שורה אחת למטה לשיפור הנראות, ותיקנתי את תקיעת הקאש בחיפוש בעמוד "כל הקבצים" כך שהעמוד נפתח נקי ללא תוצאות קודמות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת שבירת שורה יזומה (CSS/HTML) בקובץ `webapp/templates/files.html` כדי להעביר את תיבת סינון השפה בחיפוש הגלובלי לשורה נפרדת, גם במסכים רחבים.
- ביטול הניווט האוטומטי לפרמטרי חיפוש קודמים בטעינת עמוד "כל הקבצים", מה שמונע "קפיצה" לתוצאות ישנות ומבטיח פתיחה נקייה של העמוד.

## 🧪 בדיקות
בדקתי ידנית את התנהגות תיבת השפה בחיפוש הגלובלי במסכים שונים, ואת טעינת עמוד "כל הקבצים" לאחר חיפושים קודמים.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
סיכון נמוך. השינויים הם בעיקר ב-UI ובטיפול בקאש מקומי, ללא השפעה על לוגיקת שרת קריטית.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
ביצוע Rollback ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-790ef3fb-af37-4805-bbe5-126a955cec35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-790ef3fb-af37-4805-bbe5-126a955cec35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the language filter control to its own row on large screens and disables auto-navigation/restoration of saved filters on Files load (state saved only on interaction).
> 
> - **UI (templates)**:
>   - In `webapp/templates/files.html`, add a forced line break (`<div class="w-100 d-none d-lg-block"></div>`) to place the language filter control on the next row for large screens.
> - **Client-side behavior**:
>   - In `restoreFilesFilters` script, remove auto-navigation that reapplied saved query params on page load; now only capturing and saving `q`, `lang`, `category`, and `sort` on form change/submit and `popstate` without modifying the URL at load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e64824250924ed4bd825981c2592446c9fe1fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->