### PR TITLE
Fix async test fixture value error

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -116,6 +116,7 @@ def _ensure_legacy_event_loop_for_sync_tests(request: pytest.FixtureRequest) -> 
     נחזיר לולאה זמנית רק עבור טסטים שלא מסומנים כ-@pytest.mark.asyncio.
     """
     if request.node.get_closest_marker("asyncio"):
+        yield
         return
 
     created_loop: Optional[asyncio.AbstractEventLoop] = None


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקנתי את הפיקסצ'ר `_ensure_legacy_event_loop_for_sync_tests` ב-`conftest.py`.
- השינוי מונע שגיאת `ValueError: did not yield a value` בטסטים המסומנים ב-`@pytest.mark.asyncio`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `yield` לפיקסצ'ר `_ensure_legacy_event_loop_for_sync_tests` גם כאשר הטסט מסומן כ-`@pytest.mark.asyncio`, כדי להבטיח התנהגות תקינה של `pytest-asyncio`.

## 🧪 בדיקות
- נבדק ידנית על ידי הרצת הטסט הספציפי שנכשל: `tests/handlers/test_documents.py::test_handle_document_saves_small_snippet`.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (לאחר האימות הידני)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אין סודות/מפתחות בקוד
- [ ] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- סיכון נמוך. השינוי משפיע רק על תשתית הבדיקות ומתקן התנהגות שגויה של פיקסצ'ר.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה של תקלה, ניתן לבצע rollback על ידי חזרה לקומיט הקודם.

---
<a href="https://cursor.com/background-agent?bcId=bc-856b1683-08b7-4b1c-9045-c6acf39ffc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-856b1683-08b7-4b1c-9045-c6acf39ffc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a `yield` path to `_ensure_legacy_event_loop_for_sync_tests` when tests are marked with `@pytest.mark.asyncio`, preventing "did not yield a value" errors.
> 
> - **Tests/pytest fixtures**:
>   - Update `conftest.py::_ensure_legacy_event_loop_for_sync_tests` to `yield` when `@pytest.mark.asyncio` is present, ensuring proper generator fixture behavior and avoiding `ValueError: did not yield a value`.
>   - No changes to event loop setup/teardown for sync tests aside from the added early `yield` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96636a428c23124542e65033122fa37a4697bc1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->