### PR TITLE
Fix language detection for plain text

### DIFF
--- a/services/code_service.py
+++ b/services/code_service.py
@@ -39,6 +39,28 @@ except Exception:  # optional deps (e.g., cairosvg) might be missing locally
     code_processor = None
 
 
+def _normalize_detected_language(label: Optional[str]) -> Optional[str]:
+    """
+    מנרמל תוצאות זיהוי משירותים חיצוניים למונחים אחידים בתוך המערכת.
+    """
+    if not label:
+        return None
+    normalized = label.strip().lower()
+    alias_map = {
+        "text only": "text",
+        "plain text": "text",
+        "plaintext": "text",
+        "md": "markdown",
+        "gfm": "markdown",
+        "github flavored markdown": "markdown",
+        "github-flavored markdown": "markdown",
+    }
+    normalized = alias_map.get(normalized, normalized)
+    if not normalized or normalized in {"unknown"}:
+        return None
+    return normalized
+
+
 def _fallback_detect_language(code: str, filename: str) -> str:
     """
     זיהוי שפת תכנות לפי סיומת קובץ (fallback).
@@ -137,7 +159,9 @@ def detect_language(code: str, filename: str) -> str:
     detected = None
     if code_processor is not None:
         try:
-            detected = code_processor.detect_language(code, filename)
+            detected = _normalize_detected_language(
+                code_processor.detect_language(code, filename)
+            )
         except Exception:
             detected = None
 


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו פונקציית נרמול לתוצאות זיהוי שפה מ-`code_processor` כדי לטפל בערכים לא עקביים כמו "text only" או "plain text". זה מבטיח שהשירות יחזיר תמיד ערכים אחידים כמו "text" או "markdown", ופותר באג בבדיקה שכשלה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- הוספת פונקציה `_normalize_detected_language` ב-`services/code_service.py` למיפוי כינויים ווריאציות של שפות לערכים אחידים.
- שילוב פונקציית הנרמול בקריאה ל-`code_processor.detect_language` כדי לעבד את הפלט לפני החזרתו.

## 🧪 בדיקות
- הרצנו את הבדיקה הספציפית שנכשלה: `tests/unit/services/test_code_service_detect_language_new_cases.py`.
- הבדיקה עברה בהצלחה לאחר השינוי.
- [x] Unit

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השינוי משפר את עקביות זיהוי השפה. אין סיכון ביצועים משמעותי או השפעה שלילית צפויה על פרודקשן.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- החזרה לגרסה קודמת של הקובץ `services/code_service.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dfe4697-5189-44a9-9a54-93cd3f1bff27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2dfe4697-5189-44a9-9a54-93cd3f1bff27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `code_processor` language labels (e.g., "plain text", "gfm") to canonical values to improve text/markdown detection.
> 
> - **Backend**
>   - **Language detection**:
>     - Add `_normalize_detected_language` in `services/code_service.py` to map aliases (e.g., `"text only"`, `"plain text"`, `"gfm"`) to canonical `"text"`/`"markdown"` and ignore `"unknown"`.
>     - Apply normalization to `code_processor.detect_language(...)` result within `detect_language`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d36c04ef685f791e43c7d476e69dfde50eaf5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->