### PR TITLE
Respond to github message about implementation

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -391,6 +391,14 @@ def _update_ewma(duration_seconds: float) -> float:
         return float(duration_seconds)
 
 
+def get_avg_response_time_seconds() -> float:
+    """Return the smoothed average HTTP response time (seconds)."""
+    try:
+        return max(0.0, float(_EWMA_RT or 0.0))
+    except Exception:
+        return 0.0
+
+
 def _status_label_from_code(status_code: int | None, override: str | None = None) -> str:
     try:
         if override:


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו בדיקת עומק מקיפה לנקודת הקצה `/healthz` הכוללת פינג ל-Mongo, ספירת אינדקסים קריטיים ודיווח על זמני תגובה ממוצעים של האפליקציה. בנוסף, הטמענו מנגנון למדידת זמני עלייה (startup metrics) עבור חיבור ל-Mongo, יצירת אינדקסים וטעינת תבניות, עם לוג מסכם מובנה בסיום.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הרחבת `/healthz` לכלול בדיקות Mongo, ספירת אינדקסים עם מטמון (60 שניות) ודיווח EWMA של זמני תגובה, תוך שמירה על ביצועים מהירים (מתחת ל-300ms).
- הוספת מנגנון מדידת זמני עלייה (startup metrics) לחיבור ל-Mongo, יצירת אינדקסים (recent_opens, code_snippets, announcements) וטעינת תבניות, עם לוג מסכם מובנה `[startup-metrics] …` בסיום העלייה.
- הוספת פונקציית `get_avg_response_time_seconds` ל-`metrics.py` כדי לאפשר ל-`/healthz` לדווח על ה-latency הממוצע של שכבת ה-Web.

## 🧪 בדיקות
- הרצתי בדיקות ידניות: `curl -s http://127.0.0.1:$PORT/healthz` כדי לוודא את פלט ה-JSON החדש, וצפיתי בלוגים של האפליקציה כדי לראות את הלוג `[startup-metrics] …` בעת עלייה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (בדיקות ידניות בוצעו)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: הסיכון נמוך. השינויים מוסיפים בעיקר יכולות תצפיתיות. נקודת הקצה `/healthz` תוכננה להיות מהירה, ומדידות ה-startup מבוצעות רק פעם אחת בעת עליית האפליקציה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לקומיט הקודם. השינויים הם תוספתיים ואינם משנים התנהגות קיימת באופן קריטי.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f15f3ab-044f-448b-ad1a-f971787623d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f15f3ab-044f-448b-ad1a-f971787623d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands /healthz to include Mongo ping, critical index sampling and app EWMA latency, and adds startup-time metrics logging while instrumenting DB/templates/index init durations.
> 
> - **Observability**:
>   - **/healthz deep check**: Adds Mongo ping, cached critical index count, app EWMA response time, latency breakdown, error list, and proper 200/503 status.
>   - **Average latency access**: Exposes `metrics.get_avg_response_time_seconds()` for health reporting.
> - **Startup instrumentation**:
>   - Introduces `_record_startup_metric` and `_emit_startup_metrics_log` with a structured `[startup-metrics]` summary.
>   - Records init durations for `pygments` lexers, Jinja template preload, Mongo connect/ping, and index creation (`recent_opens`, `code_snippets`, `announcements`), including accumulation where relevant.
>   - Ensures startup metrics emitted on preload completion (success/failure paths).
> - **DB/init tweaks**:
>   - `get_db()` now records Mongo init duration to metrics and startup metrics.
>   - Adds short‑TTL cache for index sampling used by `/healthz`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f36b5fb5c086776ea0791dfed5f3972d04d792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->