### PR TITLE
feat: Add smooth scrolling debug panel

### DIFF
--- a/docs/webapp/smooth-scrolling.rst
+++ b/docs/webapp/smooth-scrolling.rst
@@ -102,6 +102,9 @@ API לשימוש קליינט
   - ודאו שהקריאה היא דרך ``updateConfig`` ושקיים ``window.smoothScroll``.
 - “משתמש עם Reduced Motion עדיין רואה אנימציות”:
   - בדקו את העדפת המערכת (DevTools > Rendering > Emulate CSS prefers-reduced-motion).
+- “אני לא בטוח אם הפיצ'ר פועל”:
+  - הוסיפו ל‑URL את הפרמטר ``smooth_debug=1`` (למשל ``/?smooth_debug=1`` או ``&smooth_debug=1``) כדי לפתוח חלונית בדיקה.
+  - החלונית מציגה אם הדפדפן מסמן ``prefers-reduced-motion``, אם המנגנון פעיל, ומאפשרת להפעיל/לכבות או למחוק את ההעדפה שנשמרה ב‑``localStorage``.
 
 תוכנית המשך (Roadmap מקוצר)
 ---------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add an opt‑in smooth scrolling debug panel (via URL param `smooth_debug=1`) that displays status and allows toggling/resetting preferences, and update docs accordingly.
> 
> - **WebApp JS (`webapp/static/js/smooth-scroll.js`)**:
>   - **Debug mode**: Parse `smooth_debug=1` from URL to enable a lightweight debug panel.
>   - **UI panel**: New `renderDebugPanel` and `updateDebugPanel` show:
>     - `prefers-reduced-motion` status, internal enabled state, animation duration, Samsung/Android WebView detection.
>     - Controls: toggle smooth scroll, clear `localStorage` prefs, close panel.
>   - **Internals**: Add `debugMode`/`debugRefs` state and invoke panel rendering post-init when enabled.
> - **Docs (`docs/webapp/smooth-scrolling.rst`)**:
>   - Add troubleshooting steps for enabling the debug panel via `smooth_debug=1` and what it displays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a48760751d5d08d0eb9e911aba2dade2075d69b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->