### PR TITLE
Github message response

### DIFF
--- a/services/webserver.py
+++ b/services/webserver.py
@@ -565,7 +565,16 @@ def create_app() -> web.Application:
                 }
                 if queue_delay_source:
                     access_fields["queue_delay_source"] = str(queue_delay_source)
-                emit_event(_QUEUE_DELAY_EVENT_NAME, severity="info", **access_fields)
+                # Silence noisy monitoring endpoints when request is "ok".
+                # - For health/metrics: skip only successes (<400) but keep 4xx/5xx.
+                # - For favicon: also skip 404/4xx noise, keep 5xx.
+                silent_paths = {"/metrics", "/health", "/healthz", "/favicon.ico"}
+                should_silence = False
+                if path_label in silent_paths:
+                    ok_threshold = 500 if path_label == "/favicon.ico" else 400
+                    should_silence = int(status) < int(ok_threshold)
+                if not should_silence:
+                    emit_event(_QUEUE_DELAY_EVENT_NAME, severity="info", **access_fields)
             except Exception:
                 pass
             # Warning when queue delay is suspiciously high

--- a/tests/test_metrics_integration.py
+++ b/tests/test_metrics_integration.py
@@ -19,3 +19,44 @@ def test_metrics_endpoint_exposed_in_both_services(monkeypatch):
     # Accept either 200 or 503 depending on availability of prometheus_client
     assert resp.status_code in (200, 503)
     assert isinstance(resp.data, (bytes, bytearray))
+
+
+def test_access_logs_silenced_for_flask_monitoring_endpoints_when_ok(monkeypatch):
+    try:
+        import webapp.app as flask_app
+    except Exception:
+        pytest.skip("Flask app not importable in this environment")
+
+    app = flask_app.app
+    try:
+        client = app.test_client()
+    except Exception:
+        pytest.skip("Flask test client not available")
+
+    # Force /metrics to be 200 so we can assert silence behavior deterministically.
+    try:
+        import metrics as m
+        monkeypatch.setattr(m, "metrics_endpoint_bytes", lambda: b"ok", raising=False)
+        monkeypatch.setattr(m, "metrics_content_type", lambda: "text/plain", raising=False)
+    except Exception:
+        pass
+
+    events: list[tuple[str, str, dict]] = []
+
+    def fake_emit(event: str, severity: str = "info", **fields):
+        events.append((event, severity, fields))
+
+    monkeypatch.setattr(flask_app, "emit_event", fake_emit)
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+    access = [e for e in events if e[0] == "access_logs"]
+    assert not access, "expected /metrics to be silenced when ok"
+
+    # favicon may be 200 or 404 depending on static setup; either should be silenced (unless 5xx).
+    events.clear()
+    resp2 = client.get("/favicon.ico")
+    assert resp2.status_code < 500
+    access2 = [e for e in events if e[0] == "access_logs"]
+    assert not access2, "expected /favicon.ico to be silenced when ok"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2435,19 +2435,28 @@ def _metrics_after(resp):
             except Exception:
                 pass
             try:
-                rid = getattr(request, "_req_id", "") or ""
-                access_fields: Dict[str, Any] = {
-                    "request_id": str(rid),
-                    "method": method_label,
-                    "path": path_label,
-                    "handler": handler_label,
-                    "status_code": int(status),
-                    "duration_ms": int(float(dur) * 1000),
-                    "queue_delay": int(q_ms),
-                }
-                if q_src:
-                    access_fields["queue_delay_source"] = str(q_src)
-                emit_event("access_logs", severity="info", **access_fields)
+                # Silence noisy monitoring endpoints when request is "ok".
+                # - For health/metrics: skip only successes (<400) but keep 4xx/5xx.
+                # - For favicon: also skip 404/4xx noise, keep 5xx.
+                silent_paths = {"/metrics", "/health", "/healthz", "/favicon.ico"}
+                should_silence = False
+                if path_label in silent_paths:
+                    ok_threshold = 500 if path_label == "/favicon.ico" else 400
+                    should_silence = int(status) < int(ok_threshold)
+                if not should_silence:
+                    rid = getattr(request, "_req_id", "") or ""
+                    access_fields: Dict[str, Any] = {
+                        "request_id": str(rid),
+                        "method": method_label,
+                        "path": path_label,
+                        "handler": handler_label,
+                        "status_code": int(status),
+                        "duration_ms": int(float(dur) * 1000),
+                        "queue_delay": int(q_ms),
+                    }
+                    if q_src:
+                        access_fields["queue_delay_source"] = str(q_src)
+                    emit_event("access_logs", severity="info", **access_fields)
             except Exception:
                 pass
             try:


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו מנגנון השתקה ל־`access_logs` עבור נתיבי מוניטורינג (`/metrics`, `/health`, `/healthz`) ו־`/favicon.ico`. המטרה היא להפחית רעש בלוגים מבקשות תקינות (סטטוס < 400) או 404/4xx עבור `favicon`, תוך שמירה על רישום שגיאות (4xx/5xx).

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- הוספת לוגיקת השתקה ל־`access_logs` ב־`services/webserver.py` (aiohttp middleware).
- הוספת לוגיקת השתקה ל־`access_logs` ב־`webapp/app.py` (Flask `after_request`).
- עבור `/metrics`, `/health`, `/healthz`: בקשות עם סטטוס < 400 מושתקות.
- עבור `/favicon.ico`: בקשות עם סטטוס < 500 (כולל 404) מושתקות.
- עדכון טסטים קיימים ב־`tests/test_webserver_observability_extras.py` שהשתמשו ב־`/health` כדי שלא יושפעו מההשתקה, והוספת טסטים חדשים לוודא את ההתנהגות הרצויה.
- הוספת טסט חדש ב־`tests/test_metrics_integration.py` לבדיקת השתקת לוגים ב־Flask.

## 🧪 בדיקות
- הרצנו `python3 -m pytest -q` וכל הטסטים עברו בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual (בדיקה ידנית של הלוגים לוודא שהם שקטים עבור הנתיבים הרלוונטיים)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שיפור ניכר בניקיון הלוגים, הפחתת רעש מבקשות מוניטורינג תקינות. אין השפעה שלילית צפויה על פרודקשן או ביצועים.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה של תקלה, ניתן לבצע Rollback לגרסה הקודמת של הקוד. השינויים הם נקודתיים ואינם משפיעים על לוגיקת ליבה.

---
<a href="https://cursor.com/background-agent?bcId=bc-acb3b46b-492d-4a8f-bc86-953e3b68d542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acb3b46b-492d-4a8f-bc86-953e3b68d542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Silences `access_logs` for `/metrics`, `/health`, `/healthz`, and `/favicon.ico` on successful responses and updates/adds tests accordingly.
> 
> - **Backend/Logging**:
>   - Aiohttp (`services/webserver.py`): add silencing for `access_logs` on `"ok"` responses for `/metrics`, `/health`, `/healthz` (<400) and `/favicon.ico` (<500).
>   - Flask (`webapp/app.py`): mirror the same silencing logic in `after_request`.
> - **Tests**:
>   - Update aiohttp observability tests to hit `'/incidents'` instead of `'/health'` where access logs are required.
>   - Add tests verifying silencing behavior in aiohttp and Flask (`tests/test_webserver_observability_extras.py`, `tests/test_metrics_integration.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72369e716834af63e93eb4cd49e49d06cf3ec583. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->