### PR TITLE
Alert manager always report

### DIFF
--- a/tests/test_flask_alert_manager_fallback.py
+++ b/tests/test_flask_alert_manager_fallback.py
@@ -36,3 +36,28 @@ def test_flask_records_alert_manager_samples_when_metrics_unavailable(monkeypatc
 
     assert calls, "expected alert_manager.note_request to be called at least once"
 
+
+def test_flask_records_alert_manager_samples_when_metrics_available_too(monkeypatch):
+    # Regression guard: even when metrics are available, the Flask middleware
+    # should still feed alert_manager so /triage system|latency have data.
+    app_mod, app = _build_app()
+
+    calls = []
+
+    def _fake_note_request(status_code, duration_seconds, *a, **k):
+        calls.append((int(status_code), float(duration_seconds)))
+
+    monkeypatch.setattr(app_mod, "_METRICS_AVAILABLE", True, raising=False)
+    # Avoid coupling this test to metrics.record_request_outcome behavior
+    monkeypatch.setattr(app_mod, "record_request_outcome", lambda *a, **k: None, raising=False)
+
+    import alert_manager as am
+
+    monkeypatch.setattr(am, "note_request", _fake_note_request, raising=True)
+
+    with app.test_client() as client:
+        resp = client.get("/login")
+        assert resp.status_code in (200, 302)
+
+    assert calls, "expected alert_manager.note_request to be called at least once"
+


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו באג שגרם לדוחות ה-Triage (פקודות `/triage system` ו-`/triage latency`) להישאר ריקים בפרודקשן. הדיווח ל-`alert_manager.note_request` ב-`webapp/app.py` התבצע רק כ-fallback כשמודול ה-metrics לא היה זמין, מה שמנע דיווח בפועל. כעת הדיווח מתבצע תמיד.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הסרת התנאי `if not bool(globals().get("_METRICS_AVAILABLE", False))` סביב הקריאה ל-`alert_manager.note_request` בפונקציה `_metrics_after` ב-`webapp/app.py`.
- הבטחת דיווח קבוע ל-`alert_manager` (לאחר סינון נתיבים סטטיים/בריאות) גם כאשר מודול ה-metrics זמין.
- הוספת בדיקת יחידה חדשה (`test_flask_records_alert_manager_samples_when_metrics_available_too`) כדי למנוע רגרסיה.

## 🧪 בדיקות
- בדיקות יחידה: הוספנו בדיקה חדשה שמוודאת שהדיווח ל-Alert Manager מתבצע גם כאשר מודול ה-metrics זמין. הבדיקה עברה בהצלחה.
- [x] Unit
- [ ] Integration
- [ ] Manual (הבעיה נצפתה ידנית בדוחות Triage)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על יכולות הניטור הפנימיות (פקודות `/triage`). סיכון נמוך, השינוי מבודד לפונקציית הדיווח.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR זה. השינוי מבודד וקל להחזרה.


---
<a href="https://cursor.com/background-agent?bcId=bc-b72f54d2-3cca-433f-ac00-ca2ec8070a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b72f54d2-3cca-433f-ac00-ca2ec8070a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always send Flask request outcomes to `alert_manager.note_request` regardless of metrics availability, and add a regression test.
> 
> - **Backend**:
>   - **Flask middleware**: In `webapp/app.py`, remove `_METRICS_AVAILABLE` guard and always call `alert_manager.note_request` (best-effort `try/except`) after `record_request_outcome`, while keeping static/health path filtering.
> - **Tests**:
>   - Add `test_flask_records_alert_manager_samples_when_metrics_available_too` in `tests/test_flask_alert_manager_fallback.py` to ensure alerts are recorded even when metrics are available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b63d2d87ed8f164b8c9e4c42d6e3400e5e1302f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->