### PR TITLE
Github message context response

### DIFF
--- a/tests/test_collections_manager_share_and_activity.py
+++ b/tests/test_collections_manager_share_and_activity.py
@@ -213,6 +213,14 @@ def test_is_file_active_for_regular_and_large_and_exception_path(mgr: Collection
     assert by_name2["a.py"]["is_file_active"] is False
     assert by_name2["b.big"]["is_file_active"] is False
 
+    # תאימות: אם large_files לא מוגדר, fallback ל-code_snippets עבור פריטי large
+    mgr.large_files = None  # type: ignore[assignment]
+    mgr.code_snippets.insert_one({"user_id": 20, "file_name": "b.big", "is_active": True})  # type: ignore[attr-defined]
+    out_fallback = mgr.get_collection_items(20, cid, page=1, per_page=10, include_computed=False)
+    assert out_fallback["ok"]
+    by_name_fb = {it["file_name"]: it for it in out_fallback["items"]}
+    assert by_name_fb["b.big"]["is_file_active"] is True
+
     # מסלול חריגות: large_files.find_one יזרוק — המנג'ר צריך לסמן True (fail-open)
     class Boom:
         def find_one(self, *a, **k):  # pragma: no cover - exercised here


### PR DESCRIPTION
## ✨ תיאור קצר
- בוצעה אופטימיזציה ל־`CollectionsManager.get_collection_items` לתיקון בעיית N+1 בגישה למסד הנתונים.
- החלפנו קריאות `find_one` פר-פריט לבדיקת `is_file_active` בשתי שאילתות Batch לכל היותר באמצעות `$in`, מה שמפחית דרמטית את מספר ה־roundtrips למסד ומשפר את ביצועי טעינת פריטי אוסף.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- שוכתבה לוגיקת בדיקת `is_file_active` ב־`get_collection_items` כדי למנוע שאילתות N+1.
- הוטמעה פונקציית עזר `_batch_active_names` לביצוע שאילתות יעילות על קבוצת שמות קבצים.
- נוספה לוגיקת "fail-open" (הנחת פעיל) במקרה של כשל בגישה למסד הנתונים במהלך בדיקת סטטוס קובץ.

## 🧪 בדיקות
- הרצתי סט בדיקות ממוקד על לוגיקת `is_file_active` (כולל מסלול חריגות fail-open) ועל `get_collection_items`/mixed/smart — כולן עברו.
- [ ] Unit
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] perf: שיפור ביצועים

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שיפור משמעותי בביצועים ובזמני התגובה של טעינת פריטי אוסף, במיוחד עבור אוספים גדולים או בסביבות עם השהיית DB גבוהה.
- סיכון נמוך, עם לוגיקת fail-open מיושמת במקרה של כשל בגישה למסד.

## 🔗 קישורים
- Issues קשורים: # (לא צוין Issue ספציפי)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: Revert PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f79e9c2-1c3b-4796-9159-a2a06ac2cff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f79e9c2-1c3b-4796-9159-a2a06ac2cff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces per-item `find_one` checks with up to two `$in` batch queries (regular/large) in `get_collection_items`, adding fail-open handling and source normalization.
> 
> - **Backend (performance)**:
>   - Optimizes `database/collections_manager.py` `CollectionsManager.get_collection_items`:
>     - Replaces N+1 `find_one` checks for `is_file_active` with up to two `$in` batch queries by source (`code_snippets`/`large_files`).
>     - Adds helpers `_batch_active_names` and `_mark_all` for batched resolution and fallback marking.
>     - Implements fail-open behavior on DB errors and normalizes `source` casing for compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98be1d06e9e3d112eb309b8503cd754b2669856f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->