### PR TITLE
Check editor loading issue from github

### DIFF
--- a/webapp/static/js/editor-manager.js
+++ b/webapp/static/js/editor-manager.js
@@ -248,32 +248,16 @@
     async loadCodeMirror() {
       // נסה קודם טעינה מקומית (bundle) כדי לעבוד גם ללא CDN
       try {
-        const localUrl = (() => {
-          try {
-            const base = new URL('.', import.meta.url);
-            return new URL('codemirror.local.js', base).href;
-          } catch (_) {
-            try {
-              const script = document.querySelector('script[type="module"][src*="editor-manager.js"]');
-              if (script && script.src) {
-                const src = String(script.src || '').split('?')[0];
-                return src.replace(/editor-manager\.js$/, 'codemirror.local.js');
-              }
-            } catch(_) {}
-            try {
-              const anyStatic = document.querySelector('link[href*="/static/"]');
-              if (anyStatic) {
-                const href = new URL(anyStatic.href, window.location.href);
-                const idx = href.pathname.indexOf('/static/');
-                if (idx >= 0) {
-                  const basePath = href.pathname.slice(0, idx + 1);
-                  return `${window.location.origin}${basePath}static/js/codemirror.local.js`;
-                }
-              }
-            } catch(_) {}
-            return '/static/js/codemirror.local.js';
-          }
-        })();
+        let localUrl;
+        try {
+           // שימוש בנתיב אבסולוטי מפורש כפי שנדרש
+           const baseUrl = window.location.origin;
+           localUrl = `${baseUrl}/static/js/codemirror.local.js`;
+        } catch(_) {
+           // Fallback logic
+           localUrl = '/static/js/codemirror.local.js';
+        }
+
         try { console.log('[EditorManager] Attempting to load local CodeMirror bundle from:', localUrl); } catch(_) {}
         const localModule = await this.withTimeout(import(localUrl), 12000, 'codemirror_local_import');
         const localApi = (localModule && (localModule.default || localModule.CodeMirror6)) || null;
@@ -542,4 +526,5 @@
   }
 
   window.editorManager = new EditorManager();
+  try { console.log('[EditorManager] Assigned window.editorManager instance'); } catch(_) {}
 })();

