### PR TITLE
Cursor/mobile live preview scrolling issue 2ecf

### DIFF
--- a/webapp/static/css/split-view.css
+++ b/webapp/static/css/split-view.css
@@ -471,8 +471,6 @@ html[dir="rtl"] .split-preview-content code {
   /* ה-canvas הוא אזור התוכן/iframe – הוא צריך "לגדול" לגובה הפנוי */
   flex: 1 1 auto;
   min-height: 160px;
-  /* מאפשר overflow בתוך flex container (במובייל) */
-  min-height: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   /* חשוב: canvas משמש גם לרינדור HTML של Markdown.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes split-view mobile scrolling by restructuring preview layout and updates HTML preview to use clamp-based heights for better viewport behavior.
> 
> - **Split View layout (`webapp/static/css/split-view.css`)**:
>   - Enable reliable internal scrolling in flex containers by adding `min-height: 0` to `split-panel`, `split-panel--preview`, and `split-preview-content`; move scrolling to `split-preview-canvas` with `overflow: auto` and `-webkit-overflow-scrolling: touch`.
>   - Make `split-preview-canvas` flex (`flex: 1 1 auto`) and `display: block`; ensure `iframe` is `display: block` and fills available space.
>   - Mobile: switch panels to column, remove constrained `max-height`, hide resizer and inactive panel via `data-active-panel`, and raise preview canvas min height (`min-height: 45vh`).
> - **HTML Preview page (`webapp/templates/html_preview.html`)**:
>   - Use `height: clamp(...)` for `.preview-container` (desktop and mobile breakpoints) to prevent tiny viewports; keep iframe full-size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41098e324e3eaac6af1b2e7c713cd7656e1bc0d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->