### PR TITLE
Fix scroll check button

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -1408,10 +1408,115 @@
           test: document.getElementById('smoothScrollTestBtn'),
           reset: document.getElementById('smoothScrollResetBtn'),
         };
-        const disableUi = (message) => {
-          card.querySelectorAll('input, select, button').forEach((el) => { el.disabled = true; });
+        const disableUi = (message, options = {}) => {
+          const { keepTestButton = false } = options;
+          card.querySelectorAll('input, select, button').forEach((el) => {
+            if (keepTestButton && els.test && el === els.test) return;
+            el.disabled = true;
+          });
           if (noteEl && message) noteEl.textContent = message;
         };
+
+        let activeTestMarker = null;
+        let activeTestMarkerTimeout = null;
+
+        const clearActiveTestMarker = () => {
+          if (activeTestMarkerTimeout) {
+            clearTimeout(activeTestMarkerTimeout);
+            activeTestMarkerTimeout = null;
+          }
+          if (activeTestMarker) {
+            try { activeTestMarker.remove(); } catch (_) {}
+            activeTestMarker = null;
+          }
+        };
+
+        const createScrollTestMarker = () => {
+          if (!document?.body) return null;
+          const marker = document.createElement('div');
+          marker.id = 'smooth-scroll-test-target';
+          marker.style.position = 'absolute';
+          marker.style.left = '0';
+          marker.style.width = '1px';
+          marker.style.height = '1px';
+          marker.style.pointerEvents = 'none';
+          const docHeight = Math.max(
+            document.body?.scrollHeight || 0,
+            document.documentElement?.scrollHeight || 0,
+            window.innerHeight || 0,
+            800,
+          );
+          marker.style.top = `${Math.max(200, Math.floor(docHeight / 2))}px`;
+          document.body.appendChild(marker);
+          activeTestMarker = marker;
+          activeTestMarkerTimeout = setTimeout(() => clearActiveTestMarker(), 6000);
+          return marker;
+        };
+
+        const fallbackScrollTo = (targetY, onDone) => {
+          try {
+            window.scrollTo({ top: targetY, behavior: 'smooth' });
+          } catch (_) {
+            window.scrollTo(0, targetY);
+          }
+          setTimeout(() => {
+            if (typeof onDone === 'function') onDone();
+          }, 500);
+        };
+
+        const runNativeScrollTest = (marker) => {
+          if (!marker) return;
+          const absoluteTop = (() => {
+            try {
+              const rect = marker.getBoundingClientRect();
+              return Math.max(0, (window.scrollY || window.pageYOffset || 0) + rect.top);
+            } catch (_) {
+              return 0;
+            }
+          })();
+          fallbackScrollTo(absoluteTop, () => {
+            setTimeout(() => {
+              fallbackScrollTo(0, () => {
+                clearActiveTestMarker();
+              });
+            }, 300);
+          });
+        };
+
+        const runScrollTest = () => {
+          clearActiveTestMarker();
+          const marker = createScrollTestMarker();
+          if (!marker) return;
+          const manager = window.smoothScroll;
+          if (manager && typeof manager.smoothScrollTo === 'function') {
+            try {
+              manager.smoothScrollTo(marker, {
+                callback: () => {
+                  setTimeout(() => {
+                    try {
+                      manager.smoothScrollTo('body');
+                    } catch (_) {
+                      fallbackScrollTo(0, () => clearActiveTestMarker());
+                      return;
+                    }
+                    clearActiveTestMarker();
+                  }, 300);
+                },
+              });
+              return;
+            } catch (_) {
+              // fall through to native scroll fallback
+            }
+          }
+          runNativeScrollTest(marker);
+        };
+
+        if (els.test) {
+          els.test.addEventListener('click', (event) => {
+            event.preventDefault();
+            runScrollTest();
+          });
+        }
 
         const attach = (manager) => {
           const defaults = { ...(manager.defaultConfig || {}) };
@@ -1481,48 +1586,6 @@
             });
           }
 
