### PR TITLE
Gunicorn render optimization

### DIFF
--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -169,19 +169,19 @@
    * - ``WEB_CONCURRENCY``
      - מספר ה-workers של Gunicorn ב-WebApp. אם מוגדר, גובר על ברירת המחדל של ``scripts/start_webapp.sh`` ומקטין ``queue_delay`` תחת עומס.
      - לא
-     - ``2`` (או מספר הליבות עד 4)
+     - ``2``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKERS``
      - מספר ה-workers של Gunicorn (חלופה ל-``WEB_CONCURRENCY``)
      - לא
-     - ``2`` (או מספר הליבות עד 4)
+     - ``2``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_THREADS``
      - מספר Threads לכל worker כאשר משתמשים ב-``gthread`` (משפר מקביליות לבקשות I/O)
      - לא
-     - ``4``
+     - ``2``
      - ``8``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKER_CLASS``

--- a/scripts/start_webapp.sh
+++ b/scripts/start_webapp.sh
@@ -45,36 +45,17 @@ log "Starting Gunicorn (${APP_MODULE}) on 0.0.0.0:${PORT}"
 cd "$APP_DIR"
 
 # --- Gunicorn concurrency tuning (Render/Prod) ---
-# ברירת מחדל "חכמה" כדי לצמצם queue_delay כאשר בקשות איטיות תופסות worker יחיד.
-# ניתן לשלוט ידנית דרך ENV:
+# Render (במיוחד Free/Starter) מאוד רגיש לזיכרון בזמן boot.
+# יותר מדי workers = הרבה תהליכים שמטעינים את האפליקציה במקביל -> OOM / thrash -> Port Scan timeout.
+#
+# לכן ברירת המחדל פה היא **שמרנית וקבועה**: 2 workers + 2 threads.
+# עדיין אפשר override ידני דרך ENV:
 # - WEB_CONCURRENCY / WEBAPP_GUNICORN_WORKERS
 # - WEBAPP_GUNICORN_THREADS
 # - WEBAPP_GUNICORN_WORKER_CLASS (ברירת מחדל: gthread)
 # - WEBAPP_GUNICORN_TIMEOUT / WEBAPP_GUNICORN_KEEPALIVE
-cpu_count="1"
-if command -v getconf >/dev/null 2>&1; then
-  cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
-elif command -v nproc >/dev/null 2>&1; then
-  cpu_count="$(nproc 2>/dev/null || echo 1)"
-fi
-cpu_count="$(trim "${cpu_count:-1}")"
-
-GUNICORN_WORKERS="$(trim "${WEB_CONCURRENCY:-${WEBAPP_GUNICORN_WORKERS:-}}")"
-if [ -z "$GUNICORN_WORKERS" ]; then
-  # ברירת מחדל שמרנית ל-Render Starter: 2 processes כדי שלא "worker אחד" יתקע את כולם.
-  # במכונות עם יותר CPU, נשתמש בכמות הליבות עד תקרה של 4 (למניעת צריכת זיכרון חריגה).
-  if [ "${cpu_count:-1}" -le 1 ]; then
-    GUNICORN_WORKERS="2"
-  else
-    GUNICORN_WORKERS="${cpu_count}"
-  fi
-  # cap to 4
-  if [ "${GUNICORN_WORKERS:-2}" -gt 4 ]; then
-    GUNICORN_WORKERS="4"
-  fi
-fi
-
-GUNICORN_THREADS="$(trim "${WEBAPP_GUNICORN_THREADS:-4}")"
+GUNICORN_WORKERS="$(trim "${WEB_CONCURRENCY:-${WEBAPP_GUNICORN_WORKERS:-2}}")"
+GUNICORN_THREADS="$(trim "${WEBAPP_GUNICORN_THREADS:-2}")"
 GUNICORN_WORKER_CLASS="$(trim "${WEBAPP_GUNICORN_WORKER_CLASS:-gthread}")"
 GUNICORN_TIMEOUT="$(trim "${WEBAPP_GUNICORN_TIMEOUT:-60}")"
 GUNICORN_KEEPALIVE="$(trim "${WEBAPP_GUNICORN_KEEPALIVE:-2}")"


### PR DESCRIPTION
## ✨ תיאור קצר
עדכנו את ברירות המחדל של Gunicorn ב-`start_webapp.sh` ל-2 workers ו-2 threads, ועדכנו את התיעוד בהתאם. שינוי זה נועד למנוע כשלי עלייה (Port Scan timeout) בשרתי Render עם מגבלות זיכרון, שנגרמו מצריכת זיכרון גבוהה בזמן אתחול.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי ברירת המחדל של `GUNICORN_WORKERS` ו-`GUNICORN_THREADS` ב-`scripts/start_webapp.sh` מחישוב דינמי (עד 4) לערך קבוע של 2.
- עדכון `docs/environment-variables.rst` כדי לשקף את ברירות המחדל החדשות עבור `WEB_CONCURRENCY`, `WEBAPP_GUNICORN_WORKERS` ו-`WEBAPP_GUNICORN_THREADS`.

## 🧪 בדיקות
- **Manual**: נבדק שהשינויים בקוד משקפים את ההנחיות. ההשפעה העיקרית היא על תהליך ה-deploy ב-Render, שייבדק בעת פתיחת ה-PR.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [x] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **השפעה חיובית**: יציבות משופרת בעת עלייה בשרתי Render עם מגבלות זיכרון, מניעת כשלי Port Scan.
- **השפעה אפשרית**: במקרים של עומס גבוה מאוד, ייתכן ש-2 workers ו-2 threads יספקו פחות מקביליות מ-4/4. עם זאת, ניתן להגדיר זאת ידנית דרך משתני סביבה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיט או החזרת הקבצים `scripts/start_webapp.sh` ו-`docs/environment-variables.rst` לגרסתם הקודמת.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f489947-768a-45cc-98e7-bacd9fb107dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f489947-768a-45cc-98e7-bacd9fb107dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set fixed Gunicorn defaults (2 workers, 2 threads) in start script and update environment variable docs; remove CPU-based scaling.
> 
> - **WebApp (Gunicorn runtime)**:
>   - Set fixed defaults: `GUNICORN_WORKERS=2`, `GUNICORN_THREADS=2` in `scripts/start_webapp.sh`.
>   - Remove CPU-based worker calculation and related logic; keep ENV overrides (`WEB_CONCURRENCY`, `WEBAPP_GUNICORN_WORKERS`, `WEBAPP_GUNICORN_THREADS`).
>   - Add clarifying comments about Render memory sensitivity during boot.
> - **Docs**:
>   - Update `docs/environment-variables.rst` defaults:
>     - `WEB_CONCURRENCY`: `2` (no CPU-based note).
>     - `WEBAPP_GUNICORN_WORKERS`: `2`.
>     - `WEBAPP_GUNICORN_THREADS`: `2` (was `4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae8e737c52045f48ccc898875bdc93828aa32816. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->