### PR TITLE
Feat/md preview admin folding toggle

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -2174,6 +2174,9 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
       (function initSectionContentAnimation(){
         const contentEl = content;
         if (!contentEl) return;
+        const prev = contentEl.style.transition;
+        // מניעת אנימציה בעת האתחול הראשוני
+        contentEl.style.transition = 'none';
         if (details.open) {
           contentEl.style.maxHeight = 'none';
           contentEl.style.opacity = '1';
@@ -2181,6 +2184,9 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
           contentEl.style.maxHeight = '0px';
           contentEl.style.opacity = '0';
         }
+        // כפיית reflow ואז החזרת transition לפרופיל CSS
+        void contentEl.offsetHeight;
+        requestAnimationFrame(() => { contentEl.style.transition = prev; });
       })();
 
       // עדכן מצב ושפעל אנימציה בכל שינוי
@@ -2194,9 +2200,11 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
             contentEl.style.opacity = '1';
             return;
           }
-          // פתיחה: 0 -> scrollHeight, ואז 'none' לשינוי דינמי
+          // פתיחה: קבע מצב התחלתי, כפיית reflow ואז יעד
           contentEl.style.maxHeight = '0px';
           contentEl.style.opacity = '0';
+          // כפיית reflow כדי שהדפדפן יישם את המצב ההתחלתי
+          void contentEl.offsetHeight;
           requestAnimationFrame(() => {
             contentEl.style.maxHeight = contentEl.scrollHeight + 'px';
             contentEl.style.opacity = '1';
@@ -2215,11 +2223,12 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
             contentEl.style.opacity = '0';
             return;
           }
-          // סגירה: אם בגובה 'none', הצב גובה נוכחי, ואז ל-0
+          // סגירה: אם max-height='none' הצב לגובה נוכחי, כפיית reflow ואז 0
           const cs = getComputedStyle(contentEl);
           if (cs.maxHeight === 'none') {
             contentEl.style.maxHeight = contentEl.scrollHeight + 'px';
           }
+          void contentEl.offsetHeight; // reflow
           requestAnimationFrame(() => {
             contentEl.style.maxHeight = '0px';
             contentEl.style.opacity = '0';


### PR DESCRIPTION

הוספתי אנימציית פתיחה/סגירה עדינה לקיפול H3:

טרנזישן על .md-section-content עם max-height ו-opacity, ו־JS שמחשב גובה דינמי לפתיחה/סגירה חלקה.
מכבד prefers-reduced-motion ומנטרל אנימציה אם נדרש.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds smooth max-height/opacity transitions for admin H3 collapsible (H3) sections in Markdown preview, respecting prefers-reduced-motion.
> 
> - **Markdown Preview (admin H3 folding)** in `webapp/templates/md_preview.html`:
>   - **CSS**: Add transitions on `#md-content details.md-section-collapse > .md-section-content` (overflow hidden, max-height/opacity with transition) and set open-state opacity; disable animations under `prefers-reduced-motion`.
>   - **JS**: Initialize section content styles based on `details.open` and animate open/close on `toggle` using dynamic `scrollHeight`; fall back to no animation when reduced motion is preferred; persist state in `localStorage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd0b95d82bac71f3d9954b3cef5611fb487ac8d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->