-          let activeTestMarker = null;
-          let activeTestMarkerTimeout = null;
-          const clearActiveTestMarker = () => {
-            if (activeTestMarkerTimeout) {
-              clearTimeout(activeTestMarkerTimeout);
-              activeTestMarkerTimeout = null;
-            }
-            if (activeTestMarker) {
-              try { activeTestMarker.remove(); } catch (_) {}
-              activeTestMarker = null;
-            }
-          };
-
-          if (els.test) {
-            els.test.addEventListener('click', (event) => {
-              event.preventDefault();
-              clearActiveTestMarker();
-              try {
-                const marker = document.createElement('div');
-                marker.id = 'smooth-scroll-test-target';
-                marker.style.position = 'absolute';
-                marker.style.top = `${Math.max(200, Math.floor((document.body.scrollHeight || 4000) / 2))}px`;
-                marker.style.width = '1px';
-                marker.style.height = '1px';
-                marker.style.pointerEvents = 'none';
-                document.body.appendChild(marker);
-                activeTestMarker = marker;
-                activeTestMarkerTimeout = setTimeout(() => clearActiveTestMarker(), 5000);
-                manager.smoothScrollTo(marker, {
-                  callback: () => {
-                    setTimeout(() => {
-                      try { manager.smoothScrollTo('body'); } catch (_) {}
-                      clearActiveTestMarker();
-                    }, 300);
-                  },
-                });
-              } catch (_) {
-                clearActiveTestMarker();
-              }
-            });
-          }
-
           if (els.reset) {
             els.reset.addEventListener('click', (event) => {
               event.preventDefault();
@@ -1540,7 +1603,7 @@
             return;
           }
           if (attempt > 200) {
-            disableUi('מנוע הגלילה לא נטען — רענן את הדף ובדוק את הקונסול לדיווחי שגיאה.');
+            disableUi('מנוע הגלילה לא נטען — הכפתור יריץ גלילה רגילה מהדפדפן.', { keepTestButton: true });
             return;
           }
           setTimeout(() => waitForManager(attempt + 1), 50);


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את כפתור "בדיקת גלילה" במסך ההגדרות כך שיעבוד גם אם מנוע ה-`smoothScroll` לא נטען. הוספתי מנגנון fallback לגלילה רגילה של הדפדפן והודעה מתאימה למשתמש במקרה זה.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת לוגיקת fallback לגלילת דפדפן רגילה עבור כפתור בדיקת הגלילה, במקרה שמנהל `smoothScroll` אינו זמין.
- עדכון פונקציית `disableUi` כדי לאפשר השארת כפתור הבדיקה פעיל במצבים מסוימים.
- שינוי הודעת השגיאה כאשר מנוע הגלילה לא נטען, כדי להבהיר שהכפתור יפעל עם גלילה רגילה.
- יצירת עוגן זמני באמצע הדף לבדיקת הגלילה.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
  - בדיקה ידנית: רענון מסך ההגדרות ולוודא שכפתור הבדיקה מזיז את העמוד קדימה ואחורה, גם בסביבות בהן מנוע `smoothScroll` לא נטען.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - אין השפעה מהותית על ביצועים או אבטחה. השינוי משפר את חווית המשתמש במקרים קצה בהם מנוע הגלילה אינו זמין.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - החזרה לגרסה קודמת של `webapp/templates/settings.html`. השינוי הוא בצד הלקוח ואינו משפיע על לוגיקת שרת.

---
<a href="https://cursor.com/background-agent?bcId=bc-c87192f8-4462-435a-95ef-85fdd973b212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c87192f8-4462-435a-95ef-85fdd973b212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Smooth Scroll settings to run a self-contained scroll test with native browser fallback and keep the test button enabled if the smoothScroll manager isn’t loaded.
> 
> - **Smooth Scroll settings (`webapp/templates/settings.html`)**:
>   - Add native fallback test flow: `createScrollTestMarker`, `fallbackScrollTo`, `runNativeScrollTest`, and `runScrollTest` with proper cleanup and timeouts.
>   - Refactor `disableUi(message, { keepTestButton })` to optionally keep `בדיקת גלילה` enabled; change failure note to indicate native scrolling.
>   - Register test button handler independently of manager; centralize marker lifecycle outside `attach` and remove old in-attach test logic.
>   - More robust target positioning and document height calculation; extend marker lifetime to 6000ms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae7c166c9ae1846968293578f5886eb713533a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->