### PR TITLE
Github message response

### DIFF
--- a/webapp/static/css/collections.css
+++ b/webapp/static/css/collections.css
@@ -476,9 +476,8 @@
   padding:.2rem .5rem;
   cursor:pointer
 }
-.collection-item .pin,
-.collection-item .preview{background:var(--collections-btn-bg);border:1px solid var(--collections-btn-border);border-radius:6px;color:var(--collections-btn-text);padding:.2rem .5rem;cursor:pointer}
-.collection-item .pin.pinned{background:var(--collections-pinned-bg);border-color:var(--collections-pinned-border);color:var(--collections-pinned-text)}
+.collection-item .preview,
+.collection-item .open-view{background:var(--collections-btn-bg);border:1px solid var(--collections-btn-border);border-radius:6px;color:var(--collections-btn-text);padding:.2rem .5rem;cursor:pointer}
 .loading,.empty,.error{opacity:.85}
 @media(max-width:900px){.collections-layout{grid-template-columns:1fr}}
 .workspace-board{display:flex;flex-direction:column;gap:.75rem;position:relative}


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספנו כפתור 🌐 חדש ב-UI של "האוספים שלי" ו"שולחן עבודה" המאפשר פתיחה ישירה של קבצי Markdown ו-HTML בתצוגת דפדפן.
- הסרנו את כפתור 📌 (הצמדה) ואת הלוגיקה הקשורה אליו מכלל האוספים.
- עדכנו את ה-CSS להתאמת הכפתור החדש.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת כפתור `open-view` (🌐) ב-`collections.js` עבור קבצי `.md`, `.markdown`, `.html`, `.htm`.
- הסרת כפתור `pin` (📌) מ-`collections.js` ומ-`collections.css`.
- הוספת לוגיקה ב-`handleDirectViewClick` לפתיחת קבצים בנתיבים `/md/<file_id>` או `/html/<file_id>`.
- עדכון סגנונות CSS עבור הכפתור החדש.

## 🧪 בדיקות
- נבדק ידנית ב-UI של "האוספים שלי" ו"שולחן עבודה":
  - ודאתי שהכפתור 🌐 מופיע רק עבור קבצי Markdown ו-HTML.
  - ודאתי שלחיצה על 🌐 פותחת את הקובץ בתצוגה המתאימה (Markdown או HTML).
  - ודאתי שכפתור 📌 הוסר לחלוטין.
  - ודאתי שהעיצוב של הכפתור החדש תקין.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שינוי ב-UI של "האוספים שלי" ו"שולחן עבודה" עקב הוספת כפתור והסרת כפתור.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- חזרה לגרסה קודמת של הקבצים `webapp/static/js/collections.js` ו-`webapp/static/css/collections.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4b6c144-a9ca-4d8e-ab3e-5027a387b5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4b6c144-a9ca-4d8e-ab3e-5027a387b5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new button to directly open Markdown/HTML files from collections and workspace, and removes the pin feature and its styling.
> 
> - **Frontend (Collections/Workspace)**:
>   - **Direct Open**: Add `open-view` (🌐) button for `.md/.markdown/.html/.htm` in `webapp/static/js/collections.js`.
>     - New helpers: `getDirectViewMode`, `directViewTitle`, `handleDirectViewClick` (opens `/md/<id>` or `/html/<id>` in new tab).
>     - Wire click handling in collections list and workspace cards; fallback to normal open if unsupported.
>   - **Remove Pin**: Delete pin button, indicators, and related add/update logic from collections items and workspace cards.
> - **CSS**:
>   - Style ` .collection-item .open-view` (matches existing button styles).
>   - Remove `.pin` styles in `webapp/static/css/collections.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 425f40b75e15df920c2e7a7c0b34aa68ed826d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->