### PR TITLE
Restore editor full width

### DIFF
--- a/webapp/static/css/split-view.css
+++ b/webapp/static/css/split-view.css
@@ -12,6 +12,18 @@
   margin-top: 1rem;
 }
 
+.split-view:not(.is-active) {
+  --split-editor-ratio: 1;
+}
+
+.split-view:not(.is-active) .split-panels {
+  display: block;
+}
+
+.split-view:not(.is-active) .split-panel--editor {
+  width: 100%;
+}
+
 .split-view:not(.preview-enabled) .split-toolbar {
   display: none;
 }
@@ -107,6 +119,7 @@
 
 .split-panel--editor {
   flex: var(--split-editor-ratio);
+  max-width: 100%;
   padding: 0 0.85rem 0.85rem 0.85rem;
 }
 

--- a/webapp/static/js/live-preview.js
+++ b/webapp/static/js/live-preview.js
@@ -779,6 +779,17 @@
         this.toggleBtn.setAttribute('aria-pressed', 'false');
       }
       this.root.classList.remove('is-active');
+      this.root.dataset.activePanel = 'editor';
+      const tabs = this.root.querySelectorAll('[data-panel-target]');
+      if (tabs && tabs.length) {
+        tabs.forEach((el) => {
+          const target = el.dataset.panelTarget || 'editor';
+          el.setAttribute('aria-selected', target === 'editor' ? 'true' : 'false');
+        });
+      }
+      try {
+        this.root.style.removeProperty('--split-editor-ratio');
+      } catch (_) {}
       this.setStatus(STATUS.IDLE, message || this.defaultMessage(STATUS.IDLE));
       if (this.previewCanvas) {
         this.previewCanvas.innerHTML = '<div class="split-preview-placeholder"><p>תצוגה חיה תופיע כאן</p><small>הפעל את Live Preview כדי לרענן בזמן אמת</small></div>';


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את ברירת המחדל של תצוגת העורך כך שיחזור להיות ברוחב מלא בעמודי העלאה ועריכת קובץ. הפיצול למצב Live Preview יופעל רק בלחיצה על הכפתור, ולא כברירת מחדל.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עדכון CSS כדי לאכוף תצוגת עורך ברוחב 100% כאשר מצב הפיצול אינו פעיל.
- שינוי קוד JavaScript ב-`live-preview.js` כדי לאפס את יחס הפאנלים ולהגדיר את העורך כפאנל הפעיל בעת כיבוי Live Preview.

## 🧪 בדיקות
- נבדק ידנית בעמודי העלאה ועריכת קובץ.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות)
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה מינורית על UI/UX, תיקון התנהגות לא רצויה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביצוע Rollback ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-39462c69-b771-40dc-bdd5-f68e3ada71aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39462c69-b771-40dc-bdd5-f68e3ada71aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores full-width editor when Live Preview is off and resets split/tabs state on disabling preview.
> 
> - **UI/Layout (CSS)**
>   - Default `--split-editor-ratio` to `1` when `.split-view` is not `.is-active`, making the editor full-width by default.
>   - Show `.split-panels` as block and set `.split-panel--editor` to `width: 100%` when inactive; hide `.split-panel--preview` and `.split-resizer`.
>   - Add `max-width: 100%` to `.split-panel--editor`.
> - **Behavior (JS `webapp/static/js/live-preview.js`)**
>   - On `disablePreview()`:
>     - Set `data-active-panel` to `editor` and update tab `aria-selected` states.
>     - Remove inline `--split-editor-ratio` to clear custom split sizing.
>     - Reset status/meta/content/theme consistently for the inactive state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e1a0c9a4a36700026efb67db933e49a3da8db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->