### PR TITLE
Respond to github message

### DIFF
--- a/docs/_static/copy-page.js
+++ b/docs/_static/copy-page.js
@@ -186,8 +186,10 @@
         return tokens.find((token) => token && token !== 'admonition') || 'note';
       };
 
-      const escapeQuotes = (text) =>
-        (text || '').replace(/"/g, '\\"').replace(/\s+/g, ' ').trim();
+      const escapeQuotes = (text) => {
+        const normalized = (text || '').replace(/\s+/g, ' ').trim();
+        return normalized.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      };
 
       const indentMarkdown = (markdown) => {
         if (!markdown) {


### PR DESCRIPTION
## ✨ תיאור קצר
הרחבתי את מנוע ה-Turndown בסקריפט ההעתקה (`copy-page.js`) כדי לתקן את פורמט ה-Markdown של טבלאות Sphinx ודיאגרמות Mermaid. כעת, העתקה ללוח תפיק טבלאות מעוצבות כהלכה ובלוקי Mermaid עטופים בגדרות קוד מתאימות.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת לוגיקה לטיפול בטבלאות Sphinx (בעלות class `docutils`, `longtable`, `colwidths-auto`) כך שיועתקו בפורמט Markdown תקין, כולל כותרות, יישור עמודות ו-escape של תו `|`.
- הטמעת זיהוי לבלוקים עם class `mermaid` (בתוך `PRE`, `DIV` או `CODE`) ועטיפתם בגדרות קוד ````mermaid` תוך שמירה על ההזחה המקורית.

## 🧪 בדיקות
- מומלץ לפתוח דף תיעוד אמיתי המכיל טבלה ודיאגרמת Mermaid, ללחוץ על כפתור ההעתקה ולוודא שההדבקה ב-Markdown אכן יוצאת בפורמט המצופה (כולל גדרות Mermaid תקינות).
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינוי קל בקוד צד-לקוח, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-27ac9355-e387-44fc-af57-3f6a099cb925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27ac9355-e387-44fc-af57-3f6a099cb925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends `copy-page.js` Turndown rules to correctly convert Sphinx admonitions, docutils tables, and Mermaid blocks into clean Markdown.
> 
> - **Docs copy pipeline (`docs/_static/copy-page.js`)**:
>   - **Markdown conversion**:
>     - Adds support for Sphinx admonitions: detects type, captures title, and renders as `!!! type "Title"` with indented body.
>     - Converts docutils/longtable/colwidths-auto tables to GFM tables with escaped pipes and optional captions.
>     - Wraps `.mermaid` blocks in fenced code ```mermaid with normalized indentation.
>   - **Utilities**:
>     - Introduces helpers for inline markdown extraction, quote escaping, indentation, table cell/r ow handling, and Mermaid content normalization.
>   - **Turndown integration**:
>     - Registers new rules: `sphinxAdmonitions`, `docutilsTables`, `mermaidBlocks`; keeps existing highlight block handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88b410f18d3a78e06eb6a68fae9c6822c3df382f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->