### PR TITLE
Respond to github message in hebrew

### DIFF
--- a/scripts/start_webapp.sh
+++ b/scripts/start_webapp.sh
@@ -55,11 +55,7 @@ warmup() {
   fi
   local warmup_url="${WEBAPP_WARMUP_URL:-}"
   if [ -z "$warmup_url" ]; then
-    if [ -n "${WEBAPP_URL:-}" ]; then
-      warmup_url="${WEBAPP_URL%/}/healthz"
-    else
-      warmup_url="http://127.0.0.1:${PORT}/healthz"
-    fi
+    warmup_url="http://127.0.0.1:${PORT}/healthz"
   fi
   local attempts="${WEBAPP_WARMUP_MAX_ATTEMPTS:-15}"
   local delay="${WEBAPP_WARMUP_DELAY_SECONDS:-2}"

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -153,7 +153,7 @@ http://localhost:5000
 `scripts/start_webapp.sh` הוא ה-Start Command המומלץ:
 
 - לפני העלייה הוא מחשב `ASSET_VERSION` דינמי (בברירת מחדל `RENDER_GIT_COMMIT` מקוצר, ואז `git rev-parse`, ולבסוף timestamp) ומייצא אותו ל-Flask לצורך Cache Busting של CSS/JS.
-- מיד אחרי הפעלת Gunicorn הוא מבצע קריאת `curl` best-effort ל-`/healthz` (דרך `WEBAPP_URL` או `http://127.0.0.1:$PORT`) כדי לחמם חיבורי Mongo ואינדקסים בזמן שהדיפלוי עדיין מסומן כ-In Progress.
+- מיד אחרי הפעלת Gunicorn הוא מבצע קריאת `curl` best-effort ל-`/healthz` (ברירת מחדל `http://127.0.0.1:$PORT` כדי לוודא שמחממים את ה-instance המקומי; ניתן להגדיר יעד אחר עם `WEBAPP_WARMUP_URL`) כדי לחמם חיבורי Mongo ואינדקסים בזמן שהדיפלוי עדיין מסומן כ-In Progress.
 - ניתן לכוון את ההתנהגות עם משתני סביבה: `ASSET_VERSION` (override מפורש), `WEBAPP_ENABLE_WARMUP=0` לביטול, `WEBAPP_WARMUP_URL` ליעד מותאם, `WEBAPP_WARMUP_MAX_ATTEMPTS` ו-`WEBAPP_WARMUP_DELAY_SECONDS` ללולאת ה-warmup.
 
 ## משתני סביבה 🔐
@@ -168,7 +168,7 @@ http://localhost:5000
 | `WEBAPP_URL` | כתובת ה-Web App | ❌ | `https://code-keeper-webapp.onrender.com` |
 | `ASSET_VERSION` | מזהה build לקבצים סטטיים (מוגדר אוטומטית ע"י `scripts/start_webapp.sh`) | ❌ | קומיט נוכחי |
 | `WEBAPP_ENABLE_WARMUP` | הפעלת warmup אחרי העלייה (`1`/`0`) | ❌ | `1` |
-| `WEBAPP_WARMUP_URL` | יעד ה-curl לחימום (ברירת מחדל: `${WEBAPP_URL}/healthz` או `http://127.0.0.1:$PORT/healthz`) | ❌ | - |
+| `WEBAPP_WARMUP_URL` | יעד ה-curl לחימום (ברירת מחדל: `http://127.0.0.1:$PORT/healthz`) | ❌ | - |
 | `WEBAPP_WARMUP_MAX_ATTEMPTS` | מספר ניסיונות warmup | ❌ | `15` |
 | `WEBAPP_WARMUP_DELAY_SECONDS` | השהיה בין ניסיונות warmup (שניות) | ❌ | `2` |
 | `UPTIME_PROVIDER` | ספק זמינות חיצוני (`betteruptime`/`uptimerobot`) | ❌ | - |


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו סקריפט הפעלה חדש (`scripts/start_webapp.sh`) שמטפל אוטומטית ב-Cache Busting על ידי הגדרת `ASSET_VERSION` דינמית, ומבצע Warmup ל-`/healthz` כדי למנוע בעיות Cold Start וליצור חיבור ראשוני ל-Mongo. ה-README עודכן בהתאם.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- יצירת סקריפט `scripts/start_webapp.sh` שמחשב `ASSET_VERSION` (מקומי או מ-CI) ומבצע `curl /healthz` לאחר הפעלת Gunicorn.
- עדכון ה-`Start Command` ב-`webapp/README.md` לשימוש בסקריפט החדש.
- הוספת סעיף מפורט ב-`webapp/README.md` המסביר את מנגנוני ה-Cache Busting וה-Warmup, כולל משתני סביבה חדשים לשליטה בהם.

## 🧪 בדיקות
- בדיקה ידנית של לוגיקת הסקריפט והשפעתה על הגדרת משתני סביבה והפעלת ה-Warmup.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקה ידנית)
- [x] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **השפעה חיובית:** שיפור חווית המשתמש על ידי מניעת בעיות Cache ו-Cold Start, וחיבור מהיר יותר למסד הנתונים.
- **סיכון:** סקריפט ההפעלה החדש הוא נקודת כשל פוטנציאלית בתהליך ה-Deploy אם אינו יציב.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
במקרה תקלה, ניתן לבצע Rollback ל-PR זה ולשנות את ה-Start Command ב-Render בחזרה לפקודה הקודמת: `cd webapp && gunicorn app:app --bind 0.0.0.0:$PORT`.

---
<a href="https://cursor.com/background-agent?bcId=bc-94de0a0e-3ddb-4379-9cfc-883427c8e213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94de0a0e-3ddb-4379-9cfc-883427c8e213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a startup script that runs Gunicorn, sets `ASSET_VERSION`, and performs a configurable warmup, and updates README with usage and related env vars.
> 
> - **Scripts/Backend**
>   - Add `scripts/start_webapp.sh`:
>     - Computes `ASSET_VERSION` from CI/env/git fallbacks.
>     - Starts Gunicorn (`app:app` by default), traps signals, and forwards shutdown.
>     - Performs configurable warmup hits to `/healthz` via `WEBAPP_URL` or `127.0.0.1:$PORT` using `WEBAPP_ENABLE_WARMUP`, `WEBAPP_WARMUP_URL`, `WEBAPP_WARMUP_MAX_ATTEMPTS`, `WEBAPP_WARMUP_DELAY_SECONDS`.
> - **Docs**
>   - Update `webapp/README.md`:
>     - Change Render Start Command to `./scripts/start_webapp.sh`.
>     - Add "Cache Busting & Warmup" section.
>     - Document new env vars: `ASSET_VERSION`, `WEBAPP_ENABLE_WARMUP`, `WEBAPP_WARMUP_URL`, `WEBAPP_WARMUP_MAX_ATTEMPTS`, `WEBAPP_WARMUP_DELAY_SECONDS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b9999085f1632b6d482c0499813c1f7f6d404ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->