### PR TITLE
Prevent html caching in flask

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2048,6 +2048,21 @@ def _add_default_csp(resp):
     return resp
 
 
+@app.after_request
+def _disable_html_cache(resp):
+    """Force browsers to revalidate HTML responses and pick up fresh assets."""
+    try:
+        content_type = resp.headers.get('Content-Type', '')
+        if isinstance(content_type, str) and 'text/html' in content_type:
+            resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+            resp.headers['Pragma'] = 'no-cache'
+            resp.headers['Expires'] = '0'
+    except Exception:
+        # Never fail the response if header manipulation crashes
+        pass
+    return resp
+
+
 # --- Service Worker: served at root scope (/sw.js) ---
 @app.route('/sw.js')
 def service_worker_js():


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו מנגנון למניעת שמירת HTML בדפדפן (caching) עבור תגובות `text/html`. זאת כדי לפתור בעיה שבה דפים ישנים נטענו עם עיצוב מיושן, כיוון שהדפדפן שמר את קובץ ה-HTML עצמו ולא ראה את עדכון ה-`ASSET_VERSION`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת פונקציית `@app.after_request` בשם `_disable_html_cache` ל-`webapp/app.py`.
- הפונקציה מוסיפה כותרות `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, ו-`Expires: 0` לתגובות מסוג `text/html`.
- כותרות אלו מונעות מהדפדפן לשמור את ה-HTML בזיכרון ומכריחות אותו לבדוק מול השרת בכל טעינה.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual

בדיקה ידנית:
- יש לבצע Deploy.
- לגלוש לדף באתר שייתכן ונשמר בעבר בזיכרון הדפדפן (למשל, דף שבו העיצוב לא התעדכן).
- לוודא שהעיצוב החדש נטען כראוי.
- לבדוק בכלי המפתחים של הדפדפן (Network tab) שהכותרות `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, ו-`Expires: 0` קיימות בתגובת ה-HTML.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (אין בדיקות אוטומטיות רלוונטיות לשינוי זה)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - **ביצועים:** תוספת קטנה של עומס על השרת עקב בקשות חוזרות ל-HTML, אך ההשפעה צפויה להיות זניחה מאחר וקבצי סטטיקה (CSS/JS) עדיין נשמרים בזיכרון הדפדפן.
  - **אבטחה:** אין השפעה שלילית.
  - **חווית משתמש:** שיפור בחוויה בכך שהמשתמשים יראו תמיד את העיצוב העדכני.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback לגרסה הקודמת (revert commit).

---
<a href="https://cursor.com/background-agent?bcId=bc-6337fbf3-4989-44f7-b1b6-11dd2bb055c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6337fbf3-4989-44f7-b1b6-11dd2bb055c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an after_request hook that sets no-cache headers on text/html responses to prevent browser caching.
> 
> - **Backend**:
>   - `@app.after_request` hook `_disable_html_cache` in `webapp/app.py` sets `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, and `Expires: 0` for `text/html` responses to force revalidation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e236f566dcc33cc93eeb8ba077a8febb236069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->