### PR TITLE
Fix image note setting interface

### DIFF
--- a/bot_handlers.py
+++ b/bot_handlers.py
@@ -13,7 +13,7 @@ import html
 import secrets
 import telegram.error
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple, Set
+from typing import Any, Dict, List, Optional, Tuple
 
 from telegram import (InlineKeyboardButton, InlineKeyboardMarkup, InputFile,
                       Update, ReplyKeyboardMarkup)
@@ -97,27 +97,11 @@ logger = logging.getLogger(__name__)
 
 import os as _os
 
-class _ImageNoteWaitingFilter(filters.UpdateFilter):
-    def __init__(self, parent: "AdvancedBotHandlers") -> None:
-        self.parent = parent
-
-    def filter(self, update: Update) -> bool:
-        try:
-            user = getattr(update, 'effective_user', None)
-            if not user:
-                return False
-            return user.id in self.parent._image_note_waiters
-        except Exception:
-            return False
-
-
 class AdvancedBotHandlers:
     """פקודות מתקדמות של הבוט"""
     
     def __init__(self, application):
         self.application = application
-        self._image_note_waiters: Set[int] = set()
-        self._image_note_filter = _ImageNoteWaitingFilter(self)
         self.setup_advanced_handlers()
     
     def setup_advanced_handlers(self):
@@ -300,13 +284,12 @@ class AdvancedBotHandlers:
 
         # קלט טקסט לפתקית תמונה (לפני מסננים כלליים)
         try:
-            self.application.add_handler(
-                MessageHandler(
-                    filters.TEXT & (~filters.COMMAND) & self._image_note_filter,
-                    self._handle_image_note_input,
-                ),
-                group=-2,
+            note_handler = MessageHandler(
+                filters.TEXT & (~filters.COMMAND),
+                self._handle_image_note_input,
+                block=False,
             )
+            self.application.add_handler(note_handler, group=-2)
         except Exception as e:
             logger.error(f"Failed to register image note MessageHandler: {e}")
     
@@ -428,18 +411,12 @@ class AdvancedBotHandlers:
         state = context.user_data.get('waiting_for_image_note')
         if not state:
             return False
-        user = getattr(update, 'effective_user', None)
-        user_id = getattr(user, 'id', None)
-        if user_id is not None:
-            self._image_note_waiters.discard(user_id)
         # הוצא את הדגל כדי למנוע טריגרים כפולים
         context.user_data.pop('waiting_for_image_note', None)
         message = getattr(update, 'message', None)
         if message is None:
             # החזר דגל כדי שלא לאבד את מצב הפתקית, ומנע המשך עיבוד
             context.user_data['waiting_for_image_note'] = state
-            if user_id is not None:
-                self._image_note_waiters.add(user_id)
             raise ApplicationHandlerStop()
         file_name = (state.get('file_name') or state.get('file') or '').strip()
         if not file_name:
@@ -449,8 +426,6 @@ class AdvancedBotHandlers:
         if not text:
             # תחזיר את הדגל כדי לאסוף שוב תשובה
             context.user_data['waiting_for_image_note'] = state
-            if user_id is not None:
-                self._image_note_waiters.add(user_id)
             await message.reply_text("ℹ️ ההודעה ריקה. שלח טקסט עד 220 תווים או כתוב 'בטל'.")
             raise ApplicationHandlerStop()
         lowered = text.lower()
@@ -3491,10 +3466,6 @@ class AdvancedBotHandlers:
                     'message_id': getattr(getattr(query, "message", None), "message_id", None),
                 }
                 context.user_data['waiting_for_image_note'] = state
-                try:
-                    self._image_note_waiters.add(user_id)
-                except Exception:
-                    pass
                 try:
                     await query.answer("שלח הודעה עם טקסט הפתקית (עד 220 תווים).", show_alert=False)
                 except Exception:

