### PR TITLE
Respond to github message

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -1429,16 +1429,16 @@ input.md-task-checkbox {
               <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#fdf6e3;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
               נייר חם
             </button>
-            <button class="bg-color-option" data-color="light" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#f7eadb;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
-              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#f7eadb;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
+            <button class="bg-color-option" data-color="light" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#f5e6d3;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#f5e6d3;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
               חום בהיר
             </button>
-            <button class="bg-color-option" data-color="medium" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#ecd9bd;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
-              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#ecd9bd;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
+            <button class="bg-color-option" data-color="medium" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#e8d4b0;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#e8d4b0;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
               חום בינוני
             </button>
-            <button class="bg-color-option" data-color="dark" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#dec4a3;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
-              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#dec4a3;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
+            <button class="bg-color-option" data-color="dark" style="display:block;width:100%;padding:8px 12px;margin:4px 0;border:1px solid #ddd;border-radius:6px;background:#d4b896;color:#333;cursor:pointer;font-size:14px;transition:all 0.2s ease;">
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#d4b896;border:1px solid #999;vertical-align:middle;margin-left:8px;"></span>
               חום כהה
             </button>
           </div>


### PR DESCRIPTION
## ✨ תיאור קצר
החזרנו לאחור שינויים קודמים הקשורים לצבעי רקע במארקדאונים, כפתור בחירת צבע הרקע והשפעתם על כותרות ובלוקי קוד. זאת כדי להחזיר את ההתנהגות הקודמת והנייטרלית, בעקבות דיווח על קריטיות.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- החזרת פלטת צבעי הרקע המקורית (כולל קוד וכותרות) והסרת גווני Rose Pine מברירת המחדל ב-`webapp/templates/md_preview.html`.
- החזרת כל אפשרויות כפתור "צבע רקע" (בהיר/בינוני/כהה) ועיצובו הנייטרלי של הכפתור וה-dropdown.
- לוגיקת בחירת הצבע ב-JavaScript חזרה למצב הקודם, התומך בכל הצבעים ולא מגביל ל-Rose Pine בלבד.

## 🧪 בדיקות
השינויים נבדקו ידנית על ידי בדיקת תצוגת Markdown בכל ערכות הנושא השונות.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקה ידנית)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השינוי מחזיר את התנהגות ממשק המשתמש הקודמת של בחירת צבעי רקע למארקדאון. הסיכון נמוך מכיוון שמדובר בריברט.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
תוכנית חזרה לאחור במקרה תקלה: ביצוע ריברט ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-adf52769-f722-430a-a136-5bcfbc0cb43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adf52769-f722-430a-a136-5bcfbc0cb43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores neutral sepia palette and reintroduces light/medium/dark options with updated CSS and a simplified JS background color switcher in `md_preview.html`.
> 
> - **Markdown preview (UI/CSS)**
>   - Update `#md-content.bg-sepia` palette and related code/hljs variables to a neutral Solarized-like scheme.
>   - Tweak fold variables for `#md-content.bg-sepia`.
>   - Restyle background color button/dropdown to neutral white/gray.
>   - Re-add background options (`light`, `medium`, `dark`, `sepia`) with visual swatches in `#bgColorOptions`.
> - **Background color switcher (JS)**
>   - Expand `COLORS` to include `light`, `medium`, `dark`; keep `sepia`.
>   - Simplify `applyBackgroundColor` (remove validation/remember options), explicitly manage `bg-*` classes, always persist preference, and apply saved preference on init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0249245de6b8e1ff062dc770b787de7f888688f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->