### PR TITLE
Respond to github context in hebrew

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,13 +1,27 @@
 /* Custom CSS for Code Keeper Bot Documentation */
 
 /* RTL Support for Hebrew */
-.rst-content {
-    direction: ltr;
+.wy-nav-content {
+    direction: rtl;
 }
 
-.rst-content .hebrew {
+.rst-content {
     direction: rtl;
+    unicode-bidi: plaintext;
     text-align: right;
+}
+
+.rst-content .hebrew,
+.rst-content .bidi-rtl {
+    direction: rtl;
+    unicode-bidi: plaintext;
+    text-align: right;
+}
+
+.rst-content .bidi-ltr {
+    direction: ltr;
+    unicode-bidi: embed;
+    text-align: left;
 }
 
 /* Code blocks styling */
@@ -16,6 +30,8 @@
     border: 1px solid #e1e4e8;
     border-radius: 6px;
     margin: 1em 0;
+    direction: ltr;
+    text-align: left;
 }
 
 .highlight pre {
@@ -112,6 +128,8 @@ table.docutils td {
     border-radius: 6px;
     padding: 1em;
     margin: 1em 0;
+    direction: ltr;
+    text-align: left;
 }
 
 /* Search results */


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון כיווניות (RTL) לטקסט עברי באתר התיעוד. כלל CSS גלובלי כפה LTR על כל התוכן, מה שגרם לטקסט עברי להופיע משמאל לימין.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [X] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- בוטלה כפיית `direction: ltr` על `.rst-content`.
- הוגדרו `direction: rtl` ו־`unicode-bidi: plaintext` לגוף העמוד (`.rst-content`) ויישור טקסט לימין.
- הוגדרה `direction: ltr` מפורשת לבלוקי קוד (`.highlight`, `.literal-block`) כדי לשמור על קריאותם.
- הותקנו חבילות התיעוד המקומיות והורץ Build מלא.

## 🧪 בדיקות
הורצה פקודת `make -C docs html` ונבדקו עמודי התיעוד באופן ידני כדי לוודא שהטקסט העברי מוצג נכון ובלוקי הקוד נשארים ב-LTR.
- [ ] Unit
- [ ] Integration
- [X] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [X] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [X] בדיקות רצות ועוברות
- [X] תיעוד עודכן (README/Docs)
- [X] אין סודות/מפתחות בקוד
- [X] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [X] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה על תצוגת התיעוד בלבד, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
החזרה לאחור פשוטה על ידי היפוך שינויי ה-CSS בקובץ `docs/_static/custom.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ec17e63-c216-48a0-b4f4-d6a55d04e945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ec17e63-c216-48a0-b4f4-d6a55d04e945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce richer alert/metrics storage and aggregation/query APIs, and refresh the generated docs (updated assets/Mermaid, simplified API docs, new observability/caching/Kanban sections).
> 
> - **feat(mon﻿itoring): alert/metrics data model & query APIs**
>   - `monitoring.alerts_storage` now accepts `details`, normalizes `severity`, derives/stores `endpoint`, `alert_type`, `duration_seconds`, and `search_blob`; adds helpers (`_safe_str`, `_sanitize_details`, `_extract_*`, `_build_*`).
>   - New read APIs: `fetch_alerts`, `fetch_alert_timestamps`, `aggregate_alert_summary`, `aggregate_alert_timeseries`.
>   - `monitoring.metrics_storage`: refactor to add `_build_time_match`, expose server‑side analytics (`aggregate_alert_timeseries`, `aggregate_error_ratio`, `aggregate_alert_timeseries/requests` incl. `aggregate_alert_timeseries`/`timeseries`, `average_request`/`error_ratio`, `top endpoints`), keep `enqueue_request_metric`/`flush`; add `emit_event` stub.
> - **Docs build refresh**
>   - Updated static asset hashes; switched Mermaid to 11.2.0 and removed heavy fullscreen/zoom script in generated `_modules` pages; minor import/format tweaks in `monitoring.cleanup` docs.
>   - Simplified API reference TOC (module‑level entries), added “Observability Dashboard & API” page; noted Prometheus health/startup metrics; added “Warmup for frontend assets” and “Kanban for desktop” sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed44ae711885cceeb12bd64979018bd2532539f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->