### PR TITLE
Github message response

### DIFF
--- a/webapp/static/css/split-view.css
+++ b/webapp/static/css/split-view.css
@@ -493,9 +493,17 @@ html[dir="rtl"] .split-preview-content code {
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
+  /* Mobile UX Polish: "Fixed-Height Card Layout" */
   .split-view {
-    max-height: none;
+    height: 65dvh !important;
+    max-height: 65dvh !important;
+    width: 96% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    /* שמירה על border-radius הקיים (מוגדר כברירת מחדל) */
+    overflow: hidden !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   }
 
   .split-toolbar {
@@ -513,15 +521,108 @@ html[dir="rtl"] .split-preview-content code {
 
   .split-panels {
     flex-direction: column;
+    flex: 1 1 auto;
+    height: 100% !important;
+    min-height: 0 !important; /* קריטי כדי ש-overflow יעבוד בתוך Flex */
+    max-height: none !important;
+    overflow: hidden; /* מונע גלילה כפולה/הארכת דף */
+  }
+
+  /* גם כש-Live Preview כבוי (is-active=false) נשמור Flex כדי לקבל גלילה פנימית */
+  .split-view:not(.is-active) .split-panels {
+    display: flex !important;
+  }
+
+  .split-panel {
+    min-height: 0; /* קריטי ל-Flexbox כדי לאפשר גלילה פנימית */
   }
 
   .split-panel--editor,
   .split-panel--preview {
     padding: 0.65rem;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .split-preview-content {
-    min-height: 220px;
+    height: 100%;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 1rem;
+  }
+
+  /* במובייל אנחנו עובדים עם טאבים, לא עם Resizer */
+  .split-resizer {
+    display: none !important;
+  }
+
+  /* פאנל עורך פעיל: תופס את כל הגובה של הכרטיס */
+  .split-view[data-active-panel="editor"] .split-panel--editor {
+    flex: 1 1 auto;
+    height: 100%;
+  }
+
+  /* עוטף העורך (label + textarea/CodeMirror) */
+  .split-panel--editor #editorContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .split-panel--editor #editorContainer > label {
+    flex: 0 0 auto;
+  }
+
+  /* Codemirror wrapper חייב להיות flex כדי שהעורך ימלא את הגובה */
+  .split-panel--editor .codemirror-container {
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* CodeMirror בתוך הכרטיס: לא להיתקע על min-height דסקטופ, גלילה פנימית */
+  .split-panel--editor .cm-editor {
+    flex: 1 1 auto;
+    height: 100% !important;
+    max-height: none !important;
+    min-height: 0 !important;
+  }
+
+  .split-panel--editor .cm-scroller {
+    height: 100% !important;
+    overflow-y: auto !important;
+  }
+
+  /* fallback textarea editor: גלילה פנימית */
+  .split-panel--editor textarea[name="code"],
+  .split-panel--editor textarea.code-field,
+  .split-panel--editor .editor-textarea {
+    flex: 1 1 auto;
+    min-height: 0 !important;
+    height: 100% !important;
+    overflow: auto !important;
+    resize: none;
+  }
+
+  /* פאנל Preview פעיל: תופס את כל הגובה של הכרטיס */
+  .split-view[data-active-panel="preview"] .split-panel--preview {
+    display: flex !important;
+    flex-direction: column;
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+  }
+
+  /* הקטנת שוליים כלליים בעמודי Upload/Edit (רק כאשר split-view נטען) */
+  .main-content .container {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
   }
 }
 


### PR DESCRIPTION
## ✨ תיאור קצר
מימוש עיצוב "כרטיס" בגובה קבוע (Fixed-Height Card Layout) עבור תצוגת ה־Split View במובייל, כולל גלילה פנימית חלקה בעורך ובפאנל התצוגה המקדימה, והקטנת שוליים צדדיים. זאת כדי לשפר את חווית המשתמש במכשירים ניידים.

## 📦 שינויים עיקריים
- [x] קוד (Frontend - CSS)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הגדרת `split-view` לגובה קבוע של `65dvh`, רוחב `96%` ממורכז, עם `overflow: hidden` וצל עדין ליצירת מראה "כרטיס" במובייל.
- הטמעת גלילה פנימית אמיתית עבור העורך (`.cm-scroller`/`textarea`) ועבור פאנל התצוגה המקדימה (`.split-preview-content`) באמצעות `height: 100%` ו־`overflow: auto`.
- תיקון בעיות גלילה בתצוגה המקדימה במובייל.
- הקטנת padding צדדי ל־`0.5rem` עבור `.main-content .container` בעמודי Upload/Edit במובייל.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual
  - בדיקה ידנית עם תוכן ארוך (כ-3000 שורות) בעורך ובפאנל התצוגה המקדימה.
  - בדיקה של מעבר בין טאבים (עורך/תצוגה מקדימה) במובייל.
  - אימות שהעיצוב נשאר תקין בדסקטופ.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינויים ב־CSS עשויים להשפיע על פריסת אלמנטים במובייל. נבדק שהשינויים לא משפיעים על תצוגת דסקטופ.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לגרסה הקודמת של קובץ ה־CSS `webapp/static/css/split-view.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-43251af3-0412-464a-8c50-e422f3a658a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43251af3-0412-464a-8c50-e422f3a658a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mobile split-view now uses a fixed-height card (65dvh) with tabbed panels and internal scrolling for editor/preview, hides resizer, and tweaks toolbar and container padding.
> 
> - **Frontend (CSS)** in `webapp/static/css/split-view.css`:
>   - **Mobile layout (≤768px)**:
>     - Introduces fixed-height card for `split-view` (`65dvh`, centered, shadow, `overflow: hidden`).
>     - Reworks `.split-panels` to column flex with full-height and constrained overflow; keeps flex even when `.is-active` is absent.
>     - Enables internal scrolling for editor (`.cm-editor`, `.cm-scroller`, textarea fallbacks) and preview (`.split-preview-content`).
>     - Hides `.split-resizer`; active panel (`data-active-panel`) expands to full height.
>     - Adjusts toolbar to vertical stack and shows `.split-tabs`.
>     - Reduces `.main-content .container` horizontal padding on relevant pages.
>   - Media query updated from `max-width: 767px` to `max-width: 768px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34c704fe74ca7fe3219fe505c8a3a9917e1e4e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->