### PR TITLE
Fix snippet and line number direction

### DIFF
--- a/webapp/static/css/snippets.css
+++ b/webapp/static/css/snippets.css
@@ -15,6 +15,9 @@
   font-size: 0.9rem;
   line-height: 1.5;
   color: #e8eaed;
+  direction: ltr; /* force code area to stay LTR even בתוך דף RTL */
+  text-align: left;
+  unicode-bidi: isolate;
 }
 
 /* Ensure inner <code> wraps as well */
@@ -55,6 +58,7 @@ details > summary::-webkit-details-marker { display: none; }
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
+  direction: ltr; /* keep line numbers בצד שמאל */
 }
 .hljs-ln tr { vertical-align: top; }
 .hljs-ln td {


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את כיוון התצוגה של סניפטי קוד ומספרי שורות בספריית הסניפטים בווב אפ. השינוי מבטיח שהקוד יוצג בכיוון שמאל לימין (LTR) באופן טבעי, במקום ימין לשמאל (RTL) שהיה קיים.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הגדרת `direction: ltr; text-align: left; unicode-bidi: isolate;` עבור בלוקי קוד (`.code-block`, `.snippet-code`) ב-`snippets.css`.
- הגדרת `direction: ltr;` עבור טבלת מספרי השורות (`.hljs-ln`) ב-`snippets.css`.

## 🧪 בדיקות
- בוצעה בדיקה ידנית בדפדפן, נצפה שהסניפטים ומספרי השורות מוצגים כעת בכיוון LTR תקין.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה צפויה היא תיקון ויזואלי בלבד ללא סיכונים תפקודיים.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- ניתן לבצע Rollback על ידי היפוך שינויי ה-CSS בקובץ `webapp/static/css/snippets.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-68a284f6-3d9f-46a3-a26b-8ebca005173e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68a284f6-3d9f-46a3-a26b-8ebca005173e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Force LTR direction for code blocks and line numbers to display correctly within RTL pages.
> 
> - **CSS (`webapp/static/css/snippets.css`)**:
>   - Enforce LTR in code containers: add `direction: ltr`, `text-align: left`, and `unicode-bidi: isolate` to ` .code-block, .snippet-code`.
>   - Keep line numbers on the left: add `direction: ltr` to ` .hljs-ln`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9667a6a9495c1ce2c542c0fc8f0e032ae688942e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->