### PR TITLE
Restore to commit 9b8ea3d

### DIFF
--- a/webapp/static/css/split-view.css
+++ b/webapp/static/css/split-view.css
@@ -247,8 +247,6 @@
   border: 1px solid var(--split-container-border);
   overflow: hidden;
   margin-top: 1rem;
-  width: 100%;
-  box-sizing: border-box;
 }
 
 .split-view:not(.is-active) {
@@ -346,9 +344,8 @@
 .split-panels {
   display: flex;
   flex-direction: row;
-  min-height: 320px;
-  max-height: none;
-  height: 100%;
+  min-height: 280px;
+  max-height: calc(100vh - 200px);
 }
 
 .split-panel {
@@ -356,14 +353,12 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  min-height: 0;
 }
 
 .split-panel--editor {
   flex: var(--split-editor-ratio);
   max-width: 100%;
   padding: 0 0.85rem 0.85rem 0.85rem;
-  overflow: hidden;
 }
 
 .split-panel--preview {
@@ -371,7 +366,6 @@
   background: var(--split-preview-panel-bg);
   border-inline-start: 1px solid var(--split-preview-panel-border);
   padding: 0.85rem;
-  overflow: hidden;
 }
 
 .split-resizer {
@@ -397,40 +391,9 @@
   background: var(--split-resizer-dragging);
 }
 
-.split-panel--editor #editorContainer {
-  display: flex;
-  flex-direction: column;
+.split-preview-content {
   flex: 1;
-  min-height: 0;
-}
-
-.split-panel--editor #editorContainer > label {
-  margin-bottom: 0.5rem;
-}
-
-.split-panel--editor #editorContainer textarea,
-.split-panel--editor #editorContainer .editor-textarea {
-  flex: 1;
-  min-height: 0;
-  height: 100%;
-  box-sizing: border-box;
-  resize: none;
-}
-
-.split-panel--editor .codemirror-container,
-.split-panel--editor .cm-editor {
-  flex: 1;
-  min-height: 0;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.split-panel--preview .split-preview-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
   background: var(--split-preview-bg);
   color: var(--split-preview-text);
   border-radius: 8px;
@@ -496,20 +459,14 @@ html[dir="rtl"] .split-preview-content code {
 }
 
 .split-preview-canvas {
-  min-height: 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
+  min-height: 160px;
 }
 
-.split-preview-canvas > iframe,
-.split-preview-canvas iframe {
+.split-preview-content iframe {
   width: 100%;
   height: 100%;
   border: none;
   background: var(--split-preview-bg);
-  flex: 1;
 }
 
 .split-preview-meta {

--- a/webapp/static/js/live-preview.js
+++ b/webapp/static/js/live-preview.js
@@ -735,15 +735,14 @@
     }
 
     isPreviewEligible() {
-      const languageValue = (this.languageSelect ? this.languageSelect.value : '').trim().toLowerCase();
+      const language = this.languageSelect ? this.languageSelect.value : '';
       const fileName = this.fileNameInput ? this.fileNameInput.value : '';
-      if (isMarkdownLanguage(languageValue) || isHtmlLanguage(languageValue)) {
-        return true;
-      }
-      if (languageValue && languageValue !== 'text') {
-        return false;
-      }
-      return isMarkdownExtension(fileName) || isHtmlExtension(fileName);
+      return (
+        isMarkdownLanguage(language) ||
+        isHtmlLanguage(language) ||
+        isMarkdownExtension(fileName) ||
+        isHtmlExtension(fileName)
+      );
     }
 
     updatePreviewAvailability(options = {}) {

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -2071,50 +2071,14 @@
     <script src="{{ url_for('static', filename='js/collections.js') }}?v={{ static_version }}" defer></script>
 <script>
     (function welcomeModalInit(){
-        const STORAGE_KEY = 'has_seen_welcome_modal';
         const modal = document.getElementById('welcomeModal');
         if (!modal) { return; }
-
-        const getSeenFlag = () => {
-            try { return localStorage.getItem(STORAGE_KEY); }
-            catch (_) {
-                try { return sessionStorage.getItem(STORAGE_KEY); }
-                catch (_) { return null; }
-            }
-        };
-
-        const setSeenFlag = () => {
-            let stored = false;
-            try { localStorage.setItem(STORAGE_KEY, '1'); stored = true; }
-            catch (_) {}
-            if (!stored) {
-                try { sessionStorage.setItem(STORAGE_KEY, '1'); }
-                catch (_) {}
-            }
-        };
-
-        const markClientSeen = () => {
-            setSeenFlag();
-        };
-
-        try {
-            if (getSeenFlag() === '1') {
-                fetch('/api/welcome/ack', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: '{}'
-                }).catch(() => {});
-                modal.remove();
-                return;
-            }
-        } catch (_) {}
         const backdrop = modal.querySelector('.welcome-modal__backdrop');
         const closeBtn = modal.querySelector('.welcome-modal__close');
         const skipBtn = document.getElementById('welcomeSkipBtn');
         const primaryBtn = document.getElementById('welcomePrimaryCta');
         const sendAck = () => {
             try {
-                markClientSeen();
                 fetch('/api/welcome/ack', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -2198,36 +2162,15 @@
         try { localStorage.setItem(key, value); }
         catch (_) {}
     }
-    function getThemeWizardSeenFlag(){
-        try { return localStorage.getItem(STORAGE_KEYS.seen); }
-        catch (_) {
-            try { return sessionStorage.getItem(STORAGE_KEYS.seen); }
-            catch (_) { return null; }
-        }
-    }
-    function setThemeWizardSeenFlag(value){
-        let saved = false;
-        try { localStorage.setItem(STORAGE_KEYS.seen, value); saved = true; }
-        catch (_) {}
-        if (!saved) {
-            try { sessionStorage.setItem(STORAGE_KEYS.seen, value); }
-            catch (_) {}
-        }
-    }
-    function clearThemeWizardSeenFlag(){
-        try { localStorage.removeItem(STORAGE_KEYS.seen); }
-        catch (_) {}
-        try { sessionStorage.removeItem(STORAGE_KEYS.seen); }
-        catch (_) {}
-    }
     function hasSeen(){
-        return getThemeWizardSeenFlag() === 'true';
+        return lsGet(STORAGE_KEYS.seen) === 'true';
     }
     function markSeen(){
-        setThemeWizardSeenFlag('true');
+        lsSet(STORAGE_KEYS.seen, 'true');
     }
     function resetSeen(){
-        clearThemeWizardSeenFlag();
+        try { localStorage.removeItem(STORAGE_KEYS.seen); }
+        catch (_) {}
     }
     function availableThemes(){
         return optionButtons.map((btn) => btn.dataset.themeOption).filter(Boolean);
@@ -2965,36 +2908,17 @@
     const MAX_RETRIES = 5;
     const isLoggedIn = {{ 'true' if session.user_id else 'false' }};
 
-    function getWalkthroughFlag(){
-        try { return localStorage.getItem(STORAGE_KEY); }
-        catch (_) {
-            try { return sessionStorage.getItem(STORAGE_KEY); }
-            catch (_) { return null; }
-        }
-    }
-    function setWalkthroughFlag(value){
-        let saved = false;
-        try { localStorage.setItem(STORAGE_KEY, value); saved = true; }
-        catch (_) {}
-        if (!saved) {
-            try { sessionStorage.setItem(STORAGE_KEY, value); }
-            catch (_) {}
-        }
-    }
-    function clearWalkthroughFlag(){
-        try { localStorage.removeItem(STORAGE_KEY); }
-        catch (_) {}
-        try { sessionStorage.removeItem(STORAGE_KEY); }
-        catch (_) {}
-    }
     function hasSeen(){
-        return getWalkthroughFlag() === '1';
+        try { return localStorage.getItem(STORAGE_KEY) === '1'; }
+        catch (_) { return false; }
     }
     function markSeen(){
-        setWalkthroughFlag('1');
+        try { localStorage.setItem(STORAGE_KEY, '1'); }
+        catch (_) { /* ignore */ }
     }
     function resetSeen(){
-        clearWalkthroughFlag();
+        try { localStorage.removeItem(STORAGE_KEY); }
+        catch (_) { /* ignore */ }
     }
     function getDriverFactory(){
         if (!window.driver || !window.driver.js || typeof window.driver.js.driver !== 'function') {

--- a/webapp/templates/edit_file.html
+++ b/webapp/templates/edit_file.html
@@ -20,7 +20,6 @@
     color: var(--text-primary, #ffffff);
     font: inherit;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-    box-sizing: border-box;
   }
   .form-field:focus {
     outline: none;
@@ -114,203 +113,6 @@
     font-size: 0.85rem;
     color: var(--text-muted, rgba(255,255,255,0.65));
   }
-
-  /* --- Markdown image upload controls --- */
-  .filename-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .filename-field-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-  }
-
-  .filename-input-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-  }
-
-  .filename-input-wrapper input[name="file_name"] {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .image-upload-trigger {
-    display: none;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 10px;
-    border: 1px solid var(--glass-border, rgba(255,255,255,0.25));
-    background: var(--glass, rgba(255,255,255,0.12));
-    font-size: 1.25rem;
-    cursor: pointer;
-    color: var(--text-primary, #ffffff);
-    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-  }
-
-  .image-upload-trigger.is-visible {
-    display: inline-flex;
-  }
-
-  .image-upload-trigger:focus-visible {
-    outline: 2px solid var(--primary, #9775fa);
-    outline-offset: 2px;
-  }
-
-  .image-upload-trigger:hover {
-    background: var(--glass-hover, rgba(255,255,255,0.2));
-    border-color: var(--primary, rgba(151,117,250,0.6));
-  }
-
-  .image-upload-trigger:active {
-    transform: scale(0.94);
-  }
-
-  .image-upload-status {
-    font-size: 0.9rem;
-    color: var(--text-secondary, rgba(255,255,255,0.8));
-  }
-
-  .markdown-image-hint {
-    font-size: 0.85rem;
-    color: var(--text-secondary, rgba(255,255,255,0.75));
-  }
-
-  .markdown-image-error {
-    margin-top: 0.35rem;
-    font-size: 0.9rem;
-    color: #ff8a8a;
-  }
-
-  .markdown-images-preview {
-    margin-top: 0.25rem;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
-    gap: 0.75rem;
-    padding: 0.75rem;
-    border-radius: 12px;
-    border: 1px dashed rgba(255,255,255,0.25);
-    background: rgba(255,255,255,0.04);
-  }
-
-  .markdown-images-preview.is-empty {
-    display: none;
-  }
-
-  .markdown-images-empty {
-    margin: 0;
-    font-size: 0.9rem;
-    text-align: center;
-    color: var(--text-secondary, rgba(255,255,255,0.7));
-  }
-
-  .markdown-image-thumb {
-    position: relative;
-    border-radius: 10px;
-    overflow: hidden;
-    border: 1px solid rgba(255,255,255,0.25);
-    background: rgba(0,0,0,0.2);
-    cursor: pointer;
-  }
-
-  .markdown-image-thumb img {
-    width: 100%;
-    height: 80px;
-    object-fit: cover;
-    display: block;
-  }
-
-  .markdown-image-thumb figcaption {
-    font-size: 0.75rem;
-    padding: 0.35rem 0.4rem;
-    text-align: center;
-    color: var(--text-secondary, rgba(255,255,255,0.85));
-    background: rgba(0,0,0,0.25);
-  }
-
-  .markdown-image-remove {
-    position: absolute;
-    top: 6px;
-    left: 6px;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    border: none;
-    background: rgba(0,0,0,0.55);
-    color: #fff;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.9rem;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-  }
-
-  .markdown-image-thumb:hover .markdown-image-remove {
-    opacity: 1;
-  }
-
-  .markdown-image-fullscreen {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.9);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    padding: 1.5rem;
-    z-index: 9999;
-  }
-
-  .markdown-image-fullscreen.is-open {
-    display: flex;
-  }
-
-  .markdown-image-fullscreen img {
-    max-width: 90vw;
-    max-height: 80vh;
-    border-radius: 12px;
-    box-shadow: 0 25px 90px rgba(0,0,0,0.45);
-  }
-
-  .markdown-image-fullscreen button {
-    align-self: flex-end;
-    margin-bottom: 1rem;
-    border: none;
-    background: rgba(255,255,255,0.15);
-    color: white;
-    padding: 0.4rem 0.75rem;
-    border-radius: 999px;
-    cursor: pointer;
-    font-size: 0.95rem;
-  }
-
-  .markdown-image-fullscreen-caption {
-    margin-top: 1rem;
-    color: rgba(255,255,255,0.85);
-    font-size: 0.95rem;
-    text-align: center;
-  }
-
-  @media (max-width: 520px) {
-    .image-upload-trigger {
-      width: 38px;
-      height: 38px;
-      font-size: 1.05rem;
-    }
-
-    .markdown-image-thumb img {
-      height: 70px;
-    }
-  }
 </style>
 
 <div class="glass-card">
@@ -321,36 +123,10 @@
   <div class="alert alert-success">{{ success }}</div>
   {% endif %}
 
-  <form id="editFileForm" method="post" enctype="multipart/form-data" style="display: grid; gap: 1rem;">
-    <div class="filename-field">
-      <div class="filename-field-header">
-        <label for="fileNameInput">שם קובץ</label>
-        <span class="image-upload-status" id="markdownImageStatus"></span>
-      </div>
-      <div class="filename-input-wrapper">
-        <input id="fileNameInput" type="text" name="file_name" value="{{ file.file_name }}" class="form-field">
-        <button type="button"
-                id="imageUploadTrigger"
-                class="image-upload-trigger"
-                aria-label="הוספת תמונה ל-Markdown"
-                title="צרף תמונה"
-                data-visible="false">
-          🖼️
-        </button>
-      </div>
-      <small class="markdown-image-hint" id="markdownImageHint">
-        ניתן לצרף עד 6 תמונות (PNG/JPG/WEBP, עד ‎2MB‎ לכל תמונה). הכפתור יופיע רק בקבצי ‎.md‎ או כשנבחרת שפת Markdown.
-      </small>
-      <div class="markdown-image-error" id="markdownImageError" role="alert"></div>
-      <div class="markdown-images-preview is-empty" id="markdownImagesPreview">
-        <p class="markdown-images-empty">אין תמונות מצורפות עדיין.</p>
-      </div>
-      <input type="file"
-             id="markdownImageInput"
-             name="md_images"
-             accept="image/*"
-             multiple
-             hidden>
+  <form method="post" style="display: grid; gap: 1rem;">
+    <div>
+      <label>שם קובץ</label>
+      <input type="text" name="file_name" value="{{ file.file_name }}" class="form-field">
     </div>
     <div>
       <label>שפה</label>
@@ -442,11 +218,6 @@
     </div>
   </form>
 </div>
-<div class="markdown-image-fullscreen" id="markdownImageFullscreen" aria-hidden="true">
-  <button type="button" id="markdownImageFullscreenClose">✕ סגירה</button>
-  <img id="markdownImageFullscreenImg" alt="תמונה במלוא הגודל">
-  <div class="markdown-image-fullscreen-caption" id="markdownImageFullscreenCaption"></div>
-</div>
 {% endblock %}
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/md_preview.bundle.js') }}?v={{ static_version }}" defer></script>
@@ -457,37 +228,7 @@
       const container = document.getElementById('editorContainer');
       const languageSelect = document.getElementById('languageSelect');
       const fileNameInput = document.querySelector('input[name="file_name"]');
-      const form = document.getElementById('editFileForm');
-      const imageUploadTrigger = document.getElementById('imageUploadTrigger');
-      const markdownImageInput = document.getElementById('markdownImageInput');
-      const markdownImagesPreview = document.getElementById('markdownImagesPreview');
-      const markdownImagesEmptyState = markdownImagesPreview ? markdownImagesPreview.querySelector('.markdown-images-empty') : null;
-      const markdownImageError = document.getElementById('markdownImageError');
-      const markdownImageStatus = document.getElementById('markdownImageStatus');
-      const markdownImageFullscreen = document.getElementById('markdownImageFullscreen');
-      const markdownImageFullscreenImg = document.getElementById('markdownImageFullscreenImg');
-      const markdownImageFullscreenCaption = document.getElementById('markdownImageFullscreenCaption');
-      const markdownImageFullscreenClose = document.getElementById('markdownImageFullscreenClose');
-      const MARKDOWN_IMAGE_LIMIT = 6;
-      const MARKDOWN_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
-      const MARKDOWN_ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
-      const supportsDataTransfer = (() => {
-        if (typeof DataTransfer === 'undefined') {
-          return false;
-        }
-        try {
-          new DataTransfer();
-          return true;
-        } catch (_) {
-          return false;
-        }
-      })();
-      let markdownSelectedImages = [];
       let languageSelectTouched = false;
-      let previousBodyOverflow = '';
-
-      window.addEventListener('beforeunload', revokeAllMarkdownImageUrls);
-
       if (container && window.editorManager && typeof window.editorManager.initEditor === 'function') {
         await window.editorManager.initEditor(container, {
           language: '{{ file.language }}',
@@ -495,7 +236,6 @@
           theme: 'dark'
         });
       }
-
       const languageOptionExists = (value) => {
         if (!languageSelect) {
           return false;
@@ -507,7 +247,6 @@
           return optValue === target;
         });
       };
-
       const autoSetLanguageFromFilename = (triggerSource) => {
         if (!fileNameInput || !languageSelect || !window.editorManager || typeof window.editorManager.inferLanguageFromFilename !== 'function') {
           return;
@@ -526,103 +265,19 @@
         languageSelect.value = detected;
         languageSelect.dispatchEvent(new Event('change', { bubbles: true }));
       };
-
       if (languageSelect && window.editorManager && typeof window.editorManager.updateLanguage === 'function') {
         languageSelect.addEventListener('change', async (e) => {
           if (e && e.isTrusted) {
             languageSelectTouched = true;
           }
           try { await window.editorManager.updateLanguage(e.target.value); } catch (_) {}
-          toggleImageTriggerVisibility();
-          updateMarkdownImageStatus();
         });
       }
-
       if (fileNameInput) {
-        fileNameInput.addEventListener('input', () => {
-          autoSetLanguageFromFilename('input');
-          toggleImageTriggerVisibility();
-          updateMarkdownImageStatus();
-        });
-        fileNameInput.addEventListener('blur', () => {
-          autoSetLanguageFromFilename('blur');
-          toggleImageTriggerVisibility();
-          updateMarkdownImageStatus();
-        });
+        fileNameInput.addEventListener('input', () => autoSetLanguageFromFilename('input'));
+        fileNameInput.addEventListener('blur', () => autoSetLanguageFromFilename('blur'));
       }
-
       autoSetLanguageFromFilename('initial');
-      toggleImageTriggerVisibility();
-      updateMarkdownImageStatus();
-
-      if (imageUploadTrigger && markdownImageInput) {
-        imageUploadTrigger.addEventListener('click', () => {
-          if (imageUploadTrigger.disabled) {
-            return;
-          }
-          markdownImageInput.click();
-        });
-      }
-
-      if (markdownImageInput) {
-        markdownImageInput.addEventListener('change', (event) => {
-          handleMarkdownImageFiles(event.target.files);
-          try { event.target.value = ''; } catch (_) {}
-        });
-      }
-
-      if (markdownImagesPreview) {
-        markdownImagesPreview.addEventListener('click', (event) => {
-          const removeBtn = event.target.closest('.markdown-image-remove');
-          if (removeBtn) {
-            const id = removeBtn.getAttribute('data-image-id');
-            removeMarkdownImage(id);
-            return;
-          }
-          const imgEl = event.target.closest('img[data-image-id]');
-          if (!imgEl) {
-            return;
-          }
-          const targetId = imgEl.getAttribute('data-image-id');
-          const imageItem = markdownSelectedImages.find((img) => img.id === targetId);
-          if (imageItem) {
-            openMarkdownImageFullscreen(imageItem);
-          }
-        });
-      }
-
-      if (markdownImageFullscreenClose) {
-        markdownImageFullscreenClose.addEventListener('click', () => {
-          closeMarkdownImageFullscreen();
-        });
-      }
-
-      if (markdownImageFullscreen) {
-        markdownImageFullscreen.addEventListener('click', (event) => {
-          if (event.target === markdownImageFullscreen) {
-            closeMarkdownImageFullscreen();
-          }
-        });
-      }
-
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && markdownImageFullscreen?.classList.contains('is-open')) {
-          closeMarkdownImageFullscreen();
-        }
-      });
-
-      if (form) {
-        form.addEventListener('formdata', (event) => {
-          if (!event || !event.formData) {
-            return;
-          }
-          if (!isMarkdownContext()) {
-            try { event.formData.delete('md_images'); } catch (_) {}
-            return;
-          }
-          appendMarkdownImagesToFormData(event.formData);
-        });
-      }
 
       (function initSourceUrlToggle(){
         const toggle = document.getElementById('sourceUrlToggle');
@@ -672,280 +327,6 @@
 
         input.addEventListener('input', markTouched);
       })();
-
-      function toggleImageTriggerVisibility() {
-        if (!imageUploadTrigger) {
-          return;
-        }
-        const isMarkdown = isMarkdownContext();
-        imageUploadTrigger.classList.toggle('is-visible', isMarkdown);
-        imageUploadTrigger.dataset.visible = isMarkdown ? 'true' : 'false';
-        imageUploadTrigger.setAttribute('aria-hidden', isMarkdown ? 'false' : 'true');
-        imageUploadTrigger.disabled = !isMarkdown;
-        if (markdownImageInput) {
-          markdownImageInput.disabled = !isMarkdown;
-        }
-        if (!isMarkdown) {
-          resetMarkdownImages();
-          setMarkdownImageError('');
-        }
-        updateMarkdownImageStatus();
-      }
-
-      function isMarkdownContext() {
-        const lang = (languageSelect && languageSelect.value ? languageSelect.value : '').toLowerCase();
-        const name = ((fileNameInput && fileNameInput.value) || '').trim().toLowerCase();
-        const byLanguage = lang === 'markdown' || lang === 'md';
-        const byExtension = /\.(md|markdown)$/i.test(name);
-        return byLanguage || byExtension;
-      }
-
-      function handleMarkdownImageFiles(fileList) {
-        if (!fileList || !fileList.length) {
-          return;
-        }
-        if (!isMarkdownContext()) {
-          setMarkdownImageError('כדי לצרף תמונות יש לבחור קובץ או שפת Markdown (.md)');
-          return;
-        }
-        const incoming = Array.from(fileList);
-        const nextImages = [...markdownSelectedImages];
-        const errors = [];
-        let added = 0;
-        for (const file of incoming) {
-          if (nextImages.length >= MARKDOWN_IMAGE_LIMIT) {
-            errors.push(`ניתן לצרף עד ${MARKDOWN_IMAGE_LIMIT} תמונות בלבד.`);
-            break;
-          }
-          if (!MARKDOWN_ALLOWED_TYPES.includes(file.type)) {
-            errors.push(`${file.name} אינו בפורמט תמונה נתמך.`);
-            continue;
-          }
-          if (file.size > MARKDOWN_IMAGE_MAX_BYTES) {
-            errors.push(`${file.name} גדול מדי (מקסימום ${humanFileSize(MARKDOWN_IMAGE_MAX_BYTES)}).`);
-            continue;
-          }
-          const duplicate = nextImages.some((item) => item.file.name === file.name && item.file.size === file.size);
-          if (duplicate) {
-            errors.push(`${file.name} כבר נבחרה.`);
-            continue;
-          }
-          const id = `md-img-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
-          const url = URL.createObjectURL(file);
-          nextImages.push({ id, file, url });
-          added++;
-        }
-
-        if (errors.length) {
-          setMarkdownImageError(errors.join(' '));
-        } else {
-          setMarkdownImageError('');
-        }
-
-        if (!added) {
-          if (!supportsDataTransfer && errors.length && markdownImageInput) {
-            try { markdownImageInput.value = ''; } catch (_) {}
-          }
-          renderMarkdownImages(nextImages);
-          updateMarkdownImageStatus();
-          return;
-        }
-
-        markdownSelectedImages = nextImages;
-        renderMarkdownImages(markdownSelectedImages);
-        syncMarkdownImageInput();
-        updateMarkdownImageStatus();
-      }
-
-      function removeMarkdownImage(imageId) {
-        if (!imageId) {
-          return;
-        }
-        const index = markdownSelectedImages.findIndex((item) => item.id === imageId);
-        if (index === -1) {
-          return;
-        }
-        const [removed] = markdownSelectedImages.splice(index, 1);
-        if (removed && removed.url) {
-          try { URL.revokeObjectURL(removed.url); } catch (_) {}
-        }
-        syncMarkdownImageInput();
-        renderMarkdownImages(markdownSelectedImages);
-        updateMarkdownImageStatus();
-        if (markdownImageFullscreen?.dataset?.activeImageId === imageId) {
-          closeMarkdownImageFullscreen();
-        }
-        if (!markdownSelectedImages.length) {
-          setMarkdownImageError('');
-        }
-      }
-
-      function resetMarkdownImages() {
-        if (!markdownSelectedImages.length) {
-          if (markdownImageInput) {
-            try { markdownImageInput.value = ''; } catch (_) {}
-          }
-          renderMarkdownImages(markdownSelectedImages);
-          updateMarkdownImageStatus();
-          return;
-        }
-        revokeAllMarkdownImageUrls();
-        closeMarkdownImageFullscreen();
-        markdownSelectedImages = [];
-        syncMarkdownImageInput();
-        renderMarkdownImages(markdownSelectedImages);
-        updateMarkdownImageStatus();
-      }
-
-      function renderMarkdownImages(images) {
-        if (!markdownImagesPreview) {
-          return;
-        }
-        markdownImagesPreview.querySelectorAll('.markdown-image-thumb').forEach((node) => node.remove());
-        if (!images.length) {
-          markdownImagesPreview.classList.add('is-empty');
-          if (markdownImagesEmptyState) {
-            markdownImagesEmptyState.hidden = false;
-          }
-          return;
-        }
-        markdownImagesPreview.classList.remove('is-empty');
-        if (markdownImagesEmptyState) {
-          markdownImagesEmptyState.hidden = true;
-        }
-        images.forEach((item) => {
-          const figure = document.createElement('figure');
-          figure.className = 'markdown-image-thumb';
-
-          const removeBtn = document.createElement('button');
-          removeBtn.type = 'button';
-          removeBtn.className = 'markdown-image-remove';
-          removeBtn.dataset.imageId = item.id;
-          removeBtn.setAttribute('aria-label', `הסר את ${item.file.name}`);
-          removeBtn.textContent = '✕';
-
-          const imageEl = document.createElement('img');
-          imageEl.src = item.url;
-          imageEl.alt = item.file.name;
-          imageEl.loading = 'lazy';
-          imageEl.dataset.imageId = item.id;
-
-          const caption = document.createElement('figcaption');
-          caption.textContent = item.file.name;
-
-          figure.appendChild(removeBtn);
-          figure.appendChild(imageEl);
-          figure.appendChild(caption);
-          markdownImagesPreview.appendChild(figure);
-        });
-      }
-
-      function syncMarkdownImageInput() {
-        if (!markdownImageInput) {
-          return;
-        }
-        if (!supportsDataTransfer) {
-          try { markdownImageInput.value = ''; } catch (_) {}
-          return;
-        }
-        const transfer = new DataTransfer();
-        markdownSelectedImages.forEach((item) => {
-          try { transfer.items.add(item.file); } catch (_) {}
-        });
-        markdownImageInput.files = transfer.files;
-      }
-
-      function updateMarkdownImageStatus() {
-        if (!markdownImageStatus) {
-          return;
-        }
-        const isMarkdown = isMarkdownContext();
-        if (!isMarkdown) {
-          markdownImageStatus.textContent = 'כפתור התמונות פעיל רק ל-Markdown (.md או בחירת שפה)';
-          return;
-        }
-        const count = markdownSelectedImages.length;
-        if (!count) {
-          markdownImageStatus.textContent = 'לא נבחרו תמונות';
-          return;
-        }
-        markdownImageStatus.textContent = `${count}/${MARKDOWN_IMAGE_LIMIT} תמונות מצורפות`;
-      }
-
-      function setMarkdownImageError(message) {
-        if (!markdownImageError) {
-          return;
-        }
-        markdownImageError.textContent = message || '';
-      }
-
-      function humanFileSize(bytes) {
-        const units = ['B', 'KB', 'MB'];
-        let size = bytes;
-        let unit = 0;
-        while (size >= 1024 && unit < units.length - 1) {
-          size /= 1024;
-          unit++;
-        }
-        return `${Math.round(size * 10) / 10}${units[unit]}`;
-      }
-
-      function openMarkdownImageFullscreen(imageItem) {
-        if (!markdownImageFullscreen || !markdownImageFullscreenImg) {
-          return;
-        }
-        markdownImageFullscreenImg.src = imageItem.url;
-        markdownImageFullscreenImg.alt = imageItem.file.name;
-        if (markdownImageFullscreenCaption) {
-          markdownImageFullscreenCaption.textContent = imageItem.file.name;
-        }
-        markdownImageFullscreen.dataset.activeImageId = imageItem.id;
-        markdownImageFullscreen.classList.add('is-open');
-        markdownImageFullscreen.setAttribute('aria-hidden', 'false');
-        previousBodyOverflow = document.body.style.overflow || '';
-        document.body.style.overflow = 'hidden';
-      }
-
-      function closeMarkdownImageFullscreen() {
-        if (!markdownImageFullscreen || !markdownImageFullscreenImg) {
-          return;
-        }
-        markdownImageFullscreen.classList.remove('is-open');
-        markdownImageFullscreen.setAttribute('aria-hidden', 'true');
-        markdownImageFullscreenImg.removeAttribute('src');
-        markdownImageFullscreenImg.removeAttribute('alt');
-        if (markdownImageFullscreenCaption) {
-          markdownImageFullscreenCaption.textContent = '';
-        }
-        delete markdownImageFullscreen.dataset.activeImageId;
-        document.body.style.overflow = previousBodyOverflow || '';
-      }
-
-      function revokeAllMarkdownImageUrls() {
-        markdownSelectedImages.forEach((item) => {
-          if (item && item.url) {
-            try { URL.revokeObjectURL(item.url); } catch (_) {}
-          }
-        });
-      }
-
-      function appendMarkdownImagesToFormData(targetFormData) {
-        if (!targetFormData) {
-          return;
-        }
-        try {
-          targetFormData.delete('md_images');
-        } catch (_) {}
-        markdownSelectedImages.forEach((item) => {
-          try {
-            targetFormData.append('md_images', item.file, item.file.name);
-          } catch (_) {
-            try {
-              targetFormData.append('md_images', item.file);
-            } catch (_) {}
-          }
-        });
-      }
     } catch (_) {}
   });
 </script>


### PR DESCRIPTION
This PR restores the repository to commit `9b8ea3d6f23a41f4c966b179f5118d440f7d6848` by recreating its tree on top of `main`.

נוצר אוטומטית דרך בוט CodeBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Markdown image upload support from the edit flow, simplifies editor/init logic and preview eligibility, and updates styles and templates accordingly.
> 
> - **Backend (webapp/app.py)**:
>   - Simplifies edit flow: removes Markdown image upload handling and related payload processing in `edit_file_page`.
>   - Keeps versioning logic and source URL inheritance; auto-falls back for `description`/`tags` from previous versions.
> - **UI (templates/edit_file.html)**:
>   - Streamlines edit form (no image controls or multipart); retains source URL toggle and integrates the split-view live preview.
> - **Editor JS (static/js/editor-manager.js)**:
>   - Removes cursor preservation APIs/usage; simplifies editor toggle/init; paste now sets full content via `setEditorContent`.
> - **Live Preview (static/js/live-preview.js)**:
>   - Broadens `isPreviewEligible` to allow preview by language or filename extension (Markdown/HTML).
> - **Styles (static/css/split-view.css)**:
>   - Adjusts panel min/max heights and scrolling (overflow in preview, min canvas height); cleans unused editor-specific rules.
> - **Base template (templates/base.html)**:
>   - Simplifies welcome modal, theme wizard, and walkthrough flags to use localStorage only; removes fallback/session mixing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f822be3f9c7b490829fcdc2837b787348cf6caf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->