### PR TITLE
Alert display and navigation fixes

### DIFF
--- a/tests/test_observability_api.py
+++ b/tests/test_observability_api.py
@@ -76,9 +76,10 @@ def test_observability_runbook_returns_payload(monkeypatch):
 
     captured = {}
 
-    def _fake_fetch(event_id, fallback_metadata=None):
+    def _fake_fetch(event_id, fallback_metadata=None, ui_context=None):
         captured['event_id'] = event_id
         captured['fallback'] = fallback_metadata
+        captured['ui'] = ui_context
         return {'event': {'id': event_id}, 'runbook': {'title': 'Demo', 'steps': []}, 'actions': [], 'status': {}}
 
     monkeypatch.setattr(
@@ -103,13 +104,14 @@ def test_observability_runbook_status_updates(monkeypatch):
     monkeypatch.setenv('ADMIN_USER_IDS', str(admin_id))
     captured = {}
 
-    def _fake_update(event_id, step_id, completed, user_id, fallback_metadata=None):
+    def _fake_update(event_id, step_id, completed, user_id, fallback_metadata=None, ui_context=None):
         captured.update({
             'event_id': event_id,
             'step_id': step_id,
             'completed': completed,
             'user_id': user_id,
             'fallback': fallback_metadata,
+            'ui': ui_context,
         })
         return {'event': {'id': event_id}, 'runbook': {'title': 'Demo', 'steps': [{'id': step_id, 'completed': completed}]}, 'actions': [], 'status': {'completed_steps': [step_id]}}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10027,6 +10027,7 @@ def api_observability_replay():
 def api_observability_runbook(event_id: str):
     if not _require_admin_user():
         return jsonify({'ok': False, 'error': 'admin_only'}), 403
+    ui_context = request.args.get('ui') or request.args.get('context')
     fallback = {
         'alert_type': request.args.get('alert_type'),
         'type': request.args.get('type'),
@@ -10049,6 +10050,7 @@ def api_observability_runbook(event_id: str):
         payload = observability_service.fetch_runbook_for_event(
             event_id=event_id,
             fallback_metadata=metadata or None,
+            ui_context=ui_context,
         )
     except ValueError as exc:
         logger.info("observability_runbook_invalid_request: event_id=%s error=%s", event_id, exc)
@@ -10069,6 +10071,7 @@ def api_observability_runbook_status(event_id: str):
     if not user_id:
         return jsonify({'ok': False, 'error': 'admin_only'}), 403
     payload = request.get_json(silent=True) or {}
+    ui_context = payload.get('ui') or payload.get('context')
     step_id = str(payload.get('step_id') or '').strip()
     if not step_id:
         return jsonify({'ok': False, 'error': 'missing_step_id'}), 400
@@ -10082,6 +10085,7 @@ def api_observability_runbook_status(event_id: str):
             completed=completed,
             user_id=user_id,
             fallback_metadata=fallback_metadata,
+            ui_context=ui_context,
         )
     except ValueError as exc:
         logger.warning("observability_runbook_status_invalid_request: event_id=%s error=%s", event_id, exc)

--- a/webapp/templates/observability_replay.html
+++ b/webapp/templates/observability_replay.html
@@ -857,6 +857,7 @@
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
+          ui: 'replay',
           step_id: stepId,
           completed,
           event: eventPayload,
@@ -1159,6 +1160,7 @@
     setRunbookLoading();
     try {
       const params = new URLSearchParams();
+      params.set('ui', 'replay');
       if (evt.metadata && evt.metadata.alert_type) params.set('alert_type', evt.metadata.alert_type);
       if (evt.metadata && evt.metadata.endpoint) params.set('endpoint', evt.metadata.endpoint);
       if (evt.metadata && evt.metadata.source) params.set('source', evt.metadata.source);


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו מספר באגים בלוחות ה-Observability וב-Incident Replay:
1.  **זיהוי Runbook ייעודי**: הוספנו נרמול ל-`alert_type` כדי ש-Runbooks ייעודיים יזוהו נכון ולא תמיד יופיע Fallback.
2.  **אירועי Quick Fix מיותרים**: הסרנו את ההתנהגות שבה לחיצה על Quick Fix מוסיפה אירוע ל-Incident Replay.
3.  **ניקוי UI בהתאם להקשר**: הסתרנו כפתורים ופעולות לא רלוונטיות בהתאם לעמוד שבו המשתמש נמצא (לדוגמה, "פתח בלוח" בתוך הלוח עצמו).

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת פונקציית `_normalize_alert_type` לטיפול בפורמטים שונים של `alert_type` (לדוגמה, `deployment-event` או `Deployment Event` הופכים ל-`deployment_event`).
- עדכון לוגיקת טעינת Quick Fixes ו-Runbooks להשתמש בנרמול החדש.
- הסרת הוספת אירועי `chatops` (לחיצות Quick Fix) ל-timeline של Incident Replay.
- הוספת לוגיקת סינון לפעולות Quick Fix וצעדי Runbook בהתאם ל-`ui_context` (לוח Observability או Incident Replay).
- העברת פרמטר `ui_context` ל-API של Runbooks ולפונקציות ה-backend הרלוונטיות.

## 🧪 בדיקות
- **Unit**: בדיקות היחידה הקיימות עודכנו ועברו, כולל בדיקות חדשות לנרמול `alert_type` ולבדיקה שאירועי Quick Fix לא מופיעים ב-Incident Replay.
- [x] Unit
- [ ] Integration
- [x] Manual (בדיקה ידנית של התנהגות ה-UI בלוח וב-Incident Replay)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שיפור חווית המשתמש ודיוק הצגת המידע. אין סיכון מהותי.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע rollback לגרסה הקודמת. השינויים הם בעיקר לוגיקה ו-UI, ללא שינויי DB.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b2fb12f-2e14-4caf-b1e6-c328723732a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b2fb12f-2e14-4caf-b1e6-c328723732a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize alert types, make quick-fix/runbook actions context-aware, and remove quick-fix telemetry from Incident Replay.
> 
> - **Observability (Backend)**:
>   - Add `_normalize_alert_type` and apply across runbook/quick-fix resolution, fallback alerts, coverage, and replay classification.
>   - Quick-fix selection: normalize `by_alert_type` config keys; prefer runbook actions; pass `ui_context` and filter actions via `_should_hide_quick_fix_action`.
>   - Runbook snapshot: hide self-referential step in `replay`; filter embedded actions; persist per-event state.
>   - Incident Replay: stop adding "chatops" quick-fix events; seed/cache events with normalized `alert_type`.
>   - Alerts API payload: include `quick_fixes` filtered for `dashboard_history`.
> - **Web/API**:
>   - `/api/observability/runbook/*`: accept/forward `ui`/`context` to services.
>   - Replay UI: send `ui: 'replay'` for runbook load/status; minor UI filtering alignment.
> - **Tests**:
>   - Update/extend tests for alert_type normalization, config-key matching, UI context propagation, and absence of chatops in replay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eab2a8c756c09ec4919b8a0059c141215e928721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->