### PR TITLE
Respond to github message

### DIFF
--- a/webapp/static/css/global_search.css
+++ b/webapp/static/css/global_search.css
@@ -62,66 +62,149 @@
 }
 .clear-search-btn:hover{ background: var(--glass-hover); }
 
-/* כרטיס תוצאת חיפוש – רחב וממורכז ~95% מרוחב המסך */
+/* רשימת תוצאות */
+.global-search-results{
+  display:flex;
+  flex-direction:column;
+  gap:1.25rem;
+  width:100%;
+  max-width:1400px;
+  margin:0 auto;
+  padding:0;
+}
+
+/* כרטיס תוצאת חיפוש */
 .search-result-card{
-  /* הרחבה ל-95% מרוחב המסך עם הגבלה מקסימלית */
-  width:95%;
-  max-width:1400px; /* למנוע מתיחה קיצונית במסכים גדולים */
-
-  /* מרכוז הכרטיס */
-  margin:1rem auto;
-
-  /* תחום ריפוד ורוחב כולל */
-  box-sizing:border-box;
-  padding:1.25rem;
-
-  /* טיפול בגלישת טקסט */
-  overflow-wrap:break-word;
-  word-wrap:break-word; /* תמיכה בדפדפנים ישנים */
-  word-break:break-word;
-
-  /* מניעת גלישה אופקית */
-  overflow-x:hidden;
-
-  /* צללית עדינה */
-  box-shadow:0 2px 8px rgba(0,0,0,0.1);
+  width:100%;
+  margin:0 auto;
+  padding:1.5rem;
+  border-radius:18px;
+  border:1px solid var(--search-card-border);
+  background: var(--search-card-bg);
+  box-shadow: var(--search-card-shadow);
+  backdrop-filter: blur(24px);
+  color: var(--text-primary);
+  transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+  overflow:hidden;
 }
 
-.search-result-card h6,
-.search-result-card h6 a{
+.search-result-card:hover{
+  border-color: var(--search-card-hover-border);
+  box-shadow: var(--search-card-shadow-hover);
+  transform: translateY(-2px);
+}
+
+.result-card-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+  margin-bottom:1.15rem;
+  flex-wrap:wrap;
+}
+
+.file-info{
+  display:flex;
+  align-items:center;
+  gap:0.85rem;
+  min-width:0;
+  flex:1;
+}
+
+.file-icon{
+  font-size:1.75rem;
+  flex-shrink:0;
+}
+
+.file-name{
+  color: var(--text-primary);
+  font-weight:600;
+  font-size:1.15rem;
+  text-decoration:none;
   overflow-wrap:break-word;
-  word-wrap:break-word;
   word-break:break-word;
   max-width:100%;
-  display:inline-block;
 }
 
