### PR TITLE
Github message response

### DIFF
--- a/services/observability_dashboard.py
+++ b/services/observability_dashboard.py
@@ -727,9 +727,15 @@ def _match_graph_rule(alert: Dict[str, Any]) -> Tuple[Optional[str], Optional[st
 
 
 def _describe_alert_graph(alert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    alert_type = str(alert.get("alert_type") or "").strip().lower()
     metric = _alert_metric_from_metadata(alert)
     reason = "metadata" if metric else None
     category = None
+    # Sentry issues אינם קשורים בהכרח למדדים הפנימיים (latency/error_rate וכו'),
+    # ולעיתים התאמה היוריסטית לפי מילות מפתח ("errors") יוצרת גרף "ריק" ומבלבל.
+    # אם בעתיד נרצה גרף עבור Sentry – נוסיף metric מפורש במטא־דאטה או מקור חיצוני.
+    if not metric and alert_type == "sentry_issue":
+        return None
     if not metric:
         metric, category, reason = _match_graph_rule(alert)
     if not metric:

--- a/webapp/templates/observability_replay.html
+++ b/webapp/templates/observability_replay.html
@@ -44,6 +44,26 @@
   gap: 1rem;
   align-items: center;
 }
+.replay-filters {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.replay-filter-btn {
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.replay-filter-btn.active {
+  background: rgba(255,255,255,0.15);
+  color: #121826;
+  font-weight: 600;
+}
 .replay-range-buttons {
   display: flex;
   gap: 0.45rem;
@@ -455,6 +475,9 @@
       </label>
       <button id="applyCustomRange">עדכן</button>
     </div>
+    <div class="replay-filters">
+      <button type="button" id="toggleDeploymentsBtn" class="replay-filter-btn" aria-pressed="true">🚫 הסתר Deployments</button>
+    </div>
   </div>
 
   <div class="replay-layout">
@@ -513,13 +536,17 @@
 
 <script>
 (() => {
+  const urlParams = new URLSearchParams(window.location.search || '');
   const state = {
     range: '{{ default_range|default("3h", true) }}',
     start: '{{ initial_start|default('', true) }}',
     end: '{{ initial_end|default('', true) }}',
     focus: '{{ initial_focus|default('', true) }}',
+    hideDeployments: (urlParams.get('hide_deployments') ?? '1') !== '0',
     selectedEventId: '',
-    eventsMap: {}
+    eventsMap: {},
+    allEvents: [],
+    lastCounts: {},
   };
 
   const timelineSummaryEl = document.getElementById('timelineSummary');
@@ -527,6 +554,37 @@
   const rangeButtons = document.querySelectorAll('#replayRangeButtons button');
   const storyViewer = createStoryViewer();
   const runbookPanel = document.getElementById('runbookPanel');
+  const deploymentsToggleBtn = document.getElementById('toggleDeploymentsBtn');
+
+  function updateDeploymentsToggleUi() {
+    if (!deploymentsToggleBtn) return;
+    const hidden = Boolean(state.hideDeployments);
+    deploymentsToggleBtn.classList.toggle('active', hidden);
+    deploymentsToggleBtn.setAttribute('aria-pressed', hidden ? 'true' : 'false');
+    deploymentsToggleBtn.textContent = hidden ? '🚫 הסתר Deployments' : '✅ הצג Deployments';
+  }
+  updateDeploymentsToggleUi();
+
+  function syncUrlFilterParam() {
+    try {
+      const params = new URLSearchParams(window.location.search || '');
+      params.set('hide_deployments', state.hideDeployments ? '1' : '0');
+      const newUrl = `${window.location.pathname}?${params.toString()}`;
+      window.history.replaceState({}, '', newUrl);
+    } catch (_) {}
+  }
+
+  if (deploymentsToggleBtn) {
+    deploymentsToggleBtn.addEventListener('click', () => {
+      state.hideDeployments = !state.hideDeployments;
+      updateDeploymentsToggleUi();
+      syncUrlFilterParam();
+      // רינדור מחדש מהנתונים שכבר נטענו (בלי קריאת API נוספת).
+      if (state.allEvents && state.allEvents.length) {
+        renderTimeline(state.allEvents, state.lastCounts || {}, {});
+      }
+    });
+  }
 
   function markActiveRange(rangeValue) {
     rangeButtons.forEach(b => {
@@ -566,6 +624,7 @@
       if (state.start) params.set('start', state.start);
       if (state.end) params.set('end', state.end);
       if (state.focus) params.set('focus_ts', state.focus);
+      params.set('hide_deployments', state.hideDeployments ? '1' : '0');
       const shareUrl = `${window.location.origin}/admin/observability/replay?${params.toString()}`;
       await navigator.clipboard.writeText(shareUrl);
       showShareToast('הקישור הועתק ללוח');
@@ -987,13 +1046,21 @@
     if (!res.ok) throw new Error('HTTP ' + res.status);
     const payload = await res.json();
     if (payload.ok === false) throw new Error(payload.error || 'replay_error');
-    renderTimeline(payload.events || [], payload.counts || {}, payload.window || {});
+    state.allEvents = payload.events || [];
+    state.lastCounts = payload.counts || {};
+    renderTimeline(state.allEvents, state.lastCounts, payload.window || {});
   }
 
   function renderTimeline(events, counts, windowInfo) {
-    timelineSummaryEl.textContent = `סה"כ ${counts.alerts || 0} התראות, ${counts.deployments || 0} דיפלוימנטים, ${counts.chatops || 0} פעולות ChatOps, ${counts.stories || 0} סיפורים`;
+    const totalEvents = Array.isArray(events) ? events.length : 0;
+    const filteredEvents = (events || []).filter(evt => !(state.hideDeployments && evt && evt.type === 'deployment'));
+    const hiddenDeployments = state.hideDeployments ? (counts.deployments || 0) : 0;
+    timelineSummaryEl.textContent =
+      `סה"כ ${counts.alerts || 0} התראות, ${counts.deployments || 0} דיפלוימנטים, ${counts.chatops || 0} פעולות ChatOps, ${counts.stories || 0} סיפורים` +
+      ` · מוצגים ${filteredEvents.length}/${totalEvents}` +
+      (hiddenDeployments ? ` (הוסתרו ${hiddenDeployments} דיפלוימנטים)` : '');
     const list = timelineListEl;
-    if (!events.length) {
+    if (!filteredEvents.length) {
       list.innerHTML = '<li class="empty-state">לא נמצאו אירועים בטווח הנבחר.</li>';
       state.eventsMap = {};
       state.selectedEventId = '';
@@ -1001,7 +1068,12 @@
       return;
     }
     state.eventsMap = {};
-    list.innerHTML = events.map(evt => {
+    // אם האירוע שנבחר "נעלם" עקב פילטר, ננקה בחירה ו-Runbook.
+    if (state.selectedEventId && !filteredEvents.some(evt => evt && evt.id === state.selectedEventId)) {
+      state.selectedEventId = '';
+      setRunbookEmpty();
+    }
+    list.innerHTML = filteredEvents.map(evt => {
       if (evt.id) {
         state.eventsMap[evt.id] = evt;
       }


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקנתי את הצגת גרף "הקשר" הריק עבור התראות `sentry_issue` בעמוד היסטוריית התראות.
- הוספתי כפתור סינון חדש בעמוד Incident Replay המאפשר להסתיר/להציג אירועי `deployment_event` כדי להתמקד באירועים אחרים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- מנעתי יצירת גרף "הקשר" אוטומטי עבור התראות מסוג `sentry_issue` כאשר אין `metric` מפורש במטא־דאטה, כדי למנוע הצגת גרף ריק ומבלבל עם ההודעה "אין נתונים זמינים בחלון הנבחר".
- הוספתי כפתור toggle בעמוד Incident Replay (`observability_replay.html`) המאפשר להסתיר או להציג אירועי `deployment_event`. ברירת המחדל היא להסתיר, ומצב הסינון נשמר ב-URL באמצעות פרמטר `hide_deployments`.

## 🧪 בדיקות
- **Manual:**
    - ניווט ל-Observability → היסטוריית התראות, ואימות שגרף "הקשר" עבור `sentry_issue` אינו מוצג (אלא אם הוגדר לו `metric` מפורש).
    - ניווט ל-Incident Replay, אימות שהכפתור "הסתר Deployments" קיים ופועל, ושהאירועים מסוננים בהתאם. אימות שהמצב נשמר ב-URL.
- **Unit:**
    - `python3 -m pytest -q tests/test_observability_http.py tests/test_observability_quick_fix.py` (עבר).

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (סינון דיפלוימנטים)
- [x] fix: תיקון באג (גרף `sentry_issue`)
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש ב-Observability וב-Incident Replay על ידי הצגת מידע מדויק יותר ומתן שליטה טובה יותר על התצוגה. אין סיכוני ביצועים או אבטחה ידועים.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: החזרה לאחור של ה-PR. השינויים הם בעיקר ב-UI ובטיפול בנתונים קיימים, ללא שינויים קריטיים במסד הנתונים או ב-API.

---
<a href="https://cursor.com/background-agent?bcId=bc-94b21655-0c41-4d95-bd1f-6f0a72554232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94b21655-0c41-4d95-bd1f-6f0a72554232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a hide/show deployments filter to Incident Replay and suppresses auto-generated graphs for Sentry issues without an explicit metric.
> 
> - **Frontend – Incident Replay (`webapp/templates/observability_replay.html`)**:
>   - **Filter**: Add toggle to hide/show `deployment` events; defaults to hidden and syncs via `hide_deployments` URL param and shared links.
>   - **Rendering**: Timeline filters client-side without extra API calls, updates summary with shown/total and hidden counts, and clears selection if filtered out.
>   - **UI**: New styles for filter buttons.
> - **Backend – Alerts visual context (`services/observability_dashboard.py`)**:
>   - **Graph Selection**: Skip generating context graph for `sentry_issue` alerts when no explicit `metric` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12d7a8b22a9eb3dc825f5328b03140571a85e058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->