### PR TITLE
Restore to commit 34662b0

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -33,23 +33,6 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
 .cm-selectionBackground { background-color: rgba(100,100,255,0.3) !important; }
 @media (max-width: 768px){
   .cm-editor { max-height: 50vh; font-size: 14px; }
-  /* מובייל: מוסיפים "אוויר" בתחתית הגלילה כדי שהשורות האחרונות לא ייחתכו
-     מתחת ל-UI של הדפדפן / Safe Area (iOS). */
-  :root {
-    --editor-scroll-bottom-padding: 80px;
-    /* iOS Safe Area (ישן/חדש) */
-    --editor-scroll-bottom-padding: calc(80px + constant(safe-area-inset-bottom));
-    --editor-scroll-bottom-padding: calc(80px + env(safe-area-inset-bottom));
-  }
-
-  /* CodeMirror (העורך המתקדם) */
-  .cm-editor .cm-scroller { padding-bottom: var(--editor-scroll-bottom-padding) !important; }
-
-  /* Textarea (העורך הבסיסי) */
-  #codeTextarea,
-  textarea.code-field,
-  .editor-textarea { padding-bottom: var(--editor-scroll-bottom-padding) !important; }
-
   /* Mobile: Stack vertically */
   .editor-switcher-row { flex-direction: column; align-items: stretch; gap:.5rem; }
   .editor-switcher-actions { width: 100%; flex-direction: column; }

--- a/webapp/static/css/split-view.css
+++ b/webapp/static/css/split-view.css
@@ -353,8 +353,6 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  /* חשוב לגלילה בתוך flex (בעיקר במובייל/iOS): מאפשר לילדים עם overflow להתכווץ */
-  min-height: 0;
 }
 
 .split-panel--editor {
@@ -396,8 +394,6 @@
 .split-preview-content {
   flex: 1;
   overflow: auto;
-  /* מאפשר overflow פנימי לעבוד בתוך Flexbox */
-  min-height: 0;
   background: var(--split-preview-bg);
   color: var(--split-preview-text);
   border-radius: 8px;
@@ -525,14 +521,6 @@ html[dir="rtl"] .split-preview-content code {
   }
 
   .split-preview-content {
-    /* מובייל: מכריח את ה-flex item להתכווץ כדי ש-overflow-y יעבוד */
-    min-height: 0;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  /* שומרים על גובה מינימלי נעים לתוכן/placeholder בלי לשבור גלילה */
-  .split-preview-canvas {
     min-height: 220px;
   }
 }


### PR DESCRIPTION
This PR restores the repository to commit `34662b04ef9fcb139fc2c69c8a92b4a3f9fda168` by recreating its tree on top of `main`.

נוצר אוטומטית דרך בוט CodeBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes mobile safe-area bottom padding and flex overflow/min-height hacks from editor and split-view styles to simplify responsive behavior.
> 
> - **Frontend CSS**
>   - **Editor (`webapp/static/css/codemirror-custom.css`)**:
>     - Remove mobile-only bottom padding/safe-area vars and related padding on CodeMirror and textareas.
>     - Keep mobile vertical stacking; no structural changes otherwise.
>   - **Split View (`webapp/static/css/split-view.css`)**:
>     - Remove `min-height: 0` overflow hacks on `\.split-panel` and `\.split-preview-content`.
>     - Drop mobile `overflow-y: auto` and `-webkit-overflow-scrolling: touch` overrides.
>     - Retain responsive layout; ensure preview area minimum height via `\.split-preview-content { min-height: 220px; }` on small screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffd8389ec6c7ce1cb07f8c0cb8a2aca5e1a25b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->