### PR TITLE
Github message response

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -32,7 +32,16 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
 .cm-editor.cm-focused { outline: 2px solid rgba(100,100,255,0.5); }
 .cm-selectionBackground { background-color: rgba(100,100,255,0.3) !important; }
 @media (max-width: 768px){
-  .cm-editor { max-height: 50vh; font-size: 14px; }
+  .codemirror-container {
+    border-radius: 0;
+  }
+  .cm-editor {
+    /* Mobile immersive editor: big enough to feel like an IDE */
+    min-height: 70vh;
+    min-height: 70dvh;
+    max-height: none;
+    font-size: 14px;
+  }
   /* Mobile fix: prevent last lines from being hidden by browser UI / safe-area */
   .cm-editor .cm-scroller {
     padding-bottom: 80px !important;
@@ -41,6 +50,8 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
   #editorContainer textarea[name="code"],
   textarea.code-field,
   .editor-textarea {
+    min-height: 70vh;
+    min-height: 70dvh;
     padding-bottom: 80px !important;
     padding-bottom: calc(80px + env(safe-area-inset-bottom)) !important;
   }

--- a/webapp/static/css/file-editor.css
+++ b/webapp/static/css/file-editor.css
@@ -306,6 +306,39 @@
   }
 }
 
+/* Mobile: maximize screen real-estate for upload/edit editor */
+@media (max-width: 768px) {
+  /* Full width container: reduce side padding to a thin gutter */
+  .main-content .container {
+    max-width: 100% !important;
+    padding-left: 0.25rem !important;
+    padding-right: 0.25rem !important;
+  }
+
+  /* Editor card: edge-to-edge feel */
+  .main-content .glass-card {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    width: 100% !important;
+    padding: 0.25rem !important;
+    border-radius: 0 !important;
+  }
+
+  /* Split view: remove vertical clamp and reduce inner padding */
+  .split-panels {
+    max-height: none !important;
+  }
+
+  .split-view {
+    border-radius: 0 !important;
+  }
+
+  .split-panel--editor,
+  .split-panel--preview {
+    padding: 0.4rem !important;
+  }
+}
+
 /* Fullscreen viewer (created by JS) */
 .markdown-image-fullscreen {
   position: fixed;


### PR DESCRIPTION
## ✨ תיאור קצר
שיפרתי את חווית העריכה במובייל (עד 768px) על ידי הגדלת גובה העורך (CodeMirror) ל־70vh ומתן רוחב כמעט מלא לכרטיס העורך. שינויים אלו נועדו לספק סביבת עבודה נוחה וסוחפת יותר למשתמשים במכשירים ניידים.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
-   **`webapp/static/css/codemirror-custom.css`**:
    -   הגדרת `.cm-editor` ל־`min-height: 70vh` (ו־`70dvh`) וביטול `max-height` תחת `@media (max-width: 768px)`.
    -   הוספת `min-height` דומה ל־`textarea` כ־fallback.
    -   ביטול `border-radius` ל־`.codemirror-container` במובייל.
-   **`webapp/static/css/file-editor.css`**:
    -   הפחתת `padding` צדדי של הקונטיינר הראשי (`.main-content .container`) ל־`0.25rem`.
    -   הסרת שוליים וביטול `border-radius` לכרטיס העורך (`.glass-card`), והגדרתו ל־`width: 100%`.
    -   ביטול `max-height` של `.split-panels` והפחתת `padding` פנימי ב־`.split-panel--editor` ו־`.split-panel--preview`.

## 🧪 בדיקות
-   בדיקה ידנית על מכשיר מובייל (או באמצעות כלי מפתחים בדפדפן) לוודא שהעורך תופס גובה ורוחב מקסימליים, ושאין פגיעה בתצוגת דסקטופ/טאבלט.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
-   השינויים מוגבלים ל־`@media (max-width: 768px)` ולכן הסיכון לפגיעה בתצוגת דסקטופ/טאבלט נמוך מאוד. אין השפעה על ביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
-   במקרה תקלה, ניתן לבצע Rollback על ידי היפוך השינויים בקבצי ה־CSS: `webapp/static/css/codemirror-custom.css` ו־`webapp/static/css/file-editor.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4481dd65-ccab-47fc-a5f8-6551e7bfc5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4481dd65-ccab-47fc-a5f8-6551e7bfc5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maximizes mobile workspace by increasing CodeMirror height and making the file editor edge-to-edge with reduced padding.
> 
> - **CSS (mobile ≤768px)**
>   - **Code editor (`webapp/static/css/codemirror-custom.css`)**:
>     - Set ` .cm-editor` to `min-height: 70vh/70dvh`, remove `max-height`, and use `font-size: 14px`.
>     - Add matching `min-height` to `textarea` fallbacks; keep extra bottom padding on scroller/inputs for safe-area.
>     - Set `.codemirror-container` `border-radius: 0`.
>   - **File editor layout (`webapp/static/css/file-editor.css`)**:
>     - Make `.main-content .container` full-width with thin side gutters.
>     - Make `.glass-card` edge-to-edge (`width: 100%`, no margins, no radius) with smaller padding.
>     - Remove `max-height` clamp on `.split-panels`; set `.split-view` and panels to reduced padding/no radius.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55329d45a80aba7124c50a171dd4de005636db98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->