### PR TITLE
Respond to github issue in hebrew

### DIFF
--- a/database/manager.py
+++ b/database/manager.py
@@ -813,6 +813,10 @@ class DatabaseManager:
     def get_drive_prefs(self, user_id: int) -> Optional[Dict[str, Any]]:
         return self._get_repo().get_drive_prefs(user_id)
 
+    def get_users_with_active_drive_schedule(self) -> List[Dict[str, Any]]:
+        """Return all users who have an active drive backup schedule."""
+        return self._get_repo().get_users_with_active_drive_schedule()
+
     # Image generation preferences (Telegram /image)
     def save_image_prefs(self, user_id: int, prefs: Dict[str, Any]) -> bool:
         return self._get_repo().save_image_prefs(user_id, prefs)


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו באג ב-rescheduler של גיבויי Drive שלא הצליח למצוא משתמשים עם תזמון פעיל לאחר אתחול. הבעיה נבעה מגישה ישירה ולא אמינה ל-MongoDB. כעת ה-rescheduler משתמש בפונקציה ייעודית ב-Repository לאחזור נתונים באופן בטוח ויציב.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת פונקציה `get_users_with_active_drive_schedule()` ב-`database/repository.py` לאחזור משתמשים עם תזמון גיבוי פעיל.
- חשיפת הפונקציה החדשה דרך `database/manager.py`.
- עדכון ה-rescheduler ב-`main.py` להשתמש בפונקציה החדשה במקום גישה ישירה ל-collection.
- שיפור לוגים ב-rescheduler כדי לספק יותר מידע על תהליך השחזור.
- אימות שהבעיה של "כניסה למצב גיבוי יוצרת Job חדש" כבר תוקנה.

## 🧪 בדיקות
כל בדיקות היחידה הרלוונטיות עברו בהצלחה:
- `test_drive_rescheduler_helper.py` (11 בדיקות)
- `test_drive_menu_schedule.py` (10 בדיקות)
- `test_drive_menu_facade.py` (4 בדיקות)
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית: מבטיח ש-jobs של גיבויי Drive ישוחזרו כראוי לאחר אתחול המערכת.
- סיכון נמוך: המעבר מגישה ישירה ל-DB לשימוש ב-Repository מפחית סיכונים. קיימת לוגיקת Fallback במידה והפונקציה החדשה אינה זמינה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לגרסה הקודמת של הקוד. השינויים הם בעיקר לוגיקה פנימית ואינם משפיעים על סכימת ה-DB.

---
<a href="https://cursor.com/background-agent?bcId=bc-8021aba8-5d6a-4d86-aa95-369871513a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8021aba8-5d6a-4d86-aa95-369871513a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Drive rescheduler to a repository-backed lookup for users with active backup schedules, adding a DB helper and improving fallbacks/logging.
> 
> - **Drive rescheduler (main.py)**:
>   - Use `DatabaseManager.get_users_with_active_drive_schedule()` instead of direct `users` collection queries.
>   - Simplify DB manager resolution (prefer `bot_data['db_manager']`, then module/global fallback).
>   - Add robust fallbacks to direct collection query when method unavailable, with clearer logs and skip reasons.
> - **Database**:
>   - `database/repository.py`: add `get_users_with_active_drive_schedule()` querying known schedule fields, with wide-query fallback, events, and logging.
>   - `database/manager.py`: expose `get_users_with_active_drive_schedule()` delegating to the repository.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e67d716a1462c412f500b0ca8dabbea3548718e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->