### PR TITLE
Fix/nebula theme reset

### DIFF
--- a/webapp/static/css/dark-mode.css
+++ b/webapp/static/css/dark-mode.css
@@ -13,16 +13,14 @@
 }
 
 [data-theme="dark"] .glass-card,
-[data-theme="dim"] .glass-card,
-[data-theme="nebula"] .glass-card {
+[data-theme="dim"] .glass-card {
     background: var(--card-bg);
     border: 1px solid var(--card-border);
     color: var(--text-primary);
 }
 
 [data-theme="dark"] .glass-card:hover,
-[data-theme="dim"] .glass-card:hover,
-[data-theme="nebula"] .glass-card:hover {
+[data-theme="dim"] .glass-card:hover {
     background: var(--glass-hover);
 }
 
@@ -62,16 +60,14 @@
    ============================================ */
 
 [data-theme="dark"] .btn-primary,
-[data-theme="dim"] .btn-primary,
-[data-theme="nebula"] .btn-primary {
+[data-theme="dim"] .btn-primary {
     background: var(--primary);
     color: white;
     border: 1px solid var(--primary-dark);
 }
 
 [data-theme="dark"] .btn-primary:hover,
-[data-theme="dim"] .btn-primary:hover,
-[data-theme="nebula"] .btn-primary:hover {
+[data-theme="dim"] .btn-primary:hover {
     background: var(--primary-dark);
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(124, 138, 255, 0.4);
@@ -365,8 +361,7 @@
 
 @media (max-width: 768px) {
     [data-theme="dark"] .glass-card,
-    [data-theme="dim"] .glass-card,
-    [data-theme="nebula"] .glass-card {
+    [data-theme="dim"] .glass-card {
         padding: 1rem;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `nebula` variants from select dark-mode rules and adds explicit navbar link colors for all themes.
> 
> - **Dark mode CSS** (`webapp/static/css/dark-mode.css`):
>   - Remove `nebula` selectors from `glass-card`, `.glass-card:hover`, `.btn-primary`, `.btn-primary:hover`, and mobile `@media` padding rules; keep only `dark` and `dim`.
>   - Add explicit navbar link colors and hover styles (`.navbar .nav-link`) for `dark`, `dim`, and `nebula` to ensure readable text.
>   - Retain `nebula` support in other components (e.g., forms, alerts, links, modals, badges, file cards, scrollbars).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d030ad16a983072fe6fd04071df6337c35b2098. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->