### PR TITLE
Restore to commit a154841

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -32,16 +32,7 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
 .cm-editor.cm-focused { outline: 2px solid rgba(100,100,255,0.5); }
 .cm-selectionBackground { background-color: rgba(100,100,255,0.3) !important; }
 @media (max-width: 768px){
-  .codemirror-container {
-    border-radius: 0;
-  }
-  .cm-editor {
-    /* Mobile immersive editor: big enough to feel like an IDE */
-    min-height: 70vh;
-    min-height: 70dvh;
-    max-height: none;
-    font-size: 14px;
-  }
+  .cm-editor { max-height: 50vh; font-size: 14px; }
   /* Mobile fix: prevent last lines from being hidden by browser UI / safe-area */
   .cm-editor .cm-scroller {
     padding-bottom: 80px !important;
@@ -50,8 +41,6 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
   #editorContainer textarea[name="code"],
   textarea.code-field,
   .editor-textarea {
-    min-height: 70vh;
-    min-height: 70dvh;
     padding-bottom: 80px !important;
     padding-bottom: calc(80px + env(safe-area-inset-bottom)) !important;
   }

--- a/webapp/static/css/file-editor.css
+++ b/webapp/static/css/file-editor.css
@@ -306,39 +306,6 @@
   }
 }
 
-/* Mobile: maximize screen real-estate for upload/edit editor */
-@media (max-width: 768px) {
-  /* Full width container: reduce side padding to a thin gutter */
-  .main-content .container {
-    max-width: 100% !important;
-    padding-left: 0.25rem !important;
-    padding-right: 0.25rem !important;
-  }
-
-  /* Editor card: edge-to-edge feel */
-  .main-content .glass-card {
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-    width: 100% !important;
-    padding: 0.25rem !important;
-    border-radius: 0 !important;
-  }
-
-  /* Split view: remove vertical clamp and reduce inner padding */
-  .split-panels {
-    max-height: none !important;
-  }
-
-  .split-view {
-    border-radius: 0 !important;
-  }
-
-  .split-panel--editor,
-  .split-panel--preview {
-    padding: 0.4rem !important;
-  }
-}
-
 /* Fullscreen viewer (created by JS) */
 .markdown-image-fullscreen {
   position: fixed;


### PR DESCRIPTION
This PR restores the repository to commit `a1548418bc85c70dbbdae025617030d1664de099` by recreating its tree on top of `main`.

נוצר אוטומטית דרך בוט CodeBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines mobile CSS: trims CodeMirror mobile height/sizing and removes file editor’s edge-to-edge mobile overrides.
> 
> - **CSS (mobile layouts)**:
>   - **CodeMirror** (`webapp/static/css/codemirror-custom.css`): Simplifies mobile editor sizing by setting `.cm-editor` to `max-height: 50vh; font-size: 14px;` and removing immersive min-height and container overrides; retains scroller padding/safe-area fixes.
>   - **File Editor** (`webapp/static/css/file-editor.css`): Removes the mobile `@media (max-width: 768px)` block that forced edge-to-edge container, border-radius resets, and split-view padding/height tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab4c13fa3db1857cbbc038ccd7cf98db1cb0f42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->