### PR TITLE
Fix ui menu bug

### DIFF
--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -271,7 +271,7 @@
     display: flex;
     gap: 0.75rem;
     flex-wrap: nowrap;
-    flex: 1;
+    flex: 0 1 auto;
     overflow: hidden;
     align-items: stretch;
     min-width: 0;
@@ -1926,17 +1926,7 @@ function goBack(ev){
 
     function getMenuWidth() {
         const btnRect = menuButton.getBoundingClientRect();
-        const buttonWidth = menuButton.offsetWidth || (btnRect && btnRect.width) || 0;
-        if (buttonWidth) {
-            return buttonWidth;
-        }
-        if (menuWrapper) {
-            const rect = menuWrapper.getBoundingClientRect();
-            if (rect && rect.width) {
-                return rect.width;
-            }
-        }
-        return 0;
+        return (btnRect && btnRect.width) ? btnRect.width : 48;
     }
 
     function getAvailableWidth() {
@@ -1980,11 +1970,7 @@ function goBack(ev){
         if (!(limit > 0)) {
             return true;
         }
-        const scrollWidth = actionsList.scrollWidth || 0;
-        if (scrollWidth - limit > 2) {
-            return true;
-        }
-        return measureContentWidth() > limit + 2;
+        return measureContentWidth() > limit;
     }
 
     function updateDividerVisibility() {


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג שגרם לכל כפתורי הפעולה בדסקטופ/טאבלט לעבור לתפריט 3 הנקודות. הבעיה נבעה מלוגיקת גלישה אגרסיבית מדי ויישור כפתורים שגוי.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- תיקון לוגיקת ה-overflow ב-JavaScript (`hasOverflow`, `getMenuWidth`) כדי למדוד במדויק את רוחב הכפתורים הגלויים ולמנוע הסתרה שגויה.
- שינוי CSS עבור רשימת הכפתורים (`.file-actions__list`) מ-`flex: 1` ל-`flex: 0 1 auto` כדי להבטיח שכפתור תפריט 3 הנקודות יישאר צמוד לכפתורי הפעולה האחרים.

## 🧪 בדיקות
- נבדק ידנית על דסקטופ וטאבלט כדי לוודא שהכפתורים מוצגים כראוי ושתפריט 3 הנקודות מופיע רק כשנדרש.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש בדסקטופ/טאבלט. אין סיכונים ידועים לביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע rollback לגרסה הקודמת. השינויים ממוקדים בקובץ HTML אחד (CSS ו-JS).

---
<a href="https://cursor.com/background-agent?bcId=bc-ea90287a-d4f1-44d1-947f-06b0d770945c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea90287a-d4f1-44d1-947f-06b0d770945c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents action buttons from collapsing too early by updating flex behavior and simplifying menu width/overflow calculations.
> 
> - **UI (file view `webapp/templates/view_file.html`)**
>   - **CSS**: Change ` .file-actions__list` from `flex: 1` to `flex: 0 1 auto` to stop over-expansion and keep the menu aligned.
>   - **Overflow Logic (JS)**:
>     - Simplify `getMenuWidth()` to use the menu button’s bounding width with a `48`px fallback.
>     - Simplify `hasOverflow(limit)` to rely solely on `measureContentWidth() > limit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0b36252a9e9ddf8c525b5c5cbbbb596cfddfa3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->