### PR TITLE
Respond to github message in hebrew

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -7,15 +7,15 @@
 }
 .cm-editor { min-height: 400px; max-height: 60vh; font-family: 'Fira Code','Consolas',monospace; }
 /* Modified: Default to row layout for tablets/desktop */
-.editor-switcher { display:flex; flex-direction:row; justify-content: space-between; align-items: center; flex-wrap: wrap; gap:.35rem; margin:.5rem 0; padding:.5rem; background: rgba(255,255,255,0.05); border-radius:8px; }
-.editor-switcher-row { display:flex; justify-content: space-between; align-items:center; gap:.5rem; flex-wrap:wrap; }
+.editor-switcher { display:flex; flex-direction:row; align-items: center; flex-wrap: wrap; gap:.35rem; margin:.5rem 0; padding:.5rem; background: rgba(255,255,255,0.05); border-radius:8px; }
+.editor-switcher-row { display:flex; justify-content:flex-start; align-items:center; gap:.5rem; flex-wrap:wrap; width:100%; }
 .btn-switch-editor { padding:.5rem 1rem; background: rgba(100,100,255,0.2); border:1px solid rgba(100,100,255,0.5); border-radius:6px; color:#fff; cursor:pointer; }
 .btn-switch-editor:hover { background: rgba(100,100,255,0.3); }
 .editor-clipboard-actions { display:flex; gap:.5rem; flex-wrap:wrap; }
 .btn-editor-clip { padding:.35rem .75rem; border-radius:6px; border:1px solid rgba(255,255,255,0.25); background: rgba(255,255,255,0.08); color:#fff; font-size:.85rem; display:flex; align-items:center; gap:.35rem; cursor:pointer; transition: background .2s ease, border-color .2s ease; }
 .btn-editor-clip:hover { background: rgba(255,255,255,0.15); border-color: rgba(255,255,255,0.4); }
 .btn-editor-clip:disabled { opacity:.6; cursor:not-allowed; }
-.editor-info { display:flex; flex-direction:column; gap:.15rem; font-size:.85rem; opacity:.85; min-width:0; }
+.editor-info { display:flex; flex-direction:column; gap:.15rem; font-size:.85rem; opacity:.85; min-width:0; width:100%; align-items:flex-start; text-align:start; }
 .editor-info-status { font-size:.8rem; color: var(--primary, #8ec5ff); min-height:1.1em; }
 .editor-loading { position: relative; min-height: 48px; display:flex; align-items:center; gap:.5rem; color:#fff; }
 .editor-transitioning { opacity: .7; }
@@ -36,7 +36,7 @@
 }
 
 /* Hide keyboard shortcuts hint on small mobile devices only */
-@media (max-width: 576px) {
+@media (max-width: 767px) {
   .editor-info-primary.is-keyboard-hint { display: none; }
 }
 

--- a/webapp/static/js/editor-manager.js
+++ b/webapp/static/js/editor-manager.js
@@ -227,24 +227,24 @@
             <i class="fas fa-exchange-alt"></i>
             <span>${this.currentEditor === 'simple' ? 'עורך מתקדם' : 'עורך פשוט'}</span>
           </button>
-          <div class="editor-info">
-            <span class="editor-info-primary${this.currentEditor === 'codemirror' ? ' is-keyboard-hint' : ''}">${this.currentEditor === 'codemirror' ? '<i class="fas fa-keyboard"></i> קיצורי מקלדת זמינים' : '<i class="fas fa-info-circle"></i> עורך טקסט בסיסי'}</span>
-            <span class="editor-info-status" aria-live="polite"></span>
+          <div class="editor-clipboard-actions" role="group" aria-label="פעולות עריכה">
+            <button type="button" class="btn-editor-clip btn-editor-select" title="בחר את כל הקוד">
+              <i class="fas fa-arrows-alt"></i>
+              <span>בחר הכל</span>
+            </button>
+            <button type="button" class="btn-editor-clip btn-editor-copy" title="העתק את הקוד">
+              <i class="far fa-copy"></i>
+              <span>העתק</span>
+            </button>
+            <button type="button" class="btn-editor-clip btn-editor-paste" title="הדבק מהלוח">
+              <i class="fas fa-paste"></i>
+              <span>הדבק</span>
+            </button>
           </div>
         </div>
-        <div class="editor-clipboard-actions" role="group" aria-label="פעולות עריכה">
-          <button type="button" class="btn-editor-clip btn-editor-select" title="בחר את כל הקוד">
-            <i class="fas fa-arrows-alt"></i>
-            <span>בחר הכל</span>
-          </button>
-          <button type="button" class="btn-editor-clip btn-editor-copy" title="העתק את הקוד">
-            <i class="far fa-copy"></i>
-            <span>העתק</span>
-          </button>
-          <button type="button" class="btn-editor-clip btn-editor-paste" title="הדבק מהלוח">
-            <i class="fas fa-paste"></i>
-            <span>הדבק</span>
-          </button>
+        <div class="editor-info">
+          <span class="editor-info-primary${this.currentEditor === 'codemirror' ? ' is-keyboard-hint' : ''}">${this.currentEditor === 'codemirror' ? '<i class="fas fa-keyboard"></i> קיצורי מקלדת זמינים' : '<i class="fas fa-info-circle"></i> עורך טקסט בסיסי'}</span>
+          <span class="editor-info-status" aria-live="polite"></span>
         </div>
       `;
       const codeLabel = container.querySelector('label') || container;


### PR DESCRIPTION
## ✨ תיאור קצר
שינויים במבנה ה-HTML וה-CSS של רכיב העורך. יישרתי את כפתורי "בחר הכל / העתק / הדבק" לשורה אחת עם כפתור ההחלפה, והחזרתי את הבאנר "קיצורי מקלדת זמינים" לשורה נפרדת משמאל בטאבלטים. בנוסף, הרחבתי את הסתרת הבאנר "קיצורי מקלדת זמינים" למסכים עד 767px.

## 📦 שינויים עיקריים
- [x] קוד (Frontend - JS/CSS)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי סדר האלמנטים ב-`webapp/static/js/editor-manager.js` כדי למקם את כפתורי הקליפבורד (`editor-clipboard-actions`) ליד כפתור ההחלפה (`btn-switch-editor`).
- עדכון כללי ה-CSS ב-`webapp/static/css/codemirror-custom.css` עבור `.editor-switcher`, `.editor-switcher-row`, ו-`.editor-info` ליישור נכון, רוחב מלא ויישור לשמאל.
- הרחבת ה-media query להסתרת הבאנר "קיצורי מקלדת זמינים" (`.editor-info-primary.is-keyboard-hint`) למסכים ברוחב מקסימלי של 767px (טאבלטים קטנים) במקום 576px.

## 🧪 בדיקות
- בוצעה בדיקה ידנית בדפדפן על גדלי מסך שונים (דסקטופ, טאבלט, מובייל) כדי לוודא יישור נכון והתנהגות רספונסיבית של רכיב העורך.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג (תיקון בעיית יישור UI)
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy) - רלוונטי ל-JS/CSS.
- [x] בדיקות רצות ועוברות - בדיקות ידניות עברו.
- [ ] תיעוד עודכן (README/Docs) - לא נדרש.
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש - לא נדרש עבור תיקון UI קטן.
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי - לא צורף, אך מומלץ לבדיקה ויזואלית.

## 🧩 השפעות/סיכונים
- השפעה מינורית על ה-UI של רכיב העורך. אין השפעה על לוגיקה, ביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה של תקלה, ניתן לבצע Rollback על ידי Revert של ה-Pull Request.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b6ba7df-4879-460b-bbdf-f079cc0b5223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b6ba7df-4879-460b-bbdf-f079cc0b5223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders the editor switcher to place clipboard actions beside the toggle and updates CSS layout/ breakpoint for the keyboard-hint banner.
> 
> - **UI (Editor toolbar)**:
>   - **JS (`webapp/static/js/editor-manager.js`)**:
>     - Reorders `addSwitcherButton` markup: `editor-clipboard-actions` moved into the top `editor-switcher-row` beside `btn-switch-editor`; `editor-info` moved to a separate row below.
>   - **CSS (`webapp/static/css/codemirror-custom.css`)**:
>     - Adjusts `.editor-switcher` and `.editor-switcher-row` alignment (row layout, start-justified, full-width row).
>     - Updates `.editor-info` to full-width, left-aligned.
>     - Expands keyboard-hint hide breakpoint from `max-width: 576px` to `max-width: 767px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769ce7677bd038243bf96edeb205356a404f582d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->