### PR TITLE
Fix/pytest asyncio fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -78,7 +78,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
     # הפיקסצ'ר שמנקה את http_async רלוונטי רק לטסטים אסינכרוניים
     for item in items:
         if item.get_closest_marker("asyncio"):
-            item.add_marker(pytest.mark.usefixtures("_reset_http_async_session_for_async_tests"))
+            item.add_marker(pytest.mark.usefixtures("_reset_http_async_session_between_tests"))
 
 
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:  # type: ignore[override]
@@ -223,7 +223,7 @@ def _close_http_async_session_after_session() -> None:
 
 
 @pytest_asyncio.fixture
-async def _reset_http_async_session_for_async_tests() -> None:
+async def _reset_http_async_session_between_tests() -> None:
     """סוגר את הסשן הגלובלי של http_async לפני ואחרי כל טסט אסינכרוני."""
     try:
         from http_async import close_session  # type: ignore


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert the autouse fixture to a sync fixture that runs http_async.close_session in a temporary event loop before and after each test, gracefully handling when close_session is unavailable.
> 
> - **Testing (pytest fixtures)**:
>   - Convert `@pytest.fixture(autouse=True) _reset_http_async_session_between_tests` from `async def` to sync `def`.
>     - If `http_async.close_session` is missing: simply `yield` and return.
>     - Otherwise: define async `_close()` and run it in a fresh event loop via `_run_close()` before and after each test.
>     - Adds type hints and avoids depending on an existing event loop to ensure aiohttp global session cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f1d2ca04ab53ea6c892db589d546591df05e6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->