-.search-result-card .code-snippet{
-  font-family:Consolas,Monaco,'Courier New',monospace;
-  font-size:13px;
-  max-height:240px;
-  /* גלילה רק במידת הצורך */
-  overflow-x:auto;
-  overflow-y:auto;
-  max-width:100%;
+.file-name:hover,
+.file-name:focus{
+  color: var(--primary);
 }
 
-/* לרוב קוד הוא LTR – למנוע שבירה מוזרה ב-RTL */
-.search-result-card pre{
-  white-space:pre-wrap; /* אפשר שבירת שורות */
-  word-break:break-all; /* אגרסיבי יותר לקטעי קוד ארוכים */
-  overflow-wrap:anywhere;
+.search-result-card .global-search-lang-badge{
+  flex-shrink:0;
+}
+
+.result-card-snippet{
+  background: var(--search-code-bg);
+  border:1px solid var(--search-code-border);
+  border-radius:12px;
+  padding:1rem 1.15rem;
+  margin-bottom:1.15rem;
+  overflow:auto;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02);
+}
+
+.result-card-snippet pre{
+  margin:0;
+  font-family:'Fira Code',Consolas,Monaco,'Courier New',monospace;
+  font-size:0.95rem;
+  line-height:1.55;
+  color:var(--search-code-text);
   direction:ltr;
   text-align:left;
-  max-width:100%;
-  margin:0;
+  white-space:pre-wrap;
+  word-break:break-word;
+}
+.result-card-snippet code{
+  background:none;
+  color:inherit;
+  padding:0;
+  font-family:inherit;
 }
 
-.search-result-card mark{
-  background:#ffeb3b;
-  color:#000;
+.result-card-footer{
+  display:flex;
+  flex-wrap:wrap;
+  gap:0.85rem 1.5rem;
+  border-top:1px solid var(--search-card-border);
+  padding-top:0.9rem;
+  font-size:0.9rem;
+  color: var(--search-meta-text);
+}
+
+.meta-item{
+  display:flex;
+  align-items:center;
+  gap:0.5rem;
+  font-weight:500;
+}
+
+.meta-item svg{
+  width:16px;
+  height:16px;
+  opacity: var(--search-meta-icon-opacity);
+}
+
+.result-card-snippet ::-webkit-scrollbar{
+  height:8px;
+}
+.result-card-snippet ::-webkit-scrollbar-track{
+  background: color-mix(in srgb, var(--search-code-border) 35%, transparent);
+  border-radius:4px;
+}
+.result-card-snippet ::-webkit-scrollbar-thumb{
+  background: color-mix(in srgb, var(--search-code-text) 25%, transparent);
+  border-radius:4px;
+}
+
+.global-search-highlight{
+  background: var(--search-highlight-bg);
+  color: var(--search-highlight-text);
   padding:0 2px;
-  border-radius:2px
+  border-radius:3px;
+  font-weight:600;
+  box-shadow:0 0 6px var(--search-highlight-glow);
 }
 
 /* מיכל ראשי לחיפוש ופילטרים */
@@ -227,7 +310,10 @@
   .filter-container{ justify-content:center; margin-top:0.5rem; }
   /* תפריט שפות: להתאים לרוחב הזמין במסכים קטנים */
   .lang-dropdown{ max-width: calc(100vw - 2rem) !important; }
-  .search-result-card{ width:98%; padding:1rem; margin:0.5rem auto; }
+  .search-result-card{ padding:1.25rem; }
+  .result-card-header{ flex-direction:column; align-items:flex-start; }
+  .file-info{ width:100%; }
+  .result-card-footer{ flex-direction:column; align-items:flex-start; }
 }
 
 .command-shortcuts-grid{
@@ -296,13 +382,27 @@
 /* התאמות לטאבלט */
 @media (min-width: 769px) and (max-width: 1024px){
   .search-and-filters{ padding:1rem 1.5rem; }
-  .search-result-card{ width:92%; }
 }
 
 /* ============================================
    🎨 Global Search Language Badges
    ============================================ */
 :root{
+  /* Global search card tokens */
+  --search-card-bg: var(--card-bg, rgba(255,255,255,0.12));
+  --search-card-border: var(--card-border, rgba(255,255,255,0.25));
+  --search-card-hover-border: color-mix(in srgb, var(--primary, #667eea) 45%, var(--search-card-border) 55%);
+  --search-card-shadow: 0 20px 45px rgba(15,23,42,0.25);
+  --search-card-shadow-hover: 0 28px 60px rgba(15,23,42,0.35);
+  --search-meta-text: var(--text-muted, rgba(255,255,255,0.7));
+  --search-meta-icon-opacity: 0.78;
+  --search-highlight-bg: color-mix(in srgb, var(--primary, #f7df1e) 40%, #fff 60%);
+  --search-highlight-text: #1a202c;
+  --search-highlight-glow: color-mix(in srgb, var(--primary, #f7df1e) 35%, transparent);
+  --search-code-bg: var(--code-bg, rgba(15,23,42,0.9));
+  --search-code-text: var(--code-text, var(--text-primary, #ffffff));
+  --search-code-border: var(--code-border, rgba(255,255,255,0.12));
+
   /* Hue & Saturation per language */
   --js-h:48; --js-s:90%;
   --ts-h:211; --ts-s:60%;
@@ -347,6 +447,10 @@
 }
 
 :root[data-theme="classic"]{
+  --search-card-shadow: 0 30px 60px rgba(7,7,31,0.35);
+  --search-card-shadow-hover: 0 38px 76px rgba(7,7,31,0.45);
+  --search-highlight-bg: rgba(255,215,0,0.85);
+  --search-highlight-text: #1c1f3a;
   --lang-js: hsl(var(--js-h), var(--js-s), 75%);
   --lang-ts: hsl(45, 85%, 70%);
   --lang-python: hsl(45, 90%, 75%);
@@ -370,6 +474,9 @@
 
 :root[data-theme="ocean"],
 :root[data-theme="rose-pine-dawn"]{
+  --search-card-shadow: 0 16px 40px rgba(15,23,42,0.18);
+  --search-card-shadow-hover: 0 22px 52px rgba(15,23,42,0.25);
+  --search-highlight-text: #0f172a;
   --lang-js: hsl(var(--js-h), var(--js-s), 40%);
   --lang-ts: hsl(var(--ts-h), var(--ts-s), 40%);
   --lang-python: hsl(var(--python-h), var(--python-s), 35%);
@@ -392,6 +499,9 @@
 }
 
 :root[data-theme="forest"]{
+  --search-card-shadow: 0 18px 40px rgba(34,84,61,0.22);
+  --search-card-shadow-hover: 0 24px 56px rgba(34,84,61,0.3);
+  --search-highlight-text: #1c3526;
   --lang-js: hsl(var(--js-h), var(--js-s), 40%);
   --lang-ts: hsl(var(--ts-h), var(--ts-s), 40%);
   --lang-python: hsl(var(--python-h), var(--python-s), 35%);
@@ -416,6 +526,9 @@
 :root[data-theme="dark"],
 :root[data-theme="dim"],
 :root[data-theme="nebula"]{
+  --search-card-shadow: 0 25px 55px rgba(4,7,18,0.65);
+  --search-card-shadow-hover: 0 32px 72px rgba(4,7,18,0.75);
+  --search-highlight-text: #ffffff;
   --lang-js: hsl(var(--js-h), var(--js-s), 65%);
   --lang-ts: hsl(var(--ts-h), var(--ts-s), 60%);
   --lang-python: hsl(var(--python-h), var(--python-s), 70%);
@@ -438,6 +551,19 @@
 }
 
 :root[data-theme="high-contrast"]{
+  --search-card-bg:#000000;
+  --search-card-border:#ffffff;
+  --search-card-hover-border:#ffff00;
+  --search-card-shadow:none;
+  --search-card-shadow-hover:none;
+  --search-code-bg:#000000;
+  --search-code-text:#ffffff;
+  --search-code-border:#ffffff;
+  --search-highlight-bg:#ffff00;
+  --search-highlight-text:#000000;
+  --search-highlight-glow:#ffff00;
+  --search-meta-text:#ffffff;
+  --search-meta-icon-opacity:1;
   --lang-js:#ffff00;
   --lang-ts:#00ffff;
   --lang-python:#00ff00;

--- a/webapp/static/js/global_search.js
+++ b/webapp/static/js/global_search.js
@@ -6,6 +6,11 @@
   let shortcutCatalog = null;
   let shortcutCatalogPromise = null;
   let lastShortcutQuery = '';
+  const META_ICONS = {
+    score: '<svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>',
+    size: '<svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>',
+    time: '<svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/></svg>'
+  };
 
   function $(id){ return document.getElementById(id); }
 
@@ -195,7 +200,8 @@
     if (!data.results || data.results.length === 0){
       results.innerHTML = '<p class="text-muted">לא נמצאו תוצאות</p>';
     } else {
-      results.innerHTML = data.results.map(renderCard).join('');
+      const cardsHtml = data.results.map(renderCard).join('');
+      results.innerHTML = '<div class="global-search-results" role="list">' + cardsHtml + '</div>';
     }
 
     renderPagination(pagination, data);
@@ -207,36 +213,32 @@
     const highlighted = highlightSnippet(r.snippet, r.highlights);
     const icon = fileIcon(r.language || '');
     const badgeClass = languageBadgeClass(r.language);
-    const badgeHtml = '<span class="global-search-lang-badge badge ' + badgeClass + '">' + escapeHtml(r.language || 'לא ידוע') + '</span>';
+    const langLabel = String(r.language || 'לא ידוע');
+    const badgeHtml = '<span class="global-search-lang-badge badge ' + badgeClass + '" title="שפת הקובץ">' + escapeHtml(langLabel.toUpperCase()) + '</span>';
+    const scoreValue = typeof r.score === 'number' ? r.score.toFixed(2) : '—';
+    const sizeValue = humanSize(r.size || 0);
+    const updatedValue = formatDate(r.updated_at) || '—';
 
-    // מבנה כרטיס מעודכן – ממורכז ורספונסיבי, עם טיפול בגלישת טקסט
     return (
-      '<div class="search-result-card glass-card">' +
-        '<div class="card-body">' +
-          '<div class="result-header d-flex justify-content-between align-items-start">' +
-            '<div class="result-content flex-grow-1" style="min-width: 0;">' +
-              '<h6 class="result-title mb-2">' +
-                icon + ' <a href="/file/' + r.file_id + '" target="_blank" class="text-truncate d-inline-block" style="max-width: calc(100% - 50px);">' +
-                escapeHtml(r.file_name || '') +
-                '</a>' +
-                ' ' + badgeHtml +
-              '</h6>' +
-              '<div class="code-snippet-wrapper">' +
-                '<div class="code-snippet bg-light p-3 rounded">' +
-                  '<pre class="mb-0"><code>' + highlighted + '</code></pre>' +
-                '</div>' +
-              '</div>' +
-            '</div>' +
-            '<div class="result-meta text-right ml-3 flex-shrink-0">' +
-              '<div class="small text-muted">' +
-                '<div>ציון: ' + (r.score ?? 0).toFixed(2) + '</div>' +
-                '<div>גודל: ' + humanSize(r.size || 0) + '</div>' +
-                '<div>עדכון: ' + formatDate(r.updated_at) + '</div>' +
-              '</div>' +
-            '</div>' +
+      '<article class="search-result-card glass-card" role="listitem">' +
+        '<div class="result-card-header">' +
+          '<div class="file-info">' +
+            '<span class="file-icon" aria-hidden="true">' + icon + '</span>' +
+            '<a href="/file/' + r.file_id + '" target="_blank" class="file-name" title="' + escapeHtml(r.file_name || '') + '">' +
+              escapeHtml(r.file_name || '') +
+            '</a>' +
           '</div>' +
+          badgeHtml +
         '</div>' +
-      '</div>'
+        '<div class="result-card-snippet">' +
+          '<pre class="mb-0" dir="ltr"><code>' + highlighted + '</code></pre>' +
+        '</div>' +
+        '<div class="result-card-footer">' +
+          '<div class="meta-item">' + META_ICONS.score + '<span>ציון: ' + scoreValue + '</span></div>' +
+          '<div class="meta-item">' + META_ICONS.size + '<span>' + escapeHtml(sizeValue) + '</span></div>' +
+          '<div class="meta-item">' + META_ICONS.time + '<span>' + escapeHtml(updatedValue) + '</span></div>' +
+        '</div>' +
+      '</article>'
     );
   }
 
@@ -248,7 +250,7 @@
     for (const [s,e] of items){
       if (s < last) continue;
       out += escapeHtml(text.slice(last, s));
-      out += '<mark class="bg-warning">' + escapeHtml(text.slice(s, e)) + '</mark>';
+      out += '<span class="global-search-highlight">' + escapeHtml(text.slice(s, e)) + '</span>';
       last = e;
     }
     out += escapeHtml(text.slice(last));
@@ -339,6 +341,8 @@
       ruby:'💎',
       php:'🐘',
       rust:'🦀',
+      yaml:'📘',
+      yml:'📘',
       shell:'💻',
       bash:'💻'
     };


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספנו תגיות שפה דינמיות לתוצאות החיפוש הגלובלי.
- התגיות מציגות צבעים ורקעים מותאמים אישית לכל שפה ולכל ערכת נושא, תוך שמירה על ניגודיות גבוהה, וכוללות fallback לשפות לא ידועות.

## 📦 שינויים עיקריים
- [x] קוד (Backend) - *שינויי Frontend ב-CSS ו-JS*
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת משתני CSS מותאמים אישית (Hue/Saturation/Lightness) עבור צבעי שפות שונות, עם התאמות לכל ערכות הנושא (כולל High Contrast).
- עדכון קובץ `webapp/static/css/global_search.css` עם סגנונות התגיות באמצעות `color-mix` ליצירת רקע וגבול תואמים.
- עדכון קובץ `webapp/static/js/global_search.js` כדי לייצר את מחלקת ה-CSS המתאימה לכל שפה, כולל מיפוי שמות שפות חלופיים וטיפול בשפות לא ידועות.
- החלפת תגית השפה הסטטית בתגית דינמית ב-HTML של כרטיסי התוצאות.

## 🧪 בדיקות
- [ ] Unit
- [ ] Integration
- [x] Manual

איך בדקתם? מה עבר? מה נשאר?
- בוצע חיפוש גלובלי ונבדקו התגיות ויזואלית בכל ערכות הנושא (כולל High Contrast) כדי לוודא ניגודיות נכונה.
- נבדקו שפות לא ממופות לווידוא הצגת סגנון ה־`lang-unknown`.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי (מומלץ)

## 🧩 השפעות/סיכונים
- השפעה ויזואלית בלבד על תוצאות החיפוש הגלובלי. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביצוע Rollback לקבצים `webapp/static/css/global_search.css` ו-`webapp/static/js/global_search.js` לגרסה הקודמת.

---
<a href="https://cursor.com/background-agent?bcId=bc-4010c9b4-a06f-401b-9c58-0145174e1f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4010c9b4-a06f-401b-9c58-0145174e1f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dynamic, theme-aware language badges to global search results, replacing the static label and expanding language/icon mappings.
> 
> - **Frontend**:
>   - **CSS (`webapp/static/css/global_search.css`)**:
>     - Introduces theme-driven variables for language colors and styles for `global-search-lang-badge`, including fallback `lang-unknown`.
>     - Provides per-theme overrides (classic, ocean, forest, dark/dim/nebula, high-contrast) and `color-mix` backgrounds/borders.
>   - **JS (`webapp/static/js/global_search.js`)**:
>     - Replaces static language label with dynamic `<span class="global-search-lang-badge ...">` built via `languageBadgeClass()`.
>     - Adds `languageBadgeClass(lang)` mapping (incl. aliases: js/ts/jsx/vue/c#/c++/golang/yml/md/bash/sh, etc.).
>     - Expands `fileIcon()` language-to-icon map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff5fb9f4a898eceb9b64ed8885e47c182a27cce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->