### PR TITLE
Respond to github issue about pr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,10 +85,27 @@ RUN apt-get update -y && apt-get upgrade -y && \
 # שמירה על גרסאות pip/setuptools מעודכנות
 RUN python -m pip install --upgrade --no-cache-dir 'pip>=24.1' 'setuptools>=78.1.1' 'wheel>=0.43.0'
 
-# יצירת משתמש לא-root
-RUN groupadd -g 1000 botuser && \
-    useradd -m -s /bin/bash -u 1000 -g 1000 botuser && \
-    mkdir -p /app /app/logs /app/backups /app/temp && \
+# יצירת משתמש לא-root (אידמפוטנטי גם אם ה-UID/GID כבר תפוסים בבייס)
+ARG BOT_UID=1000
+ARG BOT_GID=1000
+RUN set -eux; \
+    if getent group "${BOT_GID}" >/dev/null 2>&1; then \
+        GROUP_FLAGS="-g ${BOT_GID} -o"; \
+    else \
+        GROUP_FLAGS="-g ${BOT_GID}"; \
+    fi; \
+    if ! getent group botuser >/dev/null 2>&1; then \
+        groupadd ${GROUP_FLAGS} botuser; \
+    fi; \
+    if getent passwd "${BOT_UID}" >/dev/null 2>&1; then \
+        USER_FLAGS="-u ${BOT_UID} -o"; \
+    else \
+        USER_FLAGS="-u ${BOT_UID}"; \
+    fi; \
+    if ! id -u botuser >/dev/null 2>&1; then \
+        useradd ${USER_FLAGS} -m -s /bin/bash -g botuser botuser; \
+    fi; \
+    mkdir -p /app /app/logs /app/backups /app/temp; \
     chown -R botuser:botuser /app
 
 # העתקת Python packages ו-constraints מה-builder stage


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את תהליך יצירת המשתמש/קבוצה ב-Dockerfile כדי שיהיה אידמפוטנטי. זה פותר קריסות בנייה כאשר UID/GID 1000 כבר תפוסים בתמונת הבסיס, כפי שדווח ב-CI.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- שיניתי את הלוגיקה ליצירת המשתמש `botuser` והקבוצה `botuser` ב-Dockerfile.
- הוספתי בדיקות (`getent`) לפני יצירת הקבוצה/המשתמש כדי לוודא שהם לא קיימים.
- השתמשתי בדגל `-o` (override) עבור `groupadd` ו-`useradd` אם ה-GID/UID כבר תפוסים, כדי למנוע שגיאות.
- שמרתי את יצירת הספריות וה-`chown` באותו בלוק.

## 🧪 בדיקות
- [x] Manual
- בדקתי ידנית את הלוגיקה ב-Dockerfile.
- נדרשת הרצת `docker build --target production .` לאימות מלא של הבנייה.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על אמינות תהליך הבנייה. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביצוע Rollback לשינויים ב-Dockerfile.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bf56a04-84a4-4622-a90a-5a0398830f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2bf56a04-84a4-4622-a90a-5a0398830f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Dockerfile to create `botuser`/group idempotently using UID/GID args with conditional checks and overrides to prevent build failures.
> 
> - **Dockerfile**:
>   - Replace fixed `useradd/groupadd` with idempotent logic using `ARG BOT_UID/BOT_GID`, `getent`/`id` checks, and `-o` overrides when IDs are taken.
>   - Keep directory creation and `chown` for `/app` paths under `botuser`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8085560647469e3ad21828694a58e34b9d23d60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->