### PR TITLE
Image generator test failure

### DIFF
--- a/services/image_generator.py
+++ b/services/image_generator.py
@@ -575,6 +575,13 @@ class CodeImageGenerator:
 
     def save_optimized_png(self, img: Image.Image) -> bytes:
         """Always return PNG for crisp code images; keep optimization, avoid JPEG."""
+        # Pillow 12+ עשוי לטעון פורמטים בצורה עצלה יותר. בחלק מהסביבות זה גורם ל-
+        # KeyError: 'PNG' בזמן save אם פלאגין PNG עדיין לא נרשם.
+        # נוודא אתחול רישום הפורמטים לפני השמירה.
+        try:
+            Image.init()
+        except Exception:
+            pass
         buf = io.BytesIO()
         img.save(buf, format='PNG', optimize=True, compress_level=9)
         return buf.getvalue()


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג `KeyError: 'PNG'` שהופיע בטסטים לאחר עדכון גרסה של Pillow. הבעיה נבעה מרישום עצל של פורמטי תמונה בגרסאות חדשות של Pillow, וטופלה על ידי אתחול מפורש של רישום הפורמטים לפני שמירת PNG.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת קריאה ל-`Image.init()` בתוך `save_optimized_png` ב-`services/image_generator.py` כדי להבטיח שפורמט PNG רשום לפני ניסיון שמירה.

## 🧪 בדיקות
הטסט `tests/test_image_generator_new_themes_fonts.py::test_generator_supports_new_themes_and_fonts` נכשל עם `KeyError: 'PNG'` לפני השינוי, ועובר בהצלחה אחריו.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: הסיכון נמוך מאוד. השינוי מטפל בהתנהגות ספציפית של ספריית Pillow בגרסאות חדשות ומבטיח תאימות לאחור.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: החזרה לאחור פשוטה על ידי ריוורט של הקומיט. הסיכון נמוך מאוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8163464-89a1-4732-a029-1c6cab76f42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8163464-89a1-4732-a029-1c6cab76f42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Call `Image.init()` in `save_optimized_png` to ensure PNG plugin is registered (Pillow 12+) and prevent `KeyError: 'PNG'` during save.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e71503cda2fd96ee18facfd4b7233f1f333a091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->