### PR TITLE
Add spacing to line numbers in snippets

### DIFF
--- a/webapp/static/css/snippets.css
+++ b/webapp/static/css/snippets.css
@@ -74,6 +74,7 @@ details > summary::-webkit-details-marker { display: none; }
 }
 .hljs-ln-code {
   width: auto;
+  padding-left: 0.85rem; /* keep breathing room between numbers and code */
 }
 .hljs-ln-code > .hljs-ln-line {
   white-space: pre-wrap;


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספנו מרווח פנימי (padding-left) לעמודת הקוד בספריית הסניפטים בווב אפ.
- זאת כדי לפתור בעיה שבה מספרי השורות היו צמודים מדי לקוד לאחר יישור קודם לשמאל, ובכך לשפר את קריאות הקוד.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD
- [x] Frontend (CSS)

פירוט נקודות (רשימת תבליטים):
- הוספת `padding-left: 0.85rem;` למחלקה `.hljs-ln-code` בקובץ `webapp/static/css/snippets.css`.

## 🧪 בדיקות
- בדקתי ידנית בדפדפן את ספריית הסניפטים ולוודא שהרווח החדש נראה טוב ומשפר את הקריאות.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי (מומלץ להוסיף צילום מסך של לפני ואחרי)

## 🧩 השפעות/סיכונים
- השפעה מינימלית, שינוי ויזואלי בלבד.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביטול שינוי ה-CSS בקובץ `snippets.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-90f19f30-ec82-4488-8192-790ea9094e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90f19f30-ec82-4488-8192-790ea9094e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add 0.85rem left padding to `.hljs-ln-code` to separate line numbers from code in snippets.
> 
> - **Frontend · CSS**
>   - In `webapp/static/css/snippets.css`, add `padding-left: 0.85rem` to ``.hljs-ln-code`` to create spacing between line numbers and code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d50b98964c5f638ad93b8cf27e357be5075285bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->