### PR TITLE
Cursor/hebrew message response 77c1

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -490,20 +490,6 @@
             בונה ערכת נושא (אדמין)
           </a>
         </div>
-        {% if custom_theme and custom_theme.is_active %}
-        <div style="margin-top: 0.5rem; display: flex; justify-content: flex-end;">
-          <button
-            type="button"
-            class="btn btn-tertiary btn-icon"
-            onclick="deleteCustomTheme()"
-            title="מחק ערכה מותאמת"
-            style="border-color: rgba(245, 101, 101, 0.55); color: var(--danger);"
-          >
-            <i class="fas fa-trash" style="color: var(--danger);"></i>
-            מחק ערכה
-          </button>
-        </div>
-        {% endif %}
         {% endif %}
       </div>
     </div>
@@ -715,6 +701,33 @@
       </div>
     </div>
   </div>
+
+  {% if custom_theme %}
+  <div
+    class="glass-card"
+    style="margin-top: 1rem; border: 1px solid color-mix(in srgb, var(--danger) 55%, transparent);"
+  >
+    <h2 class="section-title" style="color: color-mix(in srgb, var(--danger) 80%, var(--text-primary) 20%);">
+      <i class="fas fa-exclamation-triangle"></i>
+      אזור סכנה
+    </h2>
+    <p style="opacity: 0.85; margin-top: -0.5rem">
+      מחיקת ערכות נושא שנבנו ע"י Theme Builder (הפעולה אינה הפיכה).
+    </p>
+    <div style="display: flex; justify-content: flex-end; margin-top: 0.75rem; gap: 0.5rem; flex-wrap: wrap;">
+      <button
+        type="button"
+        class="btn btn-outline-danger"
+        onclick="deleteCustomTheme()"
+        title="מחק ערכה {{ custom_theme.name if custom_theme.name else 'Custom' }}"
+        style="border: 1px solid color-mix(in srgb, var(--danger) 75%, transparent); background: transparent; color: var(--danger);"
+      >
+        <i class="fas fa-trash" style="opacity: 0.85;"></i>
+        מחק ערכה {{ custom_theme.name if custom_theme.name else 'Custom' }}
+      </button>
+    </div>
+  </div>
+  {% endif %}
 
   <style>
     .badge {
@@ -2407,96 +2420,6 @@
       if (pushTestBtn) pushTestBtn.addEventListener('click', testPush);
       refreshPushUi();
     })();
-    </script>
-    <script>
-      // UX: כפתור מחיקת Custom עדין, בצד, ובטקסט ברור עם שם הערכה
-      (function () {
-        try {
-          const themeSel = document.getElementById('themeSelect');
-          if (!themeSel) return;
-
-          const deleteBtn = document.querySelector('button[onclick="deleteCustomTheme()"]');
-          if (!deleteBtn) return;
-
-          const customThemeName = {{ (custom_theme.name if custom_theme and custom_theme.name else 'Custom') | tojson | safe }};
-          const name = (customThemeName && String(customThemeName).trim()) ? String(customThemeName).trim() : 'Custom';
-
-          // הצגה רק כשנמצאים על Custom (וגם כדי להימנע מלחיצות בטעות כשבוחרים ערכה אחרת)
-          function updateVisibility() {
-            try {
-              const isCustomSelected = (String(themeSel.value || '').trim().toLowerCase() === 'custom');
-              deleteBtn.style.display = isCustomSelected ? '' : 'none';
-            } catch (_) {}
-          }
-
-          // למקם את הכפתור ליד ה-select (באותה שורה)
-          try {
-            const rightCol = themeSel.parentElement;
-            if (rightCol && !rightCol.__ckThemeDeleteBarMounted) {
-              const bar = document.createElement('div');
-              bar.style.display = 'flex';
-              bar.style.alignItems = 'center';
-              bar.style.justifyContent = 'flex-end';
-              bar.style.gap = '0.5rem';
-              bar.style.flexWrap = 'wrap';
-              rightCol.__ckThemeDeleteBarMounted = true;
-
-              rightCol.insertBefore(bar, themeSel);
-              bar.appendChild(themeSel);
-
-              const oldWrap = deleteBtn.parentElement;
-              bar.appendChild(deleteBtn);
-              try {
-                if (oldWrap && oldWrap.parentElement && oldWrap.children.length === 0) {
-                  oldWrap.parentElement.removeChild(oldWrap);
-                } else if (oldWrap) {
-                  oldWrap.style.display = 'none';
-                }
-              } catch (_) {}
-            }
-          } catch (_) {}
-
-          // עיצוב פחות "צועק"
-          try {
-            deleteBtn.style.opacity = '0.82';
-            deleteBtn.style.borderColor = 'rgba(255,255,255,0.18)';
-            deleteBtn.style.color = 'inherit';
-          } catch (_) {}
-          try {
-            const icon = deleteBtn.querySelector('i');
-            if (icon) {
-              icon.style.color = 'inherit';
-              icon.style.opacity = '0.75';
-            }
-          } catch (_) {}
-
-          // טקסט ברור עם שם הערכה
-          try {
-            deleteBtn.innerHTML = `<i class="fas fa-trash" style="opacity:0.75;"></i> מחק ערכה ${name}`;
-            deleteBtn.title = `מחק ערכה "${name}"`;
-          } catch (_) {}
-
-          // דריסת confirm כדי לכלול שם ערכה, בלי לשנות את ה-HTML
-          window.deleteCustomTheme = async function deleteCustomTheme() {
-            if (!confirm(`האם למחוק את הערכה "${name}"?`)) return;
-            try {
-              const res = await fetch('/api/themes/custom', { method: 'DELETE' });
-              const data = await res.json();
-              if (!res.ok || !data || !data.ok) throw new Error((data && data.error) || 'delete_failed');
-            } catch (e) {
-              console.error('deleteCustomTheme failed:', e);
-              alert('שגיאה במחיקת הערכה');
-              return;
-            }
-            try { localStorage.setItem('dark_mode_preference', 'light'); } catch (_) {}
-            try { localStorage.setItem('user_theme', 'classic'); } catch (_) {}
-            location.reload();
-          };
-
-          themeSel.addEventListener('change', updateVisibility);
-          updateVisibility();
-        } catch (_) { /* ignore */ }
-      })();
     </script>
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
שינוי מיקום ועיצוב כפתור מחיקת ערכה

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the Custom theme delete button on the settings page with repositioning, conditional visibility, clearer labeling, named confirm, and deletion flow.
> 
> - **UI/UX – Settings (`webapp/templates/settings.html`)**:
>   - Repositions the Custom theme delete button next to `#themeSelect` and hides it unless `custom` is selected.
>   - Softens styling and updates button text/title to include the theme name.
>   - Overrides `deleteCustomTheme()` to confirm with theme name, call `DELETE /api/themes/custom`, then reset `localStorage` (`dark_mode_preference`, `user_theme`) and reload.
>   - Cleans up/hides the old wrapper container after moving the button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdeeeb5ccd7793bc3f690791fc0fac0c274c74f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->