### PR TITLE
Respond to github message

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -2128,10 +2128,25 @@
         if (!theme) { return; }
         htmlEl.setAttribute('data-theme', theme);
     }
+    function mapDarkModePreference(theme){
+        if (theme === 'dark' || theme === 'dim') {
+            return theme;
+        }
+        if (theme === 'classic') {
+            return 'light';
+        }
+        return null;
+    }
     function persistTheme(theme){
         if (!theme) { return; }
         lsSet(STORAGE_KEYS.userTheme, theme);
-        lsSet(STORAGE_KEYS.preference, theme);
+        const darkModePref = mapDarkModePreference(theme);
+        if (darkModePref) {
+            lsSet(STORAGE_KEYS.preference, darkModePref);
+        } else {
+            try { localStorage.removeItem(STORAGE_KEYS.preference); }
+            catch (_) {}
+        }
         try {
             fetch('/api/ui_prefs', {
                 method: 'POST',


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו Wizard לבחירת ערכת נושא (Theme Wizard) שמוצג למשתמשים חדשים לאחר סיום סיור ההיכרות. ה-Wizard מאפשר בחירה מבין 3 ערכות נושא עם תצוגה מקדימה חיה, ושומר את ההעדפה ב-localStorage וב-API. המטרה היא לשפר את חווית ה-onboarding ולאפשר התאמה אישית ראשונית של הממשק.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- יצירת מודל Theme Wizard חדש ב-`base.html` עם CSS ו-JS נלווים.
- המודל מציג 3 ערכות נושא לבחירה (Nebula, Rose Pine Dawn, Classic) עם תצוגה מקדימה חיה.
- שילוב עם `Driver.js` לפתיחה אוטומטית של ה-Wizard לאחר סיום/דילוג על סיור ההיכרות (פעם אחת למשתמש).
- שמירת העדפת ערכת הנושא ודגל `theme_wizard_seen` ב-localStorage ועדכון API.
- הוספת הודעה במודל המפנה למסך ההגדרות לצפייה בכל ערכות הנושא.

## 🧪 בדיקות
- בדיקות ידניות בוצעו:
  - התחברות כמשתמש חדש, סיום/דילוג על הסיור ואימות שהוויזארד נפתח פעם אחת בלבד.
  - מעבר עם העכבר/Tab על ערכות הנושא ואימות שינוי מיידי של `data-theme`.
  - לחיצה על "שמור והמשך" ואימות שהנושא נשמר ב-localStorage וב-API, והוויזארד לא חוזר.
  - לחיצה על "דלג" ואימות שהנושא נשאר ברירת המחדל, `theme_wizard_seen` מסומן והוויזארד לא חוזר.
  - רענון העמוד ואימות שהוויזארד לא מופיע שוב ושהעדפת העיצוב נשמרת.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (בדיקות ידניות עברו, אוטומטיות צד לקוח לא הורצו)
- [ ] תיעוד עודכן (README/Docs) - טרם עודכן, מומלץ להוסיף תיעוד ל-CodeBot Docs.
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש - טרם עודכן.
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי - מומלץ לצרף צילום מסך/וידאו של ה-Wizard בפעולה.

## 🧩 השפעות/סיכונים
- השפעה על חווית משתמש חדש (onboarding).
- סיכון נמוך: פוטנציאל להתנגשות עם מודלים אחרים או בעיות תצוגה בדפדפנים ישנים, אך ננקטו אמצעים למנוע זאת (waitForWelcome, fallback API).

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן להחזיר את הקוד לגרסה הקודמת. מכיוון שהשינויים הם בעיקר בצד הלקוח (HTML, CSS, JS), ההשפעה על ה-backend מינימלית (קריאת API אחת).

---
<a href="https://cursor.com/background-agent?bcId=bc-3866ffcf-393b-4fe3-8e40-25fda1021d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3866ffcf-393b-4fe3-8e40-25fda1021d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Theme Wizard modal in `base.html` that lets users preview/select a theme (Nebula, Rose Pine Dawn, Classic), auto-opens post-tour/on `/files`, and saves preference locally and via `/api/ui_prefs`.
> 
> - **UI/Onboarding**:
>   - **Theme Wizard modal** in `webapp/templates/base.html` with options `nebula`, `rose-pine-dawn`, `classic` and live preview via `data-theme`.
>   - Auto-open logic: only for logged-in users on `/files`, once per user (`theme_wizard_seen`), with 9s fallback and URL trigger (`?theme_wizard=start|restart`).
>   - Integrated with welcome/tour flow: waits for welcome modal to close and hooks into Driver.js (`watchDriver`) to open after tour finishes.
> - **Persistence & API**:
>   - Stores selection in `localStorage` (`user_theme`, `dark_mode_preference`) and POSTs `{ theme }` to `/api/ui_prefs`.
> - **Accessibility & UX**:
>   - Focus trap, ESC to close, ARIA roles/labels, overlay/close/skip/save actions.
> - **Styling**:
>   - Added scoped CSS for the wizard, including light-theme adjustments for `rose-pine-dawn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844b23282011dbebfaa03b1b73e9e2bf4bb6a128. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->