### PR TITLE
Count column drill-down button

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -2279,11 +2279,10 @@
             </div>
           `;
 
-          // Bind eye button click
-          const eyeBtn = slots.coverage.querySelector('[data-show-sentry-details]');
-          if (eyeBtn) {
-            eyeBtn.addEventListener('click', openMissingRunbooksModal);
-          }
+          // Bind eye button click (support 1+ buttons)
+          slots.coverage.querySelectorAll('[data-show-sentry-details]').forEach((btn) => {
+            btn.addEventListener('click', openMissingRunbooksModal);
+          });
 
           const minEl = document.getElementById('configRadarCoverageMinCount');
           const searchEl = document.getElementById('configRadarCoverageSearch');


### PR DESCRIPTION
## ✨ תיאור קצר
העברנו את כפתור ה-Drill-down ("העין") בטבלת ה-Config Radar מעמודת הכותרת לעמודת ה-Count, כך שהוא ממוקם לוגית וויזואלית לצד המספר אותו הוא מפרט. הוספנו סטיילינג באמצעות Flexbox ליישור נכון.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- העברנו את כפתור ה-Drill-down (`radar-eye-btn`) מהכותרת (`<h4>`) לתא הכמות (`<td>`) עבור שורות מסוג `sentry_issue` בטבלת "Missing Runbooks".
- הוספנו מחלקת CSS חדשה `radar-count-with-eye` לתא הכמות הרלוונטי, המגדירה `display: flex`, `align-items: center` ו-`gap: 8px` ליישור המספר והכפתור.
- הסרנו `margin-right: 0.5rem` מכפתור ה-`radar-eye-btn` כיוון שהמרווח מטופל כעת על ידי `gap`.

## 🧪 בדיקות
- בדקתי ידנית שהכפתור מופיע כעת בתוך עמודת ה-Count, צמוד למספר (לדוגמה: `20 👁️`).
- ודאתי שלחיצה על הכפתור עדיין פותחת את המודל בצורה תקינה.
- בדקתי ששאר הטבלאות והכפתורים לא הושפעו.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שינוי UI קוסמטי בלבד, ללא השפעה מהותית על פרודקשן, ביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback ל-PR זה. השינוי הוא נקודתי בקובץ HTML אחד.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a5f0b33-b193-46de-b9ea-b86380907acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a5f0b33-b193-46de-b9ea-b86380907acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the eye drill-down button from the section header into the `Count` cell for `sentry_issue` rows in "Missing Runbooks" and adds flex styling for proper alignment.
> 
> - **Coverage UI (settings.html)**
>   - Moves the Sentry details eye button from the header to the `Count` cell for `sentry_issue` rows in the "Missing Runbooks" table.
>   - Updates logic: compute `isMissingRunbooksTable` and `hasSentryIssues`; render count cell with number + eye (`.radar-count-with-eye`), and omit the button from the header.
>   - Click binding remains via `[data-show-sentry-details]` to open the modal.
> - **CSS**
>   - Adds `.radar-count-with-eye` (flex, centered, gap) for the count+eye layout.
>   - Removes right margin from `.radar-eye-btn` (spacing now via `gap`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8308e528f79b79341f205e92841c261130407657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->