### PR TITLE
Github message context response

### DIFF
--- a/webapp/static/css/file-editor.css
+++ b/webapp/static/css/file-editor.css
@@ -1,17 +1,15 @@
 /* Shared styles for Upload/Edit file forms (no inline CSS in templates) */
 
-/* Prevent RTL/mobile overflow caused by width:100% + padding/border */
-form[data-file-form-config],
-form[data-file-form-config] *,
-form[data-file-form-config] *::before,
-form[data-file-form-config] *::after {
+/* Edit form only: prevent RTL/mobile overflow caused by width:100% + padding/border */
+form.file-edit-form,
+form.file-edit-form *,
+form.file-edit-form *::before,
+form.file-edit-form *::after {
   box-sizing: border-box;
 }
 
 .form-field {
   width: 100%;
-  max-width: 100%;
-  min-width: 0;
   padding: 0.75rem;
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -101,8 +99,6 @@ form[data-file-form-config] *::after {
 
 .source-url-input {
   width: 100%;
-  max-width: 100%;
-  min-width: 0;
   padding: 0.75rem;
   border-radius: 10px;
   border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.25));
@@ -175,12 +171,22 @@ form[data-file-form-config] *::after {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  min-width: 0;
 }
 
 .filename-input-wrapper .form-field {
   width: auto;
   flex: 1 1 auto;
+}
+
+/* Edit form only: allow flex children to shrink without overflow */
+form.file-edit-form .form-field,
+form.file-edit-form .source-url-input {
+  max-width: 100%;
+  min-width: 0;
+}
+
+form.file-edit-form .filename-input-wrapper,
+form.file-edit-form .filename-input-wrapper .form-field {
   min-width: 0;
 }
 
@@ -205,12 +211,12 @@ form[data-file-form-config] *::after {
   }
 
   /* Allow the Source URL toggle text to wrap on small screens */
-  .source-url-toggle {
+  form.file-edit-form .source-url-toggle {
     flex-wrap: wrap;
     max-width: 100%;
   }
 
-  .source-url-toggle__text {
+  form.file-edit-form .source-url-toggle__text {
     min-width: 0;
     overflow-wrap: anywhere;
   }

--- a/webapp/templates/edit_file.html
+++ b/webapp/templates/edit_file.html
@@ -40,6 +40,7 @@
   } %}
 
   <form id="editForm"
+        class="file-edit-form"
         method="post"
         enctype="multipart/form-data"
         data-file-form-config='{{ ffm_config | tojson }}'


### PR DESCRIPTION
<h3>What</h3>
<ul>
  <li>תיקון חריגת רוחב (Overflow) במובייל במסך <strong>עריכת קובץ</strong> (RTL), כך שכל השדות, תיבת הקוד ו־Live Preview נשארים בתוך גבולות הכרטיס.</li>
  <li>שיפור רספונסיביות לשורת הפעולות (שמור/ביטול) במובייל – מעבר לעמודה ברוחב מלא.</li>
</ul>
 
<h3>Why</h3>
<ul>
  <li>במובייל, שילוב של <code>width: 100%</code> יחד עם <code>padding/border</code> (ולפעמים ילדים בתוך Flex) יכול לגרום לרוחב בפועל גדול מהקונטיינר ולהוביל לגלישה לצד שמאל ב־RTL.</li>
  <li>הפתרון הוגבל ספציפית לטופס העריכה כדי לא להשפיע על מסך העלאה.</li>
</ul>
 
<h3>How</h3>
<ul>
  <li>הוספת <code>box-sizing: border-box</code> רק ל-<code>form.file-edit-form</code> ולצאצאים שלו.</li>
  <li>הוספת <code>min-width: 0</code> באזורים רגישים בתוך Flex (למשל שורת שם הקובץ) כדי לאפשר כיווץ במקום גלישה.</li>
  <li>החלפת inline style במחלקה ייעודית לפעולות כדי לשלוט בהתנהגות במובייל.</li>
</ul>
 
<h3>Tests</h3>
<ul>
  <li>בדיקה ידנית במובייל: מסך עריכת קובץ (RTL) – אין גלישה של שדות/Preview/קוד, והכפתורים נערמים בצורה תקינה.</li>
</ul>


---
<a href="https://cursor.com/background-agent?bcId=bc-44cd3829-c4e1-4119-83c8-da67ef304d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44cd3829-c4e1-4119-83c8-da67ef304d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves mobile/RTL usability of the file edit/upload forms and standardizes the actions row layout.
> 
> - Apply `box-sizing: border-box` to `form[data-file-form-config]` and all descendants to avoid width+padding overflow
> - Ensure inputs can shrink within flex by adding `max-width: 100%`/`min-width: 0` to `.form-field`, `.source-url-input`, and `.filename-input-wrapper`
> - Add responsive `.file-form-actions` (stacks full-width buttons under 767px) and update `edit_file.html` to use it instead of inline flex styling
> - Allow Source URL toggle text to wrap on small screens for better layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d9961ed48c0a9b6d385597668babebe11ce9b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->