### PR TITLE
Github message context response

### DIFF
--- a/webapp/templates/admin_observability.html
+++ b/webapp/templates/admin_observability.html
@@ -700,6 +700,7 @@
           <option value="deployment_event">Deployment</option>
           <option value="anomaly_detected">Anomaly Detected</option>
           <option value="high_error_rate">High Error Rate</option>
+          <option value="sentry_issue">Sentry Issue</option>
         </select>
         <input type="text" id="endpointFilter" placeholder="Endpoint / Path">
         <input type="search" id="searchFilter" placeholder="חיפוש חופשי">
@@ -893,6 +894,12 @@
     if (anomalyEl) anomalyEl.textContent = summary?.anomaly ?? '0';
     if (deployEl) deployEl.textContent = summary?.deployment ?? '0';
     if (spikeEl) spikeEl.textContent = correlation?.avg_spike_during_deployment?.toFixed?.(2) ?? '0';
+  }
+
+  function updateDailyWidgets(summary) {
+    // Widgets that must always reflect the last 24h, independent of the global time range.
+    const criticalEl = document.getElementById('criticalCount');
+    if (criticalEl) criticalEl.textContent = summary?.critical ?? '0';
   }
 
   function updateLastUpdated() {
@@ -2164,11 +2171,18 @@
   }
 
   async function refreshAggregations() {
-    const params = new URLSearchParams({ timerange: state.range, limit: '5' });
-    const data = await fetchJson('/api/observability/aggregations?' + params.toString());
-    if (!data.ok) throw new Error(data.error || 'aggregation_error');
-    updateCards(data.summary, data.deployment_correlation);
-    renderTopEndpoints(data.top_slow_endpoints || []);
+    const rangeParams = new URLSearchParams({ timerange: state.range, limit: '5' });
+    const dailyParams = new URLSearchParams({ timerange: '24h', limit: '5' });
+    const rangeReq = fetchJson('/api/observability/aggregations?' + rangeParams.toString());
+    const dailyReq = (String(state.range || '').toLowerCase() === '24h')
+      ? rangeReq
+      : fetchJson('/api/observability/aggregations?' + dailyParams.toString());
+    const [rangeData, dailyData] = await Promise.all([rangeReq, dailyReq]);
+    if (!rangeData.ok) throw new Error(rangeData.error || 'aggregation_error');
+    if (!dailyData.ok) throw new Error(dailyData.error || 'aggregation_error');
+    updateCards(rangeData.summary, rangeData.deployment_correlation);
+    updateDailyWidgets(dailyData.summary);
+    renderTopEndpoints(dailyData.top_slow_endpoints || []);
   }
 
   async function refreshTimeseries() {


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספתי את האפשרות `sentry_issue` לדרופדאון "סוגים" ב"היסטוריית התראות" כך שתמיד תהיה זמינה.
- ניתקתי את וידג'טי "24 שעות אחרונות" (CRITICAL היום, נקודות קצה איטיות) מפילטר הזמן הגלובלי, כך שתמיד יציגו נתונים מ-24 השעות האחרונות.

## 📦 שינויים עיקריים
- [x] קוד (Backend) - *שינויים בלוגיקת קריאות API מה-Frontend*
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `<option value="sentry_issue">Sentry Issue</option>` לרשימת האפשרויות הקבועה בדרופדאון "סוגים" ב-`webapp/templates/admin_observability.html`.
- שינוי לוגיקת טעינת הנתונים בפונקציה `refreshAggregations` ב-JavaScript, כך שווידג'טים ספציפיים (CRITICAL היום, נקודות קצה איטיות) יטענו תמיד נתונים ל-24 שעות אחרונות, ללא תלות בפילטר הזמן הגלובלי.
- יצירת פונקציה חדשה `updateDailyWidgets` לעדכון הווידג'טים של 24 שעות.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
  - [x] Manual:
    - נכנסתי לעמוד Observability ואימתתי ש-`sentry_issue` מופיע בדרופדאון "סוגים".
    - שיניתי את טווח הזמן הגלובלי ל-7 ימים ו-30 יום ואימתתי שווידג'טי "CRITICAL היום" ו"נקודות קצה איטיות (24 שעות)" נשארו קבועים ומציגים נתונים ל-24 שעות אחרונות.
- [ ] Unit
- [ ] Integration

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - שינוי קל בלוגיקת טעינת נתונים ב-Frontend. ייתכן שינוי מינורי בעומס על ה-API עקב שתי קריאות במקום אחת עבור הווידג'טים של 24 שעות, אך זה צפוי להיות זניח.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - ביצוע Rollback ל-PR זה. השינויים הם ב-Frontend בלבד ואינם משפיעים על ה-Backend או מסד הנתונים.

---
<a href="https://cursor.com/background-agent?bcId=bc-904115d5-03b6-4034-87c0-38b107e62963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-904115d5-03b6-4034-87c0-38b107e62963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sentry_issue` to the alert type filter and fetches 24h aggregations for daily widgets and slow endpoints regardless of the selected time range.
> 
> - **Observability Dashboard (`webapp/templates/admin_observability.html`)**:
>   - **Filters**: Add `sentry_issue` option to `typeFilter` in alerts history.
>   - **Data loading**:
>     - Introduce `updateDailyWidgets()` for always-24h widgets.
>     - Update `refreshAggregations()` to fetch both selected-range and 24h aggregations (reuse when range is `24h`).
>     - Apply selected-range data to general cards via `updateCards()`; apply 24h data to daily widgets and `renderTopEndpoints()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee85f4ebfdddb091fdcccffa05e00d3aa9cae06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->