### PR TITLE
Core i18n module setup

### DIFF
--- a/app/core/i18n.py
+++ b/app/core/i18n.py
@@ -86,7 +86,10 @@ async def detect_user_language(telegram_user: Any, db_user: Any = None) -> str:
         tg_lang = None
 
     tg_value = (str(tg_lang) if tg_lang is not None else "").strip().lower()
-    detected = "he" if tg_value.startswith("he") else "en"
+    if not tg_value:
+        detected = _DEFAULT_LANG
+    else:
+        detected = "he" if tg_value.startswith("he") else "en"
 
     # best-effort sync חזרה למודל user (בזיכרון)
     if db_user is not None and not db_lang:


### PR DESCRIPTION
## ✨ תיאור קצר
נוצר מודול `app/core/i18n.py` חדש לטיפול בתרגומים וזיהוי שפת משתמש (עברית/אנגלית). המטרה היא לאפשר לבוט להגיב למשתמשים בשפתם ולפתור שגיאות ייבוא פוטנציאליות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- יצירת `app/core/i18n.py` עם מילון תרגומים בסיסי (he/en).
- מימוש `get_text(key, lang)` לשליפת טקסט מתורגם עם fallback בטוח.
- מימוש `detect_user_language(telegram_user, db_user)` לזיהוי שפה מה-DB או מטלגרם, כולל סנכרון best-effort למודל ה-DB.
- הוספת exports שימושיים: `TRANSLATIONS`, `SUPPORTED_LANGS`, `DEFAULT_LANG`.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
  - בוצעה בדיקה ידנית לוודא שהמודול נוצר וניתן לייבא אותו ללא שגיאות.
  - נבדק שהפונקציות `get_text` ו-`detect_user_language` פועלות כצפוי עם קלטים שונים.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: אין השפעה שלילית צפויה, מדובר במודול חדש שמוסיף פונקציונליות.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: מחיקת הקובץ `app/core/i18n.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-edf78673-a61f-4f47-9820-65a4ba03aadd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edf78673-a61f-4f47-9820-65a4ba03aadd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `app/core/i18n.py` providing he/en translations, safe `get_text`, and DB/Telegram-based language detection with best‑effort sync.
> 
> - **Core**:
>   - **New i18n module** (`app/core/i18n.py`):
>     - Translation map `TRANSLATIONS` for `he`/`en`; exports `SUPPORTED_LANGS`, `DEFAULT_LANG`.
>     - `_normalize_lang` to standardize codes (e.g., `he-IL`, `en-US`) with fallbacks.
>     - `get_text(key, lang)` with safe fallback to default language or `key`.
>     - `detect_user_language(telegram_user, db_user)` prioritizes DB value, falls back to Telegram `language_code`, and best-effort syncs `db_user.language`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7615d0cb82c217397c94e249410faf8ac5c7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->