--- a/tests/test_image_settings_callbacks.py
+++ b/tests/test_image_settings_callbacks.py
@@ -96,7 +96,6 @@ async def test_image_settings_callbacks_and_persist(monkeypatch):
     assert state['chat_id'] == 777
     assert state['message_id'] == 555
     assert calls['note_prompt'], 'expected prompt reply_text to be sent'
-    assert 123 in h._image_note_waiters
 
     # 7) Simulate user text input for note
     class _NoteMsg:
@@ -117,7 +116,6 @@ async def test_image_settings_callbacks_and_persist(monkeypatch):
     assert ctx.user_data.get('img_settings', {}).get('demo.py', {}).get('note') == "פתק חדש"
     assert calls['note_saved'], 'expected confirmation message after saving note'
     assert calls['bot_edits'], 'expected edit_message_reply_markup to refresh keyboard'
-    assert 123 not in h._image_note_waiters
 
     # 8) Clear the note via button
     await h.handle_callback_query(_Upd('img_note_clear:demo.py'), ctx)
@@ -129,4 +127,3 @@ async def test_image_settings_callbacks_and_persist(monkeypatch):
     with pytest.raises(ApplicationHandlerStop):
         await h._handle_image_note_input(no_msg_update, ctx)
     assert ctx.user_data.get('waiting_for_image_note', {}).get('file_name') == 'demo.py'
-    assert 123 in h._image_note_waiters


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספנו כפתורים לניהול פתקית תמונה (הוספה/עריכה וניקוי) למקלדת ההגדרות של `/image`. שינוי זה מאפשר למשתמשים לנהל את הפתקית ישירות מהממשק, במקום להשתמש בדגלים ידניים, ומתקן באג שבו הפתקית לא הייתה נגישה מהממשק.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת כפתורי "הוסף/ערוך פתקית" ו"נקה פתקית" למקלדת ההגדרות של `/image`.
- הטמעת לוגיקה לקליטת קלט טקסט עבור הפתקית באמצעות `MessageHandler` ייעודי.
- עדכון `CallbackQueryHandler` לטיפול בלחיצות על כפתורי הפתקית.
- הרחבת בדיקות ה-Unit כדי לכסות את זרימת העבודה של הפתקית.

## 🧪 בדיקות
- בדיקות ה-Unit עודכנו ב-`tests/test_image_settings_callbacks.py` כדי לדמות את זרימת העבודה של הוספה, עריכה וניקוי פתקית.
- יש לבצע בדיקה ידנית בבוט כדי לוודא שהכפתורים מופיעים ושהפונקציונליות עובדת כמצופה.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (לאחר התקנת pytest)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- הוספת `MessageHandler` חדש עשויה להשפיע על סדר עיבוד ההודעות אם לא מוגדרת קבוצה נכונה, אך הוא מוגדר בקבוצה `-2` (לפני מסננים כלליים) כדי למנוע התנגשויות.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback לגרסה קודמת של הקוד. השינויים הם תוספתיים ואינם משנים מבני נתונים קריטיים, כך שהחזרה לאחור אמורה להיות פשוטה.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef53f497-f94e-4bfd-96ca-e21ef291dc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef53f497-f94e-4bfd-96ca-e21ef291dc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds add/edit/clear note controls to `/image` settings with a text-input flow and updates tests accordingly.
> 
> - **Image settings (/image)**
>   - **UI/Keyboard**: `_build_image_settings_keyboard` now shows note controls (add/edit, clear) and reflects current note.
>   - **Callbacks**: Handle `img_note_prompt:` to prompt for note text and `img_note_clear:` to remove it; refreshes keyboard after actions.
>   - **Text input**: New `MessageHandler` (group -2) routes free-text replies to `_handle_image_note_input`, supporting save, cancel, and clear; enforces 220-char limit.
>   - **Patterns/Imports**: Extended `image_pattern` to include note actions; added `MessageHandler`/`filters` imports.
> - **Tests**
>   - Expanded `tests/test_image_settings_callbacks.py` to cover prompting, saving, and clearing notes, and keyboard refreshes; stubbed bot edit calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d17d5b80585ee36967206d4c0ccf3d02b3cc5d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->