### PR TITLE
Add push notification connectivity diagnostics

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -472,12 +472,14 @@ input:checked + .slider:before { transform: translateX(24px); }
         if (j.sent > 0) { setPushStatus('נשלחה התראת בדיקה'); return; }
         const codes = j.codes || {};
         const known = Object.keys(codes).map(k => Number(k));
-        if (known.includes(404) || known.includes(410)) {
+        // Treat only non-zero codes as meaningful; code 0 is a transport/TLS error
+        const nonZero = known.filter(k => k !== 0);
+        if (nonZero.includes(404) || nonZero.includes(410)) {
           setPushStatus('המנוי פג (404/410) — כבה/הפעל התראות ואז נסה שוב');
-        } else if (known.includes(401) || known.includes(403)) {
+        } else if (nonZero.includes(401) || nonZero.includes(403)) {
           setPushStatus('אי־התאמת מפתחות (401/403) — ודא זוג VAPID תואם ורענן מנוי');
-        } else if (known.length) {
-          setPushStatus('כשל שליחה (קודים: ' + known.join(', ') + ')');
+        } else if (nonZero.length) {
+          setPushStatus('כשל שליחה (קודים: ' + nonZero.join(', ') + ')');
         } else if (Array.isArray(j.errors) && j.errors.length) {
           const first = j.errors.find(e => !e.status || e.status === 0) || j.errors[0];
           const msg = (first && first.error) ? String(first.error) : 'שגיאה לא ידועה';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds /api/push/diagnose for Web Push connectivity checks and updates settings UI to treat status code 0 as transport/TLS errors in test results.
> 
> - **Backend**
>   - **Diagnostics**: Add `GET /api/push/diagnose` in `webapp/push_api.py` to probe FCM and Mozilla endpoints, returning per-target `status`, `ok`, and `error`; responds `200` if any succeed, else `502`.
> - **Frontend**
>   - **Test Push UX**: Update `settings.html` test handler to ignore code `0` in aggregated codes (treat as transport/TLS), adjust messages to focus on non-zero codes (404/410 expired, 401/403 key mismatch), and show a distinct message for `(0)` errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64a354a2e7bde450013924f36307ffa5ba36a9f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->