--- a/webapp/templates/snippet_submit.html
+++ b/webapp/templates/snippet_submit.html
@@ -118,24 +118,42 @@
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', async function() {
-  try {
     const container = document.getElementById('snippetEditorContainer');
-    if (container && window.editorManager) {
-      console.log('[snippet_submit] Initializing editor with language: text');
-      await window.editorManager.initEditor(container, {
-        language: 'text',
-        value: '',
-        theme: 'dark'
-      });
-
-      const languageSelect = document.getElementById('language');
-      if (languageSelect) {
-        languageSelect.addEventListener('change', async (e) => {
-          try { await window.editorManager.updateLanguage(e.target.value); } catch(_) {}
-        });
-      }
+    if (!container) {
+        console.warn('[snippet_submit] Container #snippetEditorContainer not found');
+        return;
     }
-  } catch (_) {}
+
+    // Polling for editorManager (up to 3s)
+    let attempts = 0;
+    while (!window.editorManager && attempts < 30) {
+        await new Promise(r => setTimeout(r, 100));
+        attempts++;
+    }
+
+    if (!window.editorManager) {
+        console.error('[snippet_submit] window.editorManager not found after wait');
+        // Fallback: Show simple textarea if it was hidden? It's already visible by default.
+        return;
+    }
+
+    console.log('[snippet_submit] Initializing editor with language: text');
+    try {
+        await window.editorManager.initEditor(container, {
+            language: 'text',
+            value: '',
+            theme: 'dark'
+        });
+
+        const languageSelect = document.getElementById('language');
+        if (languageSelect) {
+            languageSelect.addEventListener('change', async (e) => {
+                try { await window.editorManager.updateLanguage(e.target.value); } catch(err) { console.error(err); }
+            });
+        }
+    } catch (e) {
+        console.error('[snippet_submit] Error initializing editor:', e);
+    }
 });
 </script>
 {% endblock %}

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -54,18 +54,30 @@
 {% block extra_js %}
 <script>
   document.addEventListener('DOMContentLoaded', async function () {
-    try {
       const container = document.getElementById('editorContainer');
       const languageSelect = document.getElementById('languageSelect');
       const form = document.getElementById('uploadForm');
       const fileNameInput = document.querySelector('input[name="file_name"]');
-      if (container && window.editorManager && typeof window.editorManager.initEditor === 'function') {
-        await window.editorManager.initEditor(container, {
-          language: (languageSelect && languageSelect.value) || 'text',
-          value: {{ code_value | tojson }},
-          theme: 'dark'
-        });
+
+      // Poll for editorManager
+      let attempts = 0;
+      while (!window.editorManager && attempts < 30) {
+        await new Promise(r => setTimeout(r, 100));
+        attempts++;
       }
+
+      if (container && window.editorManager && typeof window.editorManager.initEditor === 'function') {
+        try {
+            await window.editorManager.initEditor(container, {
+            language: (languageSelect && languageSelect.value) || 'text',
+            value: {{ code_value | tojson }},
+            theme: 'dark'
+            });
+        } catch(e) { console.error('[upload] initEditor failed', e); }
+      } else {
+        if (!window.editorManager) console.error('[upload] editorManager missing');
+      }
+
       if (languageSelect && window.editorManager && typeof window.editorManager.updateLanguage === 'function') {
         languageSelect.addEventListener('change', async (e) => {
           try { await window.editorManager.updateLanguage(e.target.value); } catch (_) {}
@@ -110,7 +122,6 @@
           }
         });
       }
-    } catch (_) {}
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון בעיות בטעינת העורך (CodeMirror) בדפים `/submit` ו-`/upload`. השינויים כוללים הסרת דיכוי שגיאות, הוספת מנגנון המתנה לטעינת `editorManager` ושימוש בנתיב אבסולוטי מפורש לקבצי CodeMirror, יחד עם שיפור לוגים לאבחון תקלות.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוסרו בלוקי `try-catch` חיצוניים שדיכאו שגיאות באתחול העורך ב-`snippet_submit.html` ו-`upload.html`.
- נוסף מנגנון Polling (עד 3 שניות) ב-`snippet_submit.html` ו-`upload.html` כדי להמתין לטעינת `window.editorManager`, מה שפותר Race Conditions.
- עודכן `editor-manager.js` לשימוש בנתיב אבסולוטי מפורש (`window.location.origin`) לטעינת `codemirror.local.js`.
- נוספו הודעות Log מפורטות יותר לקונסול כדי לאבחן כשלים בטעינת העורך.

## 🧪 בדיקות
- בדקתי ידנית על ידי רענון הדפים `/submit` ו-`/upload`. העורך נטען כעת כראוי, ובמקרה של תקלה, מוצגת הודעת שגיאה מפורטת בקונסול במקום שתיקה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על יציבות טעינת העורך. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: # (התבסס על דיווח משתמש)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3866690-b8b4-4bf8-868c-b2a0060e66e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3866690-b8b4-4bf8-868c-b2a0060e66e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of CodeMirror loading and editor initialization by using an absolute local bundle path, adding polling, and surfacing errors/logs on submit/upload pages.
> 
> - **Editor Manager (`webapp/static/js/editor-manager.js`)**:
>   - Use explicit absolute URL (`window.location.origin/static/js/codemirror.local.js`) for local CodeMirror bundle; fallback to `/static/js/codemirror.local.js`.
>   - Add console log after assigning `window.editorManager`.
> - **Templates**:
>   - `webapp/templates/snippet_submit.html`:
>     - Add polling (up to ~3s) for `window.editorManager` before init.
>     - Initialize editor with guarded `try/catch` and detailed console errors; wire language change to `updateLanguage`.
>   - `webapp/templates/upload.html`:
>     - Add polling for `window.editorManager`; wrap `initEditor` in `try/catch` with error logs and missing-manager notice.
>     - Preserve existing language-change handler and submit overwrite confirmation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d0dee1873e55303d1aea5275cad1c6ce5c55612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->