### PR TITLE
Fix rollback message too long

### DIFF
--- a/tests/test_github_commit_restore_flow.py
+++ b/tests/test_github_commit_restore_flow.py
@@ -183,6 +183,49 @@ async def test_restore_commit_actions_truncate_long_commit_message(monkeypatch):
     assert "קוצרה" in text
     assert "שורה ארוכה מאוד" in text
 
+
+@pytest.mark.asyncio
+async def test_restore_commit_actions_truncation_preserves_entities(monkeypatch):
+    import github_menu_handler as gh
+
+    handler = gh.GitHubMenuHandler()
+    update = DummyUpdate()
+    context = DummyContext()
+
+    session = handler.get_user_session(update.callback_query.from_user.id)
+    session["selected_repo"] = "owner/repo"
+    monkeypatch.setattr(handler, "get_user_token", lambda _uid: "token")
+
+    long_message = "<" * 2000
+    commit_obj = make_commit("abc123456789", long_message, url="https://example.com")
+
+    class FakeRepo:
+        def get_commit(self, sha):
+            assert sha == commit_obj.sha
+            return commit_obj
+
+    class FakeGithub:
+        def __init__(self, token):
+            pass
+
+        def get_repo(self, full):
+            assert full == "owner/repo"
+            return FakeRepo()
+
+    monkeypatch.setattr(gh, "Github", FakeGithub)
+    monkeypatch.setattr(gh, "InlineKeyboardButton", lambda *a, **k: (a, k))
+    monkeypatch.setattr(gh, "InlineKeyboardMarkup", lambda rows: rows)
+
+    await handler.show_commit_restore_actions(update, context, commit_obj.sha)
+
+    text = update.callback_query.edited_texts[-1][0]
+    assert gh.TELEGRAM_TRUNCATION_NOTICE in text
+    before_notice, sep, _ = text.partition(gh.TELEGRAM_TRUNCATION_NOTICE)
+    assert sep == gh.TELEGRAM_TRUNCATION_NOTICE
+    last_amp = before_notice.rfind("&")
+    if last_amp != -1:
+        assert ";" in before_notice[last_amp:], "HTML entity was cut mid-way before notice"
+
 @pytest.mark.asyncio
 async def test_create_branch_from_commit_reports_branch_name(monkeypatch):
     import github_menu_handler as gh


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו באג שגרם להודעות "Message_too_long" בטלגרם כאשר הבוט ניסה להציג הודעות קומיט ארוכות. כעת, הודעות ארוכות ייחתכו באופן אוטומטי עם הודעת קיצור, מה שימנע קריסות וישפר את חווית המשתמש.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת מגבלת אורך גלובלית (4000 תווים) ופונקציית `_combine_with_telegram_limit` ב-`github_menu_handler.py` לחיתוך בטוח של הודעות טלגרם.
- יישום פונקציית החיתוך בזרימת `show_commit_restore_actions` כדי לטפל בהודעות קומיט ארוכות.
- הוספת בדיקת יחידה אסינכרונית חדשה המדמה קומיט ארוך ומוודאת שההודעה נחתכת כראוי.
- הוספת `pytest`, `pytest-asyncio`, `pytest-cov` ו-`requests` כתלויות בדיקה.

## 🧪 בדיקות
- נבדק ידנית על ידי ניסיון לשחזר את הבאג עם קומיט ארוך, וכן באמצעות בדיקת יחידה חדשה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה מינימלית, בעיקר שיפור יציבות הבוט במקרים של הודעות ארוכות. אין סיכון לשינוי התנהגות קריטית.

## 🔗 קישורים
- Issues קשורים: # (נוצר בעקבות דיווח משתמש על שגיאת `Message_too_long`)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע revert ל-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-a68a4dd9-6f78-400f-b666-9f64634009d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a68a4dd9-6f78-400f-b666-9f64634009d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add safe 4K limit handling and apply it when showing commit restore details, truncating long messages with a notice; add unit tests.
> 
> - **Bot/Telegram UI**:
>   - Introduce `TELEGRAM_SAFE_TEXT_LIMIT` and `TELEGRAM_TRUNCATION_NOTICE` in `github_menu_handler.py`.
>   - Add `_combine_with_telegram_limit(header, body)` to safely compose messages under Telegram’s 4K HTML limit.
>   - Apply to `show_commit_restore_actions`: split header/body and truncate commit message when needed.
> - **Tests**:
>   - Add async test ensuring long commit messages are truncated with notice.
>   - Keep/adjust existing commit restore flow tests to validate links, caching, and branch/PR behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a77c246a8c1a6ac72571c712680ae149b1ce010f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->