### PR TITLE
Rule engine boolean comparison

### DIFF
--- a/services/rule_engine.py
+++ b/services/rule_engine.py
@@ -558,6 +558,22 @@ class RuleEngine:
             logger.warning(f"Unknown operator: {operator_name}")
             return False
 
+        # 🔧 UI -> Engine: בוליאני יכול להגיע כמחרוזת ("True"/"False")
+        # כדי למנוע השוואה של True מול "True", נמיר את expected_value לבוליאני
+        # אם actual_value הוא בוליאני וה-expected_value מחרוזת.
+        if isinstance(actual_value, bool) and isinstance(expected_value, str):
+            raw_expected = expected_value
+            normalized = raw_expected.strip().lower()
+            if normalized in {"true", "false"}:
+                expected_value = normalized == "true"
+                if verbose:
+                    logger.warning(
+                        "Coerced expected_value to bool -> field '%s': '%s' -> %s",
+                        field_name,
+                        self._safe_value_for_field(field_name, raw_expected),
+                        expected_value,
+                    )
+
         # הערכת התנאי
         try:
             if verbose:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -165,6 +165,18 @@ class TestRuleEngine:
 
         assert any("operator" in e for e in errors)
 
+    def test_boolean_expected_string_is_coerced(self, engine):
+        """ה-UI שולח לפעמים בוליאן כמחרוזת; המנוע צריך לנרמל לפני השוואה."""
+        rule = {
+            "rule_id": "bool_string",
+            "name": "bool string",
+            "enabled": True,
+            "conditions": {"type": "condition", "field": "is_new_error", "operator": "eq", "value": "True"},
+            "actions": [{"type": "send_alert"}],
+        }
+
+        assert engine.evaluate(rule, EvaluationContext(data={"is_new_error": True})).matched is True
+
     def test_empty_groups_evaluation_semantics(self, engine):
         # evaluate() לא קורא validate_rule; לכן אנחנו מכסים את הסמנטיקה של קבוצות ריקות
         and_rule = {


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקון באג במנוע הכללים שבו השוואה בין ערך בוליאני לבין מחרוזת בוליאנית (לדוגמה `True` מול `'True'`) נכשלה.
- הוספנו לוגיקה להמרת מחרוזת בוליאנית לערך בוליאני ב־`_evaluate_condition` והוספנו טסט יחידה לוודא את התיקון.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- ב־`services/rule_engine.py`, בפונקציה `_evaluate_condition`, נוספה לוגיקה שממירה `expected_value` ממחרוזת ל־`bool` אם `actual_value` הוא `bool`.
- ב־`tests/test_rule_engine.py`, נוסף טסט יחידה `test_boolean_expected_string_is_coerced` המאמת את ההתנהגות המתוקנת.

## 🧪 בדיקות
- הרצתי את טסט היחידה החדש באופן ידני (`python -m pytest tests/test_rule_engine.py::TestRuleEngine::test_boolean_expected_string_is_coerced`) והוא עבר בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- סיכון נמוך. התיקון משפיע רק על מקרים ספציפיים של השוואת בוליאנים מול מחרוזות, ומונע באג קיים.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביצוע Rollback לגרסה הקודמת של הקוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-b447f048-7648-4087-817c-4bd7e5681bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b447f048-7648-4087-817c-4bd7e5681bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix**
> 
> - In `services/rule_engine.py` (`_evaluate_condition`), normalize string boolean `expected_value` ("True"/"False") to real `bool` when `actual_value` is `bool`, with verbose log of coercion.
> 
> **Tests**
> 
> - Add `test_boolean_expected_string_is_coerced` in `tests/test_rule_engine.py` validating correct comparison of `bool` vs string boolean.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f343caaba9ee4ed37d9d89d30d9cea358baf2a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->