### PR TITLE
Monitoring alert suppression

### DIFF
--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -10,7 +10,7 @@ groups:
           summary: "שיעור שגיאות גבוה (>5% בדקה)"
 
       - alert: SlowOperationsP95
-        expr: (histogram_quantile(0.95, rate(operation_latency_seconds_bucket[5m])) > 2) and on(job, instance) (time() - process_start_time_seconds > 300)
+        expr: (histogram_quantile(0.95, rate(operation_latency_seconds_bucket[5m])) > 2) and on(job, instance) (time() - process_start_time_seconds > 300) and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 10m
         labels:
           severity: warning
@@ -41,6 +41,7 @@ groups:
             ) > 1.5
           )
           and on(job, instance) (time() - process_start_time_seconds > 300)
+          and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 15m
         labels:
           severity: warning
@@ -57,6 +58,7 @@ groups:
             ) > 3
           )
           and on(job, instance) (time() - process_start_time_seconds > 300)
+          and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 30m
         labels:
           severity: critical
@@ -66,7 +68,7 @@ groups:
 
       # --- Health & Startup metrics exposed via /healthz ---
       - alert: SlowMongoConnection
-        expr: (min_over_time(health_ping_ms[5m]) > 100) and on(job, instance) (time() - process_start_time_seconds > 300)
+        expr: (min_over_time(health_ping_ms[5m]) > 100) and on(job, instance) (time() - process_start_time_seconds > 300) and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 0m
         labels:
           severity: warning
@@ -86,6 +88,7 @@ groups:
               > avg_over_time(health_ping_ms[30m] offset 6h) * 1.5
           )
           and on(job, instance) (time() - process_start_time_seconds > 300)
+          and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 10m
         labels:
           severity: warning
@@ -95,7 +98,7 @@ groups:
           description: "השוואת חצי שעה אחרונה לעומת חלון זהה עם offset 6h לאחור."
 
       - alert: MongoLatencyPredictiveSpike
-        expr: (predict_linear(health_ping_ms[1h], 10m) > 120) and on(job, instance) (time() - process_start_time_seconds > 300)
+        expr: (predict_linear(health_ping_ms[1h], 10m) > 120) and on(job, instance) (time() - process_start_time_seconds > 300) and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 0m
         labels:
           severity: critical
@@ -121,6 +124,7 @@ groups:
               > predict_linear(health_latency_ewma[2h], 15m) * 1.2
           )
           and on(job, instance) (time() - process_start_time_seconds > 300)
+          and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 10m
         labels:
           severity: warning

--- a/docker/prometheus/prometheus.render.yml
+++ b/docker/prometheus/prometheus.render.yml
@@ -14,6 +14,11 @@ alerting:
             - ${ALERTMANAGER_TARGET}
 
 scrape_configs:
+  # Self-scrape so rules can gate on Prometheus uptime after restarts.
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
   - job_name: 'render-webapp'
     scheme: https
     metrics_path: /metrics

--- a/services/webserver.py
+++ b/services/webserver.py
@@ -1178,7 +1178,6 @@ def create_app() -> web.Application:
 def run(host: str = "0.0.0.0", port: int = 10000) -> None:
     try:
         note_deployment_started("aiohttp service starting up")
-        atexit.register(lambda: note_deployment_shutdown("aiohttp service shutting down"))
     except Exception:
         pass
     app = create_app()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1012,7 +1012,6 @@ try:
     note_deployment_started("webapp service starting up")
 except Exception:
     pass
-atexit.register(lambda: note_deployment_shutdown("webapp service shutting down"))
 
 # --- Search: metrics, limiter (lightweight, optional) ---
 def _no_op(*args, **kwargs):


### PR DESCRIPTION
## ✨ תיאור קצר
ה-PR מטפל בהפחתת רעש והתראות שווא ממערכות הניטור. הוא משתיק התראות פנימיות בזמן עליית השירות, מבטל הודעות כיבוי מיותרות, מנקה את תצוגת ה-UI בטלגרם, ומוסיף תנאי uptime לחוקי Prometheus כדי למנוע התראות שווא לאחר ריסטארט.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם (ניקוי UI)
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [x] DevOps/CI/CD

פירוט נקודות:
- הוספת Gatekeeper ב-`alert_manager.py` למניעת התראות `[CRITICAL] High Latency` פנימיות ב-20 הדקות הראשונות לאחר עלייה (באמצעות `ALERT_STARTUP_GRACE_PERIOD_SECONDS`).
- מחיקת קריאות ל-`note_deployment_shutdown` מ-`webapp/app.py` ו-`services/webserver.py` לביטול הודעות "shutting down".
- הקשחת לוגיקת פורוורדר ההתראות ב-`alert_forwarder.py` כך ששורת ה-`📊 Dashboard` לא תופיע בטקסט בטלגרם (רק ככפתור Inline).
- עדכון חוקי Prometheus ב-`docker/prometheus/alerts.yml` להכללת תנאי `(time() - process_start_time_seconds{job=~".*prometheus.*"} > 600)` למניעת התראות שווא לאחר ריסטארט של Prometheus.
- הוספת self-scrape ל-Prometheus ב-`docker/prometheus/prometheus.render.yml` כדי לאפשר את תנאי ה-uptime.

## 🧪 בדיקות
- הרצת בדיקות יחידה ממוקדות עבור `alert_manager.py` ו-`alert_forwarder.py` – עברו בהצלחה.
- בדיקת Lint על הקבצים ששונו – ללא שגיאות.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs) - **יש לעדכן את `docs/environment-variables.rst` עבור `ALERT_STARTUP_GRACE_PERIOD_SECONDS`**
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על הפחתת רעש והתראות שווא בסביבת פרודקשן. סיכון נמוך לפספוס התראות קריטיות, שכן תנאי ה-uptime מוגבלים ל-Prometheus עצמו וזמן החסד מוגבל ל-20 דקות.

## 🔗 קישורים
- Issues קשורים: (ההודעה המקורית מפרטת את הבעיות)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול ה-PR וחזרה לקומיט הקודם. השינויים הם בעיקר קונפיגורציה וקוד אפליקציה, וניתנים להחזרה בקלות.

---
<a href="https://cursor.com/background-agent?bcId=bc-36dddae7-f5af-4d96-aea3-04384d7c9179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36dddae7-f5af-4d96-aea3-04384d7c9179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses noisy startup alerts, removes Telegram dashboard URL (keeps inline button), and adds Prometheus uptime gating with self-scrape; drops shutdown notifications.
> 
> - **Observability/Alerting**:
>   - `alert_manager.py`: Add startup warmup gate via `ALERT_STARTUP_GRACE_PERIOD_SECONDS` (early-return in `check_and_emit_alerts`); ensure tests bypass warmup in `reset_state_for_tests`.
>   - `alert_forwarder.py`: Telegram messages no longer include dashboard URL in body (inline button only); Slack keeps URL; anomaly batch flush uses `include_dashboard_link=False`.
> - **Prometheus/DevOps**:
>   - `docker/prometheus/alerts.yml`: Add global Prometheus-uptime guard to latency/health rules (extra `and on()` clause) alongside existing service-uptime checks.
>   - `docker/prometheus/prometheus.render.yml`: Add Prometheus self-scrape job `prometheus` to enable uptime gating.
> - **Web services**:
>   - `services/webserver.py`, `webapp/app.py`: Remove `atexit` shutdown notification registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de2f02b3e34971a197f9bfbce15467f28a71c9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->