### PR TITLE
Fix github issue 1982

### DIFF
--- a/docs/observability/observability_dashboard.md
+++ b/docs/observability/observability_dashboard.md
@@ -89,6 +89,13 @@ curl -H 'Accept: application/json' \
 }
 ```
 
+#### Meta מועשר להתראות High Error Rate
+
+- התראות `High Error Rate` שמקורן ב־`internal_alerts` כוללות כעת שדות Meta עשירים: `feature` (למשל `push_api.subscribe`), ערך `command` מלא (`webapp:post:push_api.subscribe`), נתיב `endpoint`, `method`, `request_id` ו־`user_id` (מנורמל/מגושר).
+- מוצגים גם מדדי סף (`threshold_percent`) והמדד שחורג (`error_rate_percent`, `sample_count`, `window_seconds`) כדי להבין את גודל החריגה בלי לפתוח Grafana.
+- השדה `meta_summary` מספק תצוגה קולעת בעמודת ה־Meta (לדוגמה: `push_api.subscribe · error_rate 5.63% > 5.00% · request req-meta`), ונצרב גם ב־Quick Fix.
+- כל המפתחות נמשכים עד לממשק ההיסטוריה, ל־Quick Fix ול־API, כך שניתן להתייחס אליהם בסקריפטים חיצוניים.
+
 ### `GET /api/observability/aggregations`
 
 - **מטרה:** קבלת אגרגציות מהירות עבור הקלפים והטבלאות בפאנל.

--- a/tests/test_alert_manager_integration.py
+++ b/tests/test_alert_manager_integration.py
@@ -3,6 +3,8 @@ import sys
 import types
 import importlib
 
+import pytest
+
 
 def test_alert_manager_emits_remediation_and_bump(tmp_path, monkeypatch):
     (tmp_path / "data").mkdir()
@@ -36,3 +38,58 @@ def test_alert_manager_emits_remediation_and_bump(tmp_path, monkeypatch):
     # Verify incident file exists and non-empty
     p = tmp_path / 'data' / 'incidents_log.json'
     assert p.exists() and p.stat().st_size > 0
+
+
+def test_high_error_rate_alert_carries_meta(tmp_path, monkeypatch):
+    (tmp_path / "data").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setitem(sys.modules, 'observability', types.SimpleNamespace(emit_event=lambda *a, **k: None))
+
+    captured = {}
+
+    def _fake_emit_internal_alert(name, severity="info", summary="", **details):
+        captured["name"] = name
+        captured["severity"] = severity
+        captured["summary"] = summary
+        captured["details"] = details
+
+    monkeypatch.setitem(sys.modules, 'internal_alerts', types.SimpleNamespace(emit_internal_alert=_fake_emit_internal_alert))
+
+    import remediation_manager as rm  # noqa: WPS433
+
+    monkeypatch.setattr(rm, "handle_critical_incident", lambda *a, **k: None)
+
+    am = importlib.import_module('alert_manager')
+    am.reset_state_for_tests()
+
+    ts = time.time()
+    am.note_request(
+        500,
+        0.2,
+        ts=ts,
+        context={
+            "command": "webapp:post:push_api.subscribe",
+            "path": "/api/push/subscribe",
+            "method": "POST",
+            "request_id": "req-meta-123456",
+            "user_id": "user-abc",
+            "source": "webapp",
+        },
+    )
+    am._thresholds['error_rate_percent'].threshold = 5.0  # type: ignore[attr-defined]
+
+    am._emit_critical_once(
+        key='error_rate_percent',
+        name='High Error Rate',
+        summary='err>thr',
+        details={'current_percent': 5.63, 'sample_count': 120, 'threshold_percent': 5.0, 'window_seconds': 300},
+        now_ts=ts + 1,
+    )
+
+    payload = captured["details"]
+    assert payload.get("alert_type") == "high_error_rate"
+    assert payload.get("feature") == "push_api.subscribe"
+    assert payload.get("request_id") == "req-meta-123456"
+    assert payload.get("error_rate_percent") == pytest.approx(5.63, rel=1e-3)
+    assert "meta_summary" in payload and "push_api.subscribe" in payload["meta_summary"]


### PR DESCRIPTION
## ✨ תיאור קצר
הרחבנו את מנגנון ההתראות `High Error Rate` כך שיכלול קונטקסט מפורט (כמו command, endpoint, request_id, user_id) ומטא־דאטה עשיר, במטרה לשפר את יכולת התחקור וההבנה של שגיאות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הרחבנו את `alert_manager.py` כך שכל דגימת request שגויה שומרת קונטקסט (command, endpoint, request_id, user_id וכו’) ומתווסף מנגנון העשרה שמייצר מטא־דאטה עשיר להתראות `High Error Rate`. זה כולל שדות כמו `feature`, `alert_type`, `meta_summary`, מדדי סף וגרף ייעודי – כל אלו משויכים ל־`emit_internal_alert` ונשמרים גם במסד.
- עדכנו את `metrics.py` כך שהוא מעביר את הקונטקסט הרלוונטי ל־`note_request`, מה שמאפשר לקשור התראות חריגה לחיווי כמו `webapp:post:push_api.subscribe` ולמשתמש שהפעיל את הבקשה.
- הוספנו בדיקה ב־`tests/test_alert_manager_integration.py` שמוודאת שפרטי ה־Meta החדשים אכן נשלחים.
- תיעדנו ב־`docs/observability/observability_dashboard.md` את רשימת השדות וה־meta summary החדש בעמודת ה־Meta.

## 🧪 בדיקות
- נוספה בדיקת אינטגרציה `test_high_error_rate_alert_carries_meta` ב־`tests/test_alert_manager_integration.py` המאמתת את העברת פרטי ה־Meta החדשים.
- ניסיון להריץ את הבדיקה באמצעות `python3 -m pytest tests/test_alert_manager_integration.py` נכשל בסביבת הפיתוח עקב חוסר במודול `pytest`. יש לוודא התקנת התלויות והרצה מוצלחת של הבדיקות.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (נדרשת התקנת תלויות)
- [x] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שיפור משמעותי ביכולת התחקור של שגיאות בפרודקשן. סיכון נמוך, השינויים הם בעיקר הוספת מידע למנגנון התראות קיים.

## 🔗 קישורים
- Issues קשורים: #1982
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לגרסה קודמת של הקוד. השינויים אינם כוללים מיגרציות מסד נתונים או שינויים תשתיתיים קריטיים.

---
<a href="https://cursor.com/background-agent?bcId=bc-301cb05c-4536-4272-87b5-43b6d1a15526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-301cb05c-4536-4272-87b5-43b6d1a15526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enriches High Error Rate alerts with contextual meta (feature/command/endpoint/request_id/user_id), plumbs request context from metrics to alerts, and updates docs and tests.
> 
> - **Backend**:
>   - **`alert_manager.py`**:
>     - Capture and retain recent error contexts (`_error_contexts`) with sanitization; derive `feature` from `command`.
>     - Enrich `High Error Rate` alerts with meta fields: `alert_type`, `feature`, `command`, `endpoint`, `method`, `source`, `request_id`, `user_id`, `error_rate_percent`, `threshold_percent`, `sample_count`, `window_seconds`, `meta_summary`.
>     - Extend `note_request` to accept `context`; include extra fields (`error_count`, `metric`, `graph_metric`, `window_seconds`) in alert details.
>   - **`metrics.py`**:
>     - Extract context (from args and structlog) and pass sanitized `note_context` to `alert_manager.note_request`.
> - **Tests**:
>   - Add `test_high_error_rate_alert_carries_meta` asserting enriched meta is emitted.
> - **Docs**:
>   - Update `docs/observability/observability_dashboard.md` with the new High Error Rate meta fields and `meta_summary` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc0ce2763c87f3f36c1f25b948e064d6500aa428. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->