### PR TITLE
Minimalist image widget ui

### DIFF
--- a/webapp/static/css/file-editor.css
+++ b/webapp/static/css/file-editor.css
@@ -234,13 +234,20 @@
 }
 
 #image-upload-widget .image-uploader__error {
-  margin-top: 0.1rem;
   font-size: 0.9rem;
   color: #ff8a8a;
 }
 
+#image-upload-widget .image-uploader__error:empty {
+  display: none;
+}
+
+#image-upload-widget .image-uploader__error:not(:empty) {
+  margin-bottom: 0.5rem;
+}
+
 #image-upload-widget .previews-container {
-  margin-top: 0.75rem;
+  margin-top: 0;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 0.75rem;

--- a/webapp/static/js/file-form-manager.js
+++ b/webapp/static/js/file-form-manager.js
@@ -374,14 +374,29 @@
       return isMarkdownFilename(filename) || isMarkdownLanguage(langValue);
     }
 
+    updateWidgetVisibility() {
+      if (!this.widget) {
+        return;
+      }
+
+      const isMarkdown = this.isMarkdownContext();
+      const hasImages = this.countExistingVisible() + this.newImages.length > 0;
+      const hasError = !!(this.errorEl && String(this.errorEl.textContent || '').trim().length > 0);
+
+      // ה-Widget מוצג רק אם זה Markdown וגם (יש תמונות או יש שגיאה)
+      if (isMarkdown && (hasImages || hasError)) {
+        this.widget.style.display = 'block';
+      } else {
+        this.widget.style.display = 'none';
+      }
+    }
+
     updateForContextChange() {
       if (!this.widget) {
         return;
       }
       const isMarkdown = this.isMarkdownContext();
-      // שימוש ב-style כדי לנהל display: none שמוגדר ב-HTML (מניעת FOUC)
-      this.widget.style.display = isMarkdown ? 'block' : 'none';
-      // שמירה על תאימות ל-CSS הקיים
+      // שמירה על תאימות ל-CSS הקיים (ובמיוחד מצב לא-Markdown)
       this.widget.classList.toggle('is-hidden', !isMarkdown);
 
       if (this.externalTrigger) {
@@ -397,13 +412,14 @@
 
       this.updateStatus();
       this.updateEmptyState();
+      this.updateWidgetVisibility();
     }
 
     setError(message) {
-      if (!this.errorEl) {
-        return;
+      if (this.errorEl) {
+        this.errorEl.textContent = message || '';
       }
-      this.errorEl.textContent = message || '';
+      this.updateWidgetVisibility();
     }
 
     updateStatus() {
@@ -494,6 +510,7 @@
       if (!toAdd.length) {
         this.updateStatus();
         this.updateEmptyState();
+        this.updateWidgetVisibility();
         return;
       }
 
@@ -501,6 +518,7 @@
       this.renderNewPreviews(toAdd);
       this.updateStatus();
       this.updateEmptyState();
+      this.updateWidgetVisibility();
     }
 
     renderNewPreviews(items) {
@@ -596,6 +614,7 @@
       if (!this.newImages.length && this.countExistingVisible() === 0) {
         this.setError('');
       }
+      this.updateWidgetVisibility();
     }
 
     onFormData(event) {

--- a/webapp/templates/components/editor_components.html
+++ b/webapp/templates/components/editor_components.html
@@ -1,18 +1,13 @@
 {# רכיבי עורך משותפים ל-Upload/Edit #}
 
 {% macro image_uploader(existing_images=[]) %}
-<div id="image-upload-widget" class="glass-card" data-component="image-uploader" style="display: none;">
-    <div class="image-uploader__header">
-        <span class="image-uploader__label">תמונות (לקבצי Markdown)</span>
-        <span class="image-uploader__status" data-role="image-status"></span>
-    </div>
-
-    <div class="image-uploader__actions">
-        <small class="image-uploader__hint" data-role="image-hint">
-            ניתן לצרף עד 6 תמונות (PNG/JPG/WEBP/GIF, עד ‎2MB‎ לכל תמונה). הרכיב פעיל לקבצי Markdown (סיומת ‎.md/.markdown‎ או בחירת "Markdown" בשפה).
-        </small>
-        <div class="image-uploader__error" data-role="image-error" role="alert"></div>
-    </div>
+<div
+    id="image-upload-widget"
+    class="glass-card"
+    data-component="image-uploader"
+    style="display: none; padding: 0.5rem; border: none; background: transparent;"
+>
+    <div class="image-uploader__error" data-role="image-error" role="alert"></div>
 
     <input type="file" name="md_images" hidden multiple accept="image/*" data-role="file-input">
 


### PR DESCRIPTION
## ✨ תיאור קצר
הוסתרה "קופסה ריקה" של רכיב העלאת התמונות (Image Widget) במצב Markdown כאשר אין תמונות או שגיאות, ונוקה ה-HTML שלו מטקסטים מיותרים. זאת כדי לשפר את חווית המשתמש ולפנות מקום במסך.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- **`webapp/templates/components/editor_components.html`**: רכיב ה-`image_uploader` הפך למינימליסטי, הוסרו כותרות וטקסטים סטטיים, והוגדר `display: none` כברירת מחדל.
- **`webapp/static/js/file-form-manager.js`**: נוספה לוגיקת `updateWidgetVisibility()` למחלקה `ImageManager` שמציגה את ה-Widget רק כשיש תמונות (חדשות/קיימות) או שגיאה, ונקראה מפונקציות רלוונטיות (כמו `updateForContextChange`, `handleFiles`, `removeImage`, `setError`).
- **`webapp/static/css/file-editor.css`**: בוצעו שינויים קוסמטיים להסתרת אזור השגיאה כשהוא ריק ולתיקון מרווחים.

## 🧪 בדיקות
- נבדק ידנית בממשק המשתמש:
  - במצב Markdown ללא תמונות: ה-Widget מוסתר לחלוטין.
  - בהוספת תמונה: ה-Widget נפתח ומציג את התמונה.
  - במחיקת כל התמונות: ה-Widget נסגר.
  - בהופעת שגיאה (לדוגמה, קובץ גדול מדי): ה-Widget נפתח ומציג את השגיאה.
  - בעריכת פוסט עם תמונות קיימות: ה-Widget נפתח עם התמונות.
  - כפתור הוספת התמונה (🖼️) בשורת הכותרת נשאר גלוי תמיד במצב Markdown.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` (עמוד רפרנס)
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש (UX) על ידי פישוט הממשק והסתרת רכיבים מיותרים. סיכון נמוך, השינויים הם ב-UI/JS בלבד.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור פשוטה: ביטול הקומיטים (revert) של ה-PR. השינויים הם ב-UI/JS בלבד ואינם משפיעים על לוגיקת צד השרת או מסד הנתונים.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa6f6e08-489f-4c2c-b4d5-403c054abab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa6f6e08-489f-4c2c-b4d5-403c054abab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minimizes the Markdown image widget and makes it auto-hide unless there are images or an error, updating JS logic, template markup, and CSS accordingly.
> 
> - **UI (Markdown Image Widget)**
>   - **JS (`webapp/static/js/file-form-manager.js`)**:
>     - Add `updateWidgetVisibility()` to show widget only in Markdown when there are images or an error; invoked from `updateForContextChange`, `setError`, `handleFiles`, and `removeImage`.
>     - Preserve non-Markdown behavior via `is-hidden` class, clear new images on exit, and keep external trigger visibility in sync.
>   - **Template (`webapp/templates/components/editor_components.html`)**:
>     - Simplify `image_uploader` markup: remove header/labels/hint; keep only error block, hidden file input, and previews. Default `style="display: none; ..."` for a minimalist container.
>   - **CSS (`webapp/static/css/file-editor.css`)**:
>     - Hide empty error (`.image-uploader__error:empty`) and adjust error/previews spacing; set previews `margin-top: 0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c7b0633b2a421561950e59c6138f77af8fbe0bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->