### PR TITLE
Respond to github context in hebrew

### DIFF
--- a/webapp/push_api.py
+++ b/webapp/push_api.py
@@ -585,12 +585,23 @@ def _send_for_user(user_id: int | str, reminders: list[dict]) -> None:
         except Exception:
             # If claiming fails unexpectedly, fall back to best-effort send
             pass
+        title_text = "🔔 יש פתק ממתין"
+        body_text = _coerce_preview(db, r)
+        note_id_str = str(r.get("note_id") or "")
+        file_id_str = str(r.get("file_id") or "")
+
         payload = {
-            "title": "🔔 יש פתק ממתין",
-            "body": _coerce_preview(db, r),
+            "title": title_text,
+            "body": body_text,
+            "notification": {
+                "title": title_text,
+                "body": body_text
+            },
             "data": {
-                "note_id": str(r.get("note_id") or ""),
-                "file_id": str(r.get("file_id") or ""),
+                "note_id": note_id_str,
+                "file_id": file_id_str,
+                "title": title_text,
+                "body": body_text,
             },
             "actions": [
                 {"action": "open_note", "title": "פתח פתק"},
@@ -805,10 +816,20 @@ def test_push():
             except Exception:
                 return jsonify({"ok": False, "error": "pywebpush_not_available"}), 500
 
+        title_text = "🔔 בדיקת פוש"
+        body_text = "זוהי הודעת בדיקה"
+        
         payload = {
-            "title": "🔔 בדיקת פוש",
-            "body": "זוהי הודעת בדיקה",
-            "data": {},
+            "title": title_text,
+            "body": body_text,
+            "notification": {
+                "title": title_text,
+                "body": body_text
+            },
+            "data": {
+                "title": title_text,
+                "body": body_text,
+            },
             "actions": [
                 {"action": "open_note", "title": "פתח"},
             ],


### PR DESCRIPTION
## ✨ תיאור קצר
שיפור אמינות קבלת התראות פוש במכשירי אנדרואיד/FCM על ידי יצירת Payload עמיד יותר ועדכון ה-Service Worker לטפל במבני Payload שונים. זה פותר בעיות שבהן התראות לא הופיעו עקב פרשנות שונה של מבנה ההודעה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם (Service Worker)
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- **Backend (`webapp/push_api.py`)**: עודכן לשלוח Payload "היברידי" הכולל את כותרת וגוף ההודעה בשלושה מקומות: ברמה העליונה, תחת מפתח `notification`, ותחת מפתח `data`. זה מבטיח תאימות מקסימלית עם אופן הטיפול של דפדפנים ומערכות הפעלה שונות.
- **Service Worker (`webapp/static/sw.js`)**: עודכן לחלץ את `title` ו-`body` באופן עמיד ממספר מיקומים אפשריים ב-Payload (רמה עליונה, `notification.title`, `data.title`), מה שמבטיח שההתראה תוצג גם אם מבנה ה-Payload מפורש אחרת.

## 🧪 בדיקות
- הבדיקות הקיימות (`tests/test_push_api.py`, `tests/test_push_remote.py`) עברו בהצלחה. בוצעה בדיקה ידנית של שליחת פוש דרך כפתור הבדיקה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על אמינות קבלת התראות פוש, במיוחד במכשירי אנדרואיד המשתמשים ב-FCM. סיכון נמוך, השינויים ממוקדים בפורמט ה-Payload ובפרשנותו.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback לגרסה הקודמת של הקבצים `webapp/push_api.py` ו-`webapp/static/sw.js`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d660d34-0251-4cae-be38-318b9ce24710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d660d34-0251-4cae-be38-318b9ce24710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sends title/body in top-level, `notification`, and `data` payloads and updates the service worker to robustly extract fields from any of these shapes.
> 
> - **Backend (`webapp/push_api.py`)**:
>   - Send hybrid payload for reminders and test push: include `title`/`body` at top-level, under `notification`, and in `data`.
>   - Add `note_id`/`file_id` as strings in `data`; reuse computed `title_text`/`body_text`.
> - **Service Worker (`webapp/static/sw.js`)**:
>   - Robust parsing of push payload: derive `title`/`body` from top-level, `notification`, or `data`.
>   - Merge top-level `note_id`/`file_id` into `data` if missing; pass merged `data` to notifications.
>   - Use extracted `title`/`body` when calling `showNotification`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5713e5b2926e88725baa9f3d256240b79ac55c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->