### PR TITLE
Fix markdown theme display

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -2848,20 +2848,27 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
   const WHITE_BG_THEMES = new Set(['classic', 'ocean', 'forest', 'rose-pine-dawn']);
 
   function themeSurfaceColor(rootEl) {
+    const element = rootEl || document.documentElement;
     try {
-      const value = getComputedStyle(rootEl || document.documentElement).getPropertyValue('--md-surface');
+      const value = getComputedStyle(element).getPropertyValue('--md-surface');
       return (value && value.trim()) || '#1f1f1f';
     } catch(_) {
       return '#1f1f1f';
     }
   }
 
+  function getCurrentTheme(rootEl) {
+    const element = rootEl || document.documentElement;
+    return (element && element.getAttribute('data-theme')) || 'classic';
+  }
+
   // החלת צבע רקע
-  function applyBackgroundColor(color) {
+  function applyBackgroundColor(color, options = {}) {
     const mdContent = document.getElementById('md-content');
     if (!mdContent) return;
     const indicator = document.querySelector('#bgColorBtn span');
     const rootEl = document.documentElement;
+    const skipSave = Boolean(options.skipSave);
     
     // הסרת כל המחלקות הקודמות (כולל ברירת המחדל)
     const COLOR_CLASSES = ['bg-default-light', 'bg-sepia', 'bg-light', 'bg-medium', 'bg-dark'];
@@ -2876,7 +2883,7 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
         indicator.style.background = COLORS[color];
       }
     } else {
-      const currentTheme = (rootEl && rootEl.getAttribute('data-theme')) || 'classic';
+      const currentTheme = getCurrentTheme(rootEl);
       const wantsWhiteBackground = WHITE_BG_THEMES.has(currentTheme);
       
       if (wantsWhiteBackground) {
@@ -2900,8 +2907,10 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
       }
     });
     
-    // שמירת ההעדפה
-    saveColorPreference(color);
+    // שמירת ההעדפה אלא אם דילגנו (למשל בעקבות שינוי תמה)
+    if (!skipSave) {
+      saveColorPreference(color);
+    }
   }
   
   // אתחול המערכת
@@ -2958,6 +2967,18 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
     bgColorOptions.insertBefore(defaultBtn, bgColorOptions.firstChild);
     
     // סימון ברירת המחדל אם אין צבע שמור - יעשה אוטומטית דרך applyBackgroundColor
+
+    // מעקב אחרי שינוי ערכת נושא (theme wizard)
+    const htmlEl = document.documentElement;
+    if (htmlEl) {
+      const observer = new MutationObserver((mutations) => {
+        if (mutations.some(m => m.type === 'attributes' && m.attributeName === 'data-theme')) {
+          const saved = getSavedColorPreference();
+          applyBackgroundColor(saved, { skipSave: true });
+        }
+      });
+      observer.observe(htmlEl, { attributes: true, attributeFilter: ['data-theme'] });
+    }
   }
   
   // הפעלת המערכת לאחר טעינת הדף


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג שגרם לכך שאפשרות "רקע לבן" בתצוגת Markdown לא עבדה כראוי בערכות נושא כהות (כמו Rose Pine Dawn), והציגה רקע כהה במקום לבן. הוספנו מחלקת CSS `bg-default` והתאמנו את לוגיקת ה-JS כדי להבטיח שהרקע הלבן ינצח את הגדרות ה-theme.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת מחלקת CSS חדשה `bg-default` ב-`md_preview.html` עם הגדרות רקע לבן וטקסט כהה, המבטלת משתני CSS של ה-theme.
- שינוי ה-HTML ב-`md_preview.html` כך ש-#md-content יתחיל עם המחלקה `bg-default`.
- עדכון פונקציית `applyBackgroundColor` ב-`md_preview.html` כדי להסיר/להוסיף את `bg-default` באופן עקבי, ולוודא שהיא נקראת באתחול.

## 🧪 בדיקות
- **Manual:**
    - רענון `md_preview.html`.
    - מעבר בין ערכות נושא (Classic, Dim, Rose Pine Dawn) ולוודא שכפתור "רקע לבן" מציג רקע לבן וטקסט כהה כנדרש.
    - בחירת צבע רקע אחר (Sepia/Medium) ולוודא שהכיתוב והקוד מקבלים את הפלטות החומות.
    - חזרה ל"רקע לבן" ולוודא שהמחלקה `bg-default` חוזרת.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: תיקון UI קטן, סיכון נמוך. משפר את חווית המשתמש עבור אפשרות קיימת.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיט (revert) של השינויים בקובץ `webapp/templates/md_preview.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-34caf5b8-aa0e-41a5-a659-385a21391fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34caf5b8-aa0e-41a5-a659-385a21391fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `bg-default-light` and updates background switcher to respect theme defaults, fixing Markdown preview background on light/dawn themes.
> 
> - **Markdown Preview styling (`webapp/templates/md_preview.html`)**
>   - **CSS**: Add `#md-content.bg-default-light` with explicit white surface/text/border/code vars for true white default.
>   - **JS – Background switcher**:
>     - Introduce `WHITE_BG_THEMES` and `themeSurfaceColor()` to derive default surface per theme.
>     - Refactor `applyBackgroundColor`:
>       - Remove all color classes including `bg-default-light` before applying.
>       - On explicit color, set class and update button indicator; otherwise, apply `bg-default-light` for themes in `WHITE_BG_THEMES`, or use computed `--md-surface` color for indicator.
>     - Call `applyBackgroundColor(savedColor)` on init regardless of presence.
>     - Add “default (white)” option that clears selection and re-applies theme-based default.
>   - Minor: Update active-option handling to recognize empty/default selection and keep indicator in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e991ca11e279deeb25954d442c05ffb59c11310. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->