### PR TITLE
Fix key error in snippet library tests

### DIFF
--- a/services/snippet_library_service.py
+++ b/services/snippet_library_service.py
@@ -575,8 +575,8 @@ class SensitiveDataFilter(logging.Filter):
             msg = str(record.getMessage())
             # זיהוי בסיסי של טוקנים: ghp_..., github_pat_..., Bearer ...
             patterns = [
-                (r"ghp_[A-Za-z0-9]{20,}", "ghp_***REDACTED***"),
-                (r"github_pat_[A-Za-z0-9_]{20,}", "github_pat_***REDACTED***"),
+                (r"ghp_[A-Za-z0-9]{{20,}}", "ghp_***REDACTED***"),
+                (r"github_pat_[A-Za-z0-9_]{{20,}}", "github_pat_***REDACTED***"),
                 (r"Bearer{bs}s+[A-Za-z0-9._=:/+-]{{10,}}", "Bearer ***REDACTED***"),
             ]
             redacted = msg


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי `KeyError: '20,'` שהתרחש ב-`services/snippet_library_service.py` על ידי כפילת סוגריים מסולסלים בתבניות regex. זה מונע ממתודת `.format` לפרש אותם כ-placeholders, ובכך פותר את שגיאת זמן הריצה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי תבניות ה-regex ב-`SensitiveDataFilter` (שורות 578-579) מ-`{20,}` ל-`{{20,}}` כדי למנוע פרשנות שגויה על ידי `.format`.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
הבאג זוהה על ידי בדיקת יחידה שנכשלה (כפי שצוין בתיאור המשימה). התיקון מכוון לפתור את ה-`KeyError` הספציפי הזה.
- [x] Unit

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (התיקון פותר את הבדיקה שנכשלה)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
אין השפעה שלילית צפויה. התיקון משפר את יציבות הקוד ומונע קריסה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
החזרה לקומיט הקודם. השינוי קטן וממוקד.

---
<a href="https://cursor.com/background-agent?bcId=bc-042fbef5-716f-4774-950b-2fb7c2998b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-042fbef5-716f-4774-950b-2fb7c2998b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Escapes regex quantifiers in `SensitiveDataFilter` to prevent string formatting errors and ensure token redaction works.
> 
> - **Backend**:
>   - **Logging/Security**: In `services/snippet_library_service.py`, updated `SensitiveDataFilter` regex patterns to use `{{...}}` for quantifiers (e.g., `ghp_...`, `github_pat_...`) to avoid `.format` interpolation and maintain correct token redaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c32f089e92403fff978f55a0447844beb32f4fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->