### PR TITLE
Respond to github message in hebrew

### DIFF
--- a/services/image_generator.py
+++ b/services/image_generator.py
@@ -881,6 +881,11 @@ class CodeImageGenerator:
         max_width = min(max(160, min(int(base.width * 0.35), 320)), card_width)
         if base.width - max_width < 60 or base.height < 120 or max_width < 80:
             return img
+        content_top = self.CARD_MARGIN + self.TITLE_BAR_HEIGHT + inner_padding
+        content_bottom = base.height - self.CARD_MARGIN - inner_padding
+        available_height = max(0, content_bottom - content_top)
+        if available_height <= 0:
+            return img
         font_size = max(14, self.FONT_SIZE + 4)
         font = self._get_note_font(font_size, bold=True)
         padding = 18
@@ -896,6 +901,14 @@ class CodeImageGenerator:
         except Exception:
             measured_height = font_size
         line_height = max(24, int(measured_height * 1.2))
+        min_note_height = padding * 2 + line_height
+        if available_height < min_note_height:
+            return img
+        space_for_lines = max(0, available_height - padding * 2)
+        max_lines_fit = min(len(lines), max(1, space_for_lines // line_height))
+        if len(lines) > max_lines_fit:
+            lines = lines[:max_lines_fit]
+            lines[-1] = lines[-1][: max(0, len(lines[-1]) - 1)] + "…"
         height = padding * 2 + line_height * len(lines)
         overlay = Image.new('RGBA', (max_width, height), (255, 244, 148, 235))
         draw = ImageDraw.Draw(overlay)
@@ -922,8 +935,6 @@ class CodeImageGenerator:
         card_left = card_left_boundary
         card_right = card_right_boundary
         x = max(card_left, card_right - max_width)
-        content_top = self.CARD_MARGIN + self.TITLE_BAR_HEIGHT + inner_padding
-        content_bottom = base.height - self.CARD_MARGIN - inner_padding
         y = content_top
         if y + height > content_bottom:
             y = max(content_top, content_bottom - height)


### PR DESCRIPTION
## ✨ תיאור קצר
הזזנו את פתקית ההערה לתוך גבולות הכרטיס, שינינו את הפונט שלה לפונט קריא התומך בעברית, והתאמנו את גודל הפונט וגובה השורה. שינויים אלו מבטיחים שההערות מוצגות באופן אסתטי וקריא יותר בתוך התמונה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- הוספת מטמון (`_note_font_cache`) ופונקציה ייעודית (`_get_note_font`) לבחירת פונטים קריאים (כמו DejaVu Sans ו-Noto Sans) התומכים בעברית עבור הערות, במקום פונט הקוד המונוספייסי.
- עדכון לוגיקת המיקום והגודל של הפתקית בפונקציה `_add_annotation_overlay` כדי להבטיח שהיא מוצבת בתוך גבולות הכרטיס (`card_left_boundary`, `card_right_boundary`), עם רוחב מוגבל, מיקום מעוגן לימין, והתאמת גובה וגודל פונט.
- שינוי חישוב `line_height` לשימוש ב-`font.getmetrics()` למדידה מדויקת יותר של גובה השורה.

## 🧪 בדיקות
- ניסיון להריץ `python3 -m pytest tests/test_image_generator.py` נכשל עקב חוסר בתלויות (`No module named pytest`).
- בוצעו בדיקות ידניות של יצירת תמונות עם הערות כדי לוודא מיקום, פונט ותמיכה בעברית.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש בזכות הצגה טובה יותר של הערות בתמונות.
- סיכון נמוך: שינויים ויזואליים בלבד.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- החזרה לאחור של הקומיט הנוכחי.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2cb56af-4967-4653-b78a-e3f90bf64108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2cb56af-4967-4653-b78a-e3f90bf64108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches note overlay to a Hebrew-supporting sans font with metric-based line height and constrains its placement within the code card.
> 
> - **Image generation (`services/image_generator.py`)**:
>   - **Fonts**:
>     - Add `_note_font_cache` and `_get_note_font` to use readable sans fonts (e.g., DejaVu Sans, Noto Sans) with Hebrew support for notes, including bold variants.
>   - **Notes overlay layout**:
>     - Constrain overlay within card using `card_left_boundary`/`card_right_boundary`, inner padding, and safe width checks.
>     - Use `_get_note_font` with larger default size; compute line height via `font.getmetrics()`.
>     - Adjust positioning to anchor to the right within content area and respect top/bottom content boundaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e372a7637f5664ff764801ea2282c4dfce13b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->