### PR TITLE
Test start and help command handlers

### DIFF
--- a/tests/_telegram_stubs.py
+++ b/tests/_telegram_stubs.py
@@ -106,7 +106,7 @@ class CommandHandler:
                 commands_tuple = (cmds,)
         filtered = tuple(c for c in commands_tuple if c)
         self.commands = filtered
-        self.command = filtered[0] if filtered else None
+        self.command = list(filtered) if filtered else None
 
 class MessageHandler:
     def __init__(self, filters, callback, *args, **kwargs):


### PR DESCRIPTION
## ✨ תיאור קצר
עדכנתי את הסטאב `CommandHandler` בקובץ `tests/_telegram_stubs.py`. כעת, התכונה `self.command` בסטאב מחזירה רשימה של פקודות, מה שמתאים להתנהגות הצפויה של `telegram.ext.CommandHandler` ופותר כשל בבדיקה שחיפשה פקודות כמו `/start` ו-`/help`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי ב-`tests/_telegram_stubs.py`: התכונה `self.command` בסטאב `CommandHandler` הוגדרה להחזיר רשימה (לדוגמה `['start']`) במקום מחרוזת בודדת או `None`.

## 🧪 בדיקות
- ניסיתי להריץ `python3 -m pytest tests/test_start_and_help_texts.py` באופן ידני, אך `pytest` לא היה מותקן בסביבה המקומית.
- התיקון מכוון ישירות לפתרון ה-`AssertionError` בבדיקה `test_start_and_help_texts_include_highlights`.
- [ ] Unit (צפוי לעבור ב-CI)
- [ ] Integration
- [x] Manual (ניסיון מקומי)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (צפוי לעבור ב-CI)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אין סודות/מפתחות בקוד
- [ ] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים (צפוי לעבור ב-CI)
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- הסיכון נמוך מאוד, השינוי משפיע רק על קובץ סטאבים המשמש לבדיקות יחידה.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- ניתן לבצע Rollback על ידי החזרת השורה היחידה ששונתה בקובץ `tests/_telegram_stubs.py` למצבה הקודם. ההשפעה צפויה להיות מינימלית.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff5d3c3-bc6c-4fe3-a137-73143b3a44b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ff5d3c3-bc6c-4fe3-a137-73143b3a44b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test stub so `CommandHandler.command` returns a list of commands instead of a single value.
> 
> - **Tests / Telegram stubs**:
>   - In `tests/_telegram_stubs.py`, `CommandHandler` now sets `self.command` to `list(filtered)` (list of commands) instead of `filtered[0]` (single command).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54763c0ceab574ba490e99e3610650c8cc6732ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->