### PR TITLE
Respond to github message in hebrew

### DIFF
--- a/tests/test_webapp_upload_draft_reset.py
+++ b/tests/test_webapp_upload_draft_reset.py
@@ -1,0 +1,84 @@
+import pytest
+
+from webapp import app as webapp_app
+
+
+class _StubInsertResult:
+    def __init__(self, inserted_id="507f1f77bcf86cd799439011"):
+        self.inserted_id = inserted_id
+
+
+class _StubCodeSnippets:
+    def __init__(self, languages=None):
+        self._languages = languages or []
+        self.last_inserted = None
+
+    def distinct(self, field, query):
+        return list(self._languages)
+
+    def find_one(self, *args, **kwargs):
+        return None
+
+    def insert_one(self, doc):
+        self.last_inserted = doc
+        return _StubInsertResult()
+
+
+class _StubDB:
+    def __init__(self, languages=None):
+        self.code_snippets = _StubCodeSnippets(languages or [])
+
+
+def _login(client):
+    with client.session_transaction() as sess:
+        sess["user_id"] = 42
+        sess["user_data"] = {"id": 42, "first_name": "Tester"}
+
+
+def test_upload_get_marks_reset_flag(monkeypatch):
+    stub_db = _StubDB([])
+    monkeypatch.setattr(webapp_app, "get_db", lambda: stub_db)
+
+    flask_app = webapp_app.app
+    flag_key = webapp_app._UPLOAD_CLEAR_DRAFT_SESSION_KEY
+
+    with flask_app.test_client() as client:
+        _login(client)
+        with client.session_transaction() as sess:
+            sess[flag_key] = True
+
+        resp = client.get("/upload")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'data-reset-draft="1"' in html
+
+        with client.session_transaction() as sess:
+            assert flag_key not in sess
+
+
+def test_successful_upload_sets_session_flag(monkeypatch):
+    stub_db = _StubDB([])
+    monkeypatch.setattr(webapp_app, "get_db", lambda: stub_db)
+    monkeypatch.setattr(webapp_app, "_log_webapp_user_activity", lambda: False)
+
+    flask_app = webapp_app.app
+    flag_key = webapp_app._UPLOAD_CLEAR_DRAFT_SESSION_KEY
+
+    with flask_app.test_client() as client:
+        _login(client)
+        resp = client.post(
+            "/upload",
+            data={
+                "file_name": "example.py",
+                "code": "print('hi')",
+                "language": "python",
+                "description": "",
+                "tags": "",
+                "source_url": "",
+                "source_url_touched": "0",
+            },
+        )
+        assert resp.status_code == 302
+
+        with client.session_transaction() as sess:
+            assert sess.get(flag_key) is True

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -128,7 +128,7 @@
   <div class="alert alert-success">{{ success }}</div>
   {% endif %}
 
-  <form id="uploadForm" method="post" enctype="multipart/form-data" data-upload-success="{{ '1' if success else '0' }}" style="display: grid; gap: 1rem;">
+  <form id="uploadForm" method="post" enctype="multipart/form-data" data-upload-success="{{ '1' if success else '0' }}" data-reset-draft="{{ '1' if clear_local_draft else '0' }}" style="display: grid; gap: 1rem;">
     <div>
       <label>שם קובץ</label>
       <input type="text" name="file_name" placeholder="example.py" value="{{ file_name_value or '' }}" style="width: 100%; padding: .75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white;">
@@ -398,7 +398,8 @@
         }
 
         const uploadSucceeded = form.getAttribute('data-upload-success') === '1';
-        if (uploadSucceeded) {
+        const shouldResetDraft = form.getAttribute('data-reset-draft') === '1';
+        if (uploadSucceeded || shouldResetDraft) {
           removeDraft(true);
         }
 


### PR DESCRIPTION
## ✨ תיאור קצר
- יישמתי מנגנון לאיפוס הטיוטה ב-`localStorage` לאחר שמירה מוצלחת של קובץ.
- השינוי נדרש כדי למנוע הצגת תוכן טיוטה ישן בשדה העלאת הקבצים לאחר שהמשתמש כבר שמר את הקובץ בהצלחה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת דגל סשן (`_UPLOAD_CLEAR_DRAFT_SESSION_KEY`) שנרשם בסשן לאחר שמירה מוצלחת של קובץ.
- בבקשת GET ל-`/upload`, הדגל נצרך מהסשן ומועבר לתבנית ה-HTML.
- בתבנית ה-HTML, נוסף מאפיין `data-reset-draft` לטופס, המציין אם יש לאפס את הטיוטה.
- קוד ה-JavaScript בצד הלקוח עודכן כך שיבדוק את המאפיין `data-reset-draft` ויאפס את הטיוטה ב-`localStorage` אם הוא מסומן.
- נוספו בדיקות יחידה לוודא שהדגל נשמר בסשן ומועבר נכון לתבנית.

## 🧪 בדיקות
- נוספו בדיקות יחידה חדשות ב-`tests/test_webapp_upload_draft_reset.py` המכסות את הלוגיקה של דגל הסשן ואיפוס הטיוטה.
- הבדיקות רצו והצליחו באופן מקומי.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה מינימלית, שינוי בלוגיקת סשן ו-frontend לאיפוס טיוטה.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה של תקלה, ניתן לבצע Rollback ל-PR זה. הסיכון נמוך.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cfc295a-e2ef-40b7-8a48-9bc9c287b0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cfc295a-e2ef-40b7-8a48-9bc9c287b0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a session flag to clear the upload page’s local draft after a successful save, wired through the `/upload` route and template, with unit tests covering the flow.
> 
> - **Backend (Flask)**:
>   - Add session flag `'_UPLOAD_CLEAR_DRAFT_SESSION_KEY'` set on successful insert in `upload_file_web` and popped on GET to compute `should_clear_local_draft`.
>   - Pass `clear_local_draft` to template context in `render_template('upload.html', ...)`.
> - **Frontend (Template/JS)**:
>   - In `webapp/templates/upload.html`, add `data-reset-draft` to `#uploadForm` and update client logic to clear local draft when `data-reset-draft="1"` (in addition to `data-upload-success`).
> - **Tests**:
>   - New `tests/test_webapp_upload_draft_reset.py` verifying GET `/upload` consumes the flag and sets `data-reset-draft="1"`, and POST `/upload` sets the session flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e3287eb9ee037e2dc4ecf03ba4324feac82fd83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->