### PR TITLE
Revert "Address theme display bugs on github (#1817)"

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -60,78 +60,21 @@
         /* Theme palettes */
         :root[data-theme="classic"] {
             --primary: #667eea;
-            --primary-dark: #5a67d8;
             --secondary: #764ba2;
-            --text-primary: #ffffff;
-            --text-secondary: rgba(255, 255, 255, 0.82);
-            --text-muted: rgba(255, 255, 255, 0.65);
-            --bg-primary: #6b63ff;
-            --bg-secondary: #8e63ff;
-            --bg-tertiary: rgba(255, 255, 255, 0.25);
-            --card-bg: rgba(255, 255, 255, 0.12);
-            --card-border: rgba(255, 255, 255, 0.25);
         }
         :root[data-theme="ocean"] {
             --primary: #3182ce;
-            --primary-dark: #2b6cb0;
             --secondary: #2c5282;
-            --bg-primary: #e6f2ff;
-            --bg-secondary: #d7eefe;
-            --bg-tertiary: #cde4fb;
-            --text-primary: #0f172a;
-            --text-secondary: #1d3557;
-            --text-muted: #4a5568;
-            --glass: rgba(49, 130, 206, 0.15);
-            --glass-border: rgba(49, 130, 206, 0.3);
-            --glass-hover: rgba(49, 130, 206, 0.22);
-            --card-bg: rgba(236, 246, 255, 0.96);
-            --card-border: rgba(49, 130, 206, 0.25);
-            --code-bg: #0f172a;
-            --code-text: #e2e8f0;
-            --code-border: rgba(15, 23, 42, 0.4);
         }
         :root[data-theme="forest"] {
             --primary: #2f855a;
-            --primary-dark: #276749;
             --secondary: #22543d;
-            --bg-primary: #edf7f1;
-            --bg-secondary: #e0f2e2;
-            --bg-tertiary: #d3ebd7;
-            --text-primary: #1c3526;
-            --text-secondary: #2f855a;
-            --text-muted: #4a674f;
-            --glass: rgba(47, 133, 90, 0.15);
-            --glass-border: rgba(47, 133, 90, 0.28);
-            --glass-hover: rgba(47, 133, 90, 0.22);
-            --card-bg: rgba(237, 247, 241, 0.96);
-            --card-border: rgba(47, 133, 90, 0.3);
-            --code-bg: #142a1d;
-            --code-text: #e6fffa;
-            --code-border: rgba(34, 84, 61, 0.45);
         }
         /* Rose Pine Dawn (light) */
         :root[data-theme="rose-pine-dawn"] {
             --primary: #907aa9; /* iris */
             --primary-dark: #7b6f9a;
             --secondary: #d7827e; /* rose */
-            --bg-primary: #faf4ed;
-            --bg-secondary: #f2e9e1;
-            --bg-tertiary: #eaddd5;
-            --text-primary: #575279;
-            --text-secondary: #6e6a86;
-            --text-muted: #797593;
-            --glass: rgba(250, 244, 237, 0.9);
-            --glass-border: rgba(144, 122, 169, 0.35);
-            --glass-hover: rgba(144, 122, 169, 0.25);
-            --card-bg: rgba(250, 244, 237, 0.96);
-            --card-border: rgba(144, 122, 169, 0.35);
-            --code-bg: #f2e9e1;
-            --code-text: #433c59;
-            --code-border: rgba(87, 82, 121, 0.25);
-            --success: #56949f;
-            --danger: #b4637a;
-            --warning: #ea9d34;
-            --info: #907aa9;
         }
 
         /* Theme palettes - Dark & Dim */
@@ -239,13 +182,6 @@
             color: var(--text-primary);
         }
 
-        :root[data-theme="ocean"] body,
-        :root[data-theme="forest"] body,
-        :root[data-theme="rose-pine-dawn"] body {
-            background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-            color: var(--text-primary);
-        }
-
         body::before {
             content: '';
             position: fixed;
@@ -271,18 +207,6 @@
 
         :root[data-theme="nebula"] body::before {
             background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%2324324a" fill-opacity="0.22" d="M0,96L48,112C96,128,192,160,288,160C384,160,480,128,576,122.7C672,117,768,139,864,138.7C960,139,1056,117,1152,101.3C1248,85,1344,75,1392,69.3L1440,64L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"/></svg>') no-repeat bottom center;
-        }
-
-        :root[data-theme="ocean"] body::before {
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%233182ce" fill-opacity="0.12" d="M0,96L48,112C96,128,192,160,288,160C384,160,480,128,576,122.7C672,117,768,139,864,138.7C960,139,1056,117,1152,101.3C1248,85,1344,75,1392,69.3L1440,64L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"/></svg>') no-repeat bottom center;
-        }
-
-        :root[data-theme="forest"] body::before {
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%232f855a" fill-opacity="0.12" d="M0,96L48,112C96,128,192,160,288,160C384,160,480,128,576,122.7C672,117,768,139,864,138.7C960,139,1056,117,1152,101.3C1248,85,1344,75,1392,69.3L1440,64L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"/></svg>') no-repeat bottom center;
-        }
-
-        :root[data-theme="rose-pine-dawn"] body::before {
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="%23f2e9e1" fill-opacity="0.4" d="M0,96L48,112C96,128,192,160,288,160C384,160,480,128,576,122.7C672,117,768,139,864,138.7C960,139,1056,117,1152,101.3C1248,85,1344,75,1392,69.3L1440,64L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"/></svg>') no-repeat bottom center;
         }
 
         
@@ -345,7 +269,7 @@
         .logo {
             font-size: 1.5rem;
             font-weight: 700;
-            color: var(--text-primary, white);
+            color: white;
             text-decoration: none;
             display: flex;
             align-items: center;
@@ -360,7 +284,7 @@
         }
         
         .nav-link {
-            color: var(--text-primary, white);
+            color: white;
             text-decoration: none;
             font-weight: 500;
             transition: opacity 0.3s;
@@ -457,7 +381,7 @@
         
         .btn-secondary {
             background: var(--glass);
-            color: var(--text-primary, white);
+            color: white;
             border: 1px solid var(--glass-border);
         }
         
@@ -568,7 +492,7 @@
             display: none;
             background: transparent;
             border: none;
-            color: var(--text-primary, white);
+            color: white;
             font-size: 1.5rem;
             cursor: pointer;
         }
@@ -695,29 +619,25 @@
         }
 
         .quick-access-toggle {
-            background: var(--quick-toggle-bg, var(--glass));
-            border: 1px solid var(--quick-toggle-border, var(--glass-border));
-            color: var(--quick-toggle-color, var(--text-primary, #ffffff));
-            padding: 0.5rem 0.85rem;
-            border-radius: 10px;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid var(--glass-border);
+            color: white;
+            padding: 0.5rem 0.75rem;
+            border-radius: 8px;
             cursor: pointer;
-            transition: all 0.25s ease;
+            transition: all 0.3s ease;
             font-size: 1.1rem;
-            box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
         }
 
         .quick-access-toggle:hover {
-            background: var(--quick-toggle-hover-bg, var(--glass-hover, rgba(255, 255, 255, 0.2)));
+            background: rgba(255, 255, 255, 0.2);
             transform: translateY(-2px);
-            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
-            color: var(--primary, currentColor);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         }
 
         .quick-access-toggle.active {
             background: var(--primary);
-            border-color: var(--primary);
-            color: #ffffff;
-            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+            color: white;
         }
 
         .quick-access-dropdown {
@@ -725,9 +645,9 @@
             top: 100%;
             right: 0; /* נפתח מתחת לכפתור ולא מכסה את הלוגו */
             transform: translateY(6px);
-            background: var(--quick-dropdown-bg, var(--card-bg, #ffffff));
+            background: white;
             border-radius: 12px;
-            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.15);
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
             opacity: 0;
             visibility: hidden;
             transition: all 0.25s ease;
@@ -738,7 +658,6 @@
             padding: .4rem;
             max-width: calc(100vw - 24px); /* אין גלילה אופקית */
             overflow-x: hidden;
-            border: 1px solid var(--quick-dropdown-border, var(--card-border, rgba(0, 0, 0, 0.08)));
         }
 
         .quick-access-dropdown.active {
@@ -754,10 +673,10 @@
             height: 44px;
             padding: 0;
             border-radius: 10px;
-            color: var(--text-primary, #333);
+            color: #333;
             text-decoration: none;
-            background: var(--quick-item-bg, transparent);
-            border: 1px solid var(--quick-item-border, var(--glass-border, rgba(0,0,0,0.08)));
+            background: none;
+            border: 1px solid rgba(0,0,0,0.08);
             cursor: pointer;
             transition: transform .15s ease, background .2s ease;
         }
@@ -766,9 +685,8 @@
         .quick-access-item:last-child { border-radius: 0 0 12px 12px; }
 
         .quick-access-item:hover {
-            background: var(--glass-hover, rgba(103, 126, 234, 0.1));
+            background: rgba(103, 126, 234, 0.1);
             color: var(--primary);
-            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
         }
 
         .qa-icon { font-size: 1.1rem; }
@@ -988,7 +906,7 @@
             border-radius: 12px;
             margin-top: 8px;
             padding: 6px 10px;
-            color: var(--text-primary, #fff);
+            color: #fff;
             display: flex;
             align-items: center;
             gap: 8px;
@@ -1006,7 +924,7 @@
             animation: none !important;
         }
         .announcement-banner__content { white-space: normal; line-height: 1.28; opacity: 0.95; font-size: 0.95rem; }
-        .announcement-banner__content a { color: inherit; text-decoration: underline; }
+        .announcement-banner__content a { color: #fff; text-decoration: underline; }
         .announcement-banner__content a:hover { opacity: 0.9; }
         .announcement-banner:hover .announcement-banner__inner,
         .announcement-banner:focus-within .announcement-banner__inner,

--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -136,71 +136,7 @@
   height: auto;
 }
 /* מיקום כפתור "צבע רקע" – העברה לכותרת ומניעת חפיפה */
-#md-search {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  padding: 0.75rem;
-  border-radius: 12px 12px 0 0;
-  margin: -16px -16px 0 -16px;
-  background: var(--md-search-bg, var(--card-bg, rgba(255, 255, 255, 0.95)));
-  border: 1px solid var(--md-search-border, var(--card-border, rgba(0, 0, 0, 0.08)));
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
-}
-
-#md-search input {
-  flex: 1 1 220px;
-  min-width: 0;
-  border-radius: 8px;
-  padding: 0.6rem 0.8rem;
-  font-size: 0.95rem;
-  background: var(--md-search-input-bg, var(--bg-tertiary, rgba(255, 255, 255, 0.85)));
-  border: 1px solid var(--md-search-input-border, var(--glass-border, rgba(0, 0, 0, 0.1)));
-  color: var(--text-primary, #1f2933);
-  outline: none;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-
-#md-search input::placeholder {
-  color: var(--text-muted, rgba(15, 23, 42, 0.55));
-}
-
-#md-search input:focus {
-  border-color: var(--primary, #9775fa);
-  box-shadow: 0 0 0 3px rgba(151, 117, 250, 0.2);
-  background: var(--md-search-input-focus-bg, #ffffff);
-}
-
-#md-search .result-count {
-  color: var(--text-secondary, var(--text-primary, #1f2933));
-  font-size: 0.85rem;
-  padding: 0.35rem 0.6rem;
-  background: var(--md-search-pill-bg, var(--glass, rgba(0, 0, 0, 0.04)));
-  border-radius: 6px;
-  min-width: 60px;
-  text-align: center;
-  border: 1px solid var(--glass-border, rgba(0, 0, 0, 0.08));
-  flex: 0 0 auto;
-}
-
-#md-search button {
-  flex: 0 0 auto;
-  min-width: 0;
-  border-radius: 8px;
-  background: var(--md-search-btn-bg, var(--glass, rgba(0, 0, 0, 0.04)));
-  border: 1px solid var(--md-search-btn-border, var(--glass-border, rgba(0, 0, 0, 0.12)));
-  color: var(--md-search-btn-color, var(--text-primary, #1f2933));
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-#md-search button:hover,
-#md-search button:focus-visible {
-  background: var(--glass-hover, rgba(0, 0, 0, 0.1));
-  border-color: var(--primary, rgba(151, 117, 250, 0.5));
-  color: var(--primary, #9775fa);
-}
+#md-search { position: relative; }
 #bgColorSwitcher { position: relative; z-index: 1; margin-inline-end: .5rem; }
 @media (max-width: 600px) {
   /* במובייל – אם צריך, ניתן להעביר לשורה שנייה בתוך הכותרת */
@@ -578,10 +514,6 @@ input.md-task-checkbox {
   --accent-30: color-mix(in srgb, var(--primary) 30%, transparent);
   --accent-35: color-mix(in srgb, var(--primary) 35%, transparent);
   --accent-40: color-mix(in srgb, var(--primary) 40%, transparent);
-  --md-toc-mini-bg: var(--glass, rgba(255, 255, 255, 0.92));
-  --md-toc-mini-hover-bg: var(--glass-hover, rgba(255, 255, 255, 0.98));
-  --md-toc-mini-border: var(--glass-border, rgba(0, 0, 0, 0.12));
-  --md-toc-mini-shadow: 0 4px 14px rgba(15, 23, 42, 0.15);
 }
 
 .md-toc {
@@ -667,31 +599,18 @@ input.md-task-checkbox {
 
 .md-toc-toggle,
 .md-toc-search-btn {
-  background: var(--glass, rgba(255,255,255,0.2));
-  border: 1px solid var(--glass-border, rgba(255,255,255,0.3));
+  background: rgba(255,255,255,0.2);
+  border: 1px solid rgba(255,255,255,0.3);
   border-radius: 8px;
   padding: 0.4rem 0.6rem;
   cursor: pointer;
-  color: var(--text-primary, white);
+  color: white;
   transition: all 0.2s ease;
-}
-
-/* Theme overrides for TOC */
-:root[data-theme="rose-pine-dawn"] .md-toc-header {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border-bottom: 1px solid var(--glass-border);
-}
-:root[data-theme="rose-pine-dawn"] .md-toc-toggle,
-:root[data-theme="rose-pine-dawn"] .md-toc-search-btn {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  border-color: var(--glass-border);
 }
 
 .md-toc-toggle:hover,
 .md-toc-search-btn:hover {
-  background: var(--glass-hover, rgba(255,255,255,0.3));
+  background: rgba(255,255,255,0.3);
   transform: scale(1.05);
 }
 
@@ -881,12 +800,12 @@ input.md-task-checkbox {
   left: 12px;  /* בצד שמאל של המסך */
   width: 44px;
   height: 44px;
-  border-radius: 12px;
-  background: var(--md-toc-mini-bg);
-  color: var(--text-primary, #1f2933);
-  border: 1px solid var(--md-toc-mini-border);
+  border-radius: 10px; /* ריבוע מעוגל קלות */
+  background: var(--toc-header-gradient);
+  color: white;
+  border: none;
   cursor: pointer;
-  box-shadow: var(--md-toc-mini-shadow);
+  box-shadow: 0 4px 12px var(--accent-35);
   transition: transform 0.15s ease, box-shadow 0.2s ease;
   z-index: 1000;
   touch-action: none; /* מאפשר גרירה חלקה במובייל */
@@ -894,9 +813,7 @@ input.md-task-checkbox {
 
 .md-toc-mini-btn:hover {
   transform: scale(1.1);
-  background: var(--md-toc-mini-hover-bg);
-  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.22);
-  color: var(--primary, currentColor);
+  box-shadow: 0 6px 20px var(--accent-40);
 }
 
 /* Virtual Scrolling - פריט placeholder */
@@ -1041,11 +958,11 @@ input.md-task-checkbox {
         מסך מלא
       </button>
     </div>
-    <div class="search-bar" id="md-search">
-      <input id="mdSearchInput" type="text" placeholder="🔍 חפש בקוד...">
-      <span id="mdSearchCount" class="result-count"></span>
-      <button id="mdSearchNext" type="button" class="btn btn-secondary btn-icon" title="הבא">▶</button>
-      <button id="mdSearchClear" type="button" class="btn btn-secondary btn-icon" title="נקה">✕</button>
+    <div class="search-bar" id="md-search" style="display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;background:linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);padding:.75rem;border-radius:12px 12px 0 0;box-shadow:0 2px 8px rgba(0,0,0,0.2);margin:-16px -16px 0 -16px;position:relative;">
+      <input id="mdSearchInput" type="text" placeholder="🔍 חפש בקוד..." style="flex:1 1 220px;min-width:0;background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);border-radius:8px;padding:.6rem .8rem;color:#fff;font-size:.95rem;outline:none;">
+      <span id="mdSearchCount" class="result-count" style="color:rgba(255,255,255,.9);font-size:.85rem;padding:.35rem .6rem;background:rgba(255,255,255,.12);border-radius:6px;min-width:60px;text-align:center;flex:0 0 auto;"></span>
+      <button id="mdSearchNext" type="button" class="btn btn-secondary btn-icon" title="הבא" style="background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);flex:0 0 auto;">▶</button>
+      <button id="mdSearchClear" type="button" class="btn btn-secondary btn-icon" title="נקה" style="background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);flex:0 0 auto;">✕</button>
     </div>
     <div id="md-content" style="margin-inline:-4px;width:calc(100% + 8px);"></div>
   </div>

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -80,66 +80,60 @@
     padding: 0.75rem;
     margin: 0 -0.25rem 0.75rem;
     border-radius: 12px;
-    background: var(--code-search-bg, var(--bg-tertiary, rgba(255, 255, 255, 0.95)));
-    border: 1px solid var(--code-search-border, var(--card-border, rgba(0, 0, 0, 0.08)));
-    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.12);
+    background: var(--glass, rgba(255, 255, 255, 0.08));
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
     backdrop-filter: blur(18px);
-    color: var(--text-primary, #1f2933);
 }
 
 .code-search-input {
     flex: 1 1 220px;
     min-width: 0;
-    background: var(--code-search-input-bg, var(--bg-tertiary, rgba(255, 255, 255, 0.85)));
-    border: 1px solid var(--code-search-input-border, var(--glass-border, rgba(0, 0, 0, 0.1)));
+    background: var(--glass, rgba(255, 255, 255, 0.08));
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
     border-radius: 8px;
     padding: 0.6rem 0.8rem;
     font-size: 0.95rem;
-    color: var(--text-primary, #1f2933);
+    color: var(--text-primary, #ffffff);
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .code-search-input::placeholder {
-    color: var(--text-muted, rgba(15, 23, 42, 0.55));
+    color: rgba(255, 255, 255, 0.65);
 }
 
 .code-search-input:focus {
     border-color: var(--primary, #9775fa);
-    box-shadow: 0 0 0 3px var(--glass-border, rgba(151, 117, 250, 0.25));
-    background: var(--code-search-input-focus-bg, #ffffff);
+    box-shadow: 0 0 0 3px rgba(151, 117, 250, 0.25);
+    background: rgba(255, 255, 255, 0.12);
 }
 
 .code-search-count {
-    color: var(--text-secondary, var(--text-primary, #1f2933));
+    color: var(--text-primary, #ffffff);
     font-size: 0.85rem;
     padding: 0.35rem 0.6rem;
-    background: var(--code-search-pill-bg, var(--glass, rgba(0, 0, 0, 0.04)));
+    background: var(--glass, rgba(255, 255, 255, 0.12));
     border-radius: 6px;
     min-width: 60px;
     text-align: center;
-    border: 1px solid var(--glass-border, rgba(0, 0, 0, 0.08));
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
     flex: 0 0 auto;
 }
 
 .code-search-btn {
-    background: var(
-        --code-search-btn-bg,
-        var(--bg-tertiary, var(--glass, rgba(0, 0, 0, 0.05)))
-    ) !important;
-    border: 1px solid var(--code-search-btn-border, var(--glass-border, rgba(0, 0, 0, 0.12))) !important;
-    color: var(--code-search-btn-color, var(--text-primary, #1f2933)) !important;
+    background: var(--glass, rgba(255, 255, 255, 0.12)) !important;
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.25)) !important;
+    color: var(--text-primary, #ffffff) !important;
     flex: 0 0 auto;
     min-width: 0;
-    border-radius: 8px;
-    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .code-search-btn:hover,
 .code-search-btn:focus-visible {
-    background: var(--glass-hover, rgba(0, 0, 0, 0.08)) !important;
-    border-color: var(--primary, rgba(151, 117, 250, 0.5)) !important;
-    color: var(--primary, #9775fa) !important;
+    background: rgba(255, 255, 255, 0.2) !important;
+    border-color: rgba(255, 255, 255, 0.35) !important;
 }
 
 /* כאשר הכרטיס במסך מלא – הקוד יתפוס כמעט את כל הגובה */


### PR DESCRIPTION
Restore base, markdown preview, and view file templates to the pre-PR #1817 styling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts theme/UI tweaks from #1817 and restores prior dark/glass styling across base layout, Markdown preview, and file view (simplifying themes and hardening colors).
> 
> - **Styling/Theming**:
>   - Simplifies theme variables to focus on `dark`/`dim`/`nebula`; removes per-theme palettes and related body/wave styles for `classic`/`ocean`/`forest`/`rose-pine-dawn`.
>   - Replaces many `var(--text-*)` uses with explicit `white` and fixed RGBA values; standardizes glass/gradient look.
> - **Base (`webapp/templates/base.html`)**:
>   - Updates navbar/logo/nav-link/button colors to white.
>   - Refactors quick-access menu: fixed backgrounds/borders/shadows; dropdown uses `white`; item colors/borders simplified.
>   - Announcement banner link color set explicitly to `#fff`.
> - **Markdown Preview (`webapp/templates/md_preview.html`)**:
>   - Removes prior CSS block for search bar; adds compact positioning and inlined styles for `#md-search` and inputs/buttons.
>   - TOC controls/buttons and mini-button restyled to fixed rgba/gradient; removes theme-specific overrides.
> - **File View (`webapp/templates/view_file.html`)**:
>   - Restyles code search toolbar/inputs/buttons to glassy dark look with white text and RGBA borders/shadows.
>   - Keeps functionality intact (copy, share, fullscreen, search) while adjusting visuals only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eef1442ac46de37a509dc0a07718de4deff72ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->