### PR TITLE
Respond to script crash with illegal option

### DIFF
--- a/scripts/start_with_worker.sh
+++ b/scripts/start_with_worker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
-set -euo pipefail
+set -eu
+
+# Enable pipefail when running under shells that support it (dash does not).
+if [ -n "${BASH_VERSION:-}" ] || [ -n "${ZSH_VERSION:-}" ]; then
+  # shellcheck disable=SC3040
+  set -o pipefail
+fi
 
 # Load local worker overrides if present (not committed to git)
 if [ -f ".env.worker" ]; then


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון קריסה בסקריפט `start_with_worker.sh` שנגרמה עקב שימוש ב־`set -o pipefail` בסביבת `dash` shell. השינוי מאפשר הפעלת `pipefail` רק ב־shells תומכים (bash/zsh), ובכך מונע את השגיאה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הסרת `o pipefail` מהשורה הראשונה של `set -euo pipefail`.
- הוספת בדיקה לגרסת ה־shell (`BASH_VERSION` או `ZSH_VERSION`) לפני הפעלת `set -o pipefail` ב־`scripts/start_with_worker.sh`.

## 🧪 בדיקות
הבעיה אובחנה כחוסר תמיכה של `dash` באופציה `pipefail` והפתרון מטפל ישירות בשורש הבעיה. לא בוצעה הרצה מלאה של הסקריפט כדי לא להעלות את האפליקציה.
- [ ] Unit
- [ ] Integration
- [x] Manual (נדרשת הרצה בסביבת המשתמש לווידוא)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

### דוגמאות Conventional Commits

| סוג | דוגמה להודעה | מתי להשתמש |
| --- | --- | --- |
| feat | feat: הוספת מסך הגדרות | פיצ'ר חדש למשתמש |
| fix | fix: תיקון קריסה בעת התחברות | תיקון באג מול משתמשים/פרודקשן |
| chore | chore: שדרוג Gradle ל-8.9 | תחזוקה, כלי פיתוח, housekeeping |
| docs | docs: עדכון README עם הוראות התקנה | שינויי תיעוד בלבד |
| refactor | refactor: חילוץ Repository ל-UseCases | שינוי מבני ללא שינוי התנהגות |
| test | test: הוספת בדיקות ל-LoginViewModel | הוספת/עדכון בדיקות |
| build | build: הוספת flavor staging ל-CI | שינויים בבילד/תלויות/תצורה |

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה חיובית: מונע קריסה של הסקריפט `start_with_worker.sh` בסביבות `dash` shell. אין השפעה שלילית צפויה על סביבות `bash`/`zsh` שכן הן כבר תומכות ב־`pipefail`.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
החזרת הקובץ `scripts/start_with_worker.sh` לגרסתו הקודמת.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c690ce-0e12-4ee8-8ca7-d315632aa8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45c690ce-0e12-4ee8-8ca7-d315632aa8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids dash crash by only setting `pipefail` when running under bash/zsh and defaulting to `set -eu`.
> 
> - **Scripts**:
>   - `scripts/start_with_worker.sh`:
>     - Replace `set -euo pipefail` with `set -eu`.
>     - Conditionally enable `set -o pipefail` only for shells supporting it (`bash`/`zsh`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97926a39f7f61f10c8156f3498c4e4292abe6278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->