### PR TITLE
Github message context response

### DIFF
--- a/services/github_issue_action.py
+++ b/services/github_issue_action.py
@@ -253,7 +253,15 @@ class GitHubIssueAction:
 """
 
         # בחירת תבנית ברירת המחדל בהתאם לסוג המידע
-        if "sentry_permalink" in alert_data:
+        # חשוב: "in alert_data" בודק רק קיום מפתח, לא ערך. נעדיף בדיקה דפנסיבית.
+        sentry_permalink = alert_data.get("sentry_permalink")
+        has_sentry_permalink = (
+            bool(sentry_permalink.strip())
+            if isinstance(sentry_permalink, str)
+            else bool(sentry_permalink)
+        )
+
+        if has_sentry_permalink:
             default_template = sentry_template
         else:
             default_template = generic_template

--- a/tests/test_github_issue_action.py
+++ b/tests/test_github_issue_action.py
@@ -94,6 +94,28 @@ class TestGitHubIssueAction:
         assert "https://sentry.example.com/issues/123" in body
         assert "TypeError: NoneType is not iterable" in body
 
+    def test_build_issue_body_sentry_permalink_empty_falls_back_to_generic(self, action, sample_action_config):
+        triggered = ["is_new_error eq true"]
+        alert = {
+            "sentry_permalink": "",  # קיים אבל ריק → לא לבחור תבנית Sentry
+            "alert_type": "error",
+            "service_name": "api-gateway",
+            "environment": "production",
+            "error_message": "Connection refused",
+            "error_signature": "abc123def456",
+            "stack_trace": "Traceback...",
+            "error_rate": 0.05,
+            "latency_avg_ms": 200,
+            "occurrence_count": 1,
+            "rule_name": "Test Rule",
+        }
+
+        body = action._build_issue_body(sample_action_config, alert, triggered)
+
+        assert "sentry_issue" not in body
+        assert "Connection refused" in body
+        assert "[👉 צפייה בשגיאה המקורית ב-Sentry]" not in body
+
     @pytest.mark.asyncio
     async def test_execute_creates_issue(self, action, sample_action_config, sample_alert):
         with patch("aiohttp.ClientSession") as mock_session:


### PR DESCRIPTION
## ✨ תיאור קצר
עדכנו את הפונקציה `_build_issue_body` ב־`services/github_issue_action.py` כך שתבחר אוטומטית תבנית ייעודית להתראות Sentry כאשר קיים `sentry_permalink`. שינוי זה נועד לספק תיאורי Issue מפורטים ורלוונטיים יותר ב-GitHub עבור שגיאות Sentry, כולל קישור ישיר לשגיאה המקורית.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הוספת תבנית Markdown חדשה ומפורטת עבור התראות Sentry בתוך `_build_issue_body`.
- הטמעת לוגיקה לבחירה דינמית בין תבנית Sentry לתבנית גנרית, תוך שמירה על עדיפות ל־`body_template` שהוגדר ידנית.
- הוספת בדיקת יחידה חדשה ב־`tests/test_github_issue_action.py` לוודא שהתבנית של Sentry נבחרת כראוי ומכילה את הנתונים הרלוונטיים.

## 🧪 בדיקות
- הוספנו בדיקת יחידה חדשה שמוודאת את בחירת התבנית של Sentry ואת תקינות הפלט שלה. כל הבדיקות הקיימות והחדשות עברו בהצלחה.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- אין השפעות צפויות על פרודקשן, ביצועים או אבטחה. השינוי הוא תוספתי וקונדיציונלי, ומשפר את הפונקציונליות הקיימת מבלי לשנות את התנהגות ברירת המחדל עבור התראות שאינן מסנטרי.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback על ידי החזרת ה-PR. השינוי מבודד לפונקציה אחת ולבדיקה חדשה, מה שהופך את תהליך ההחזרה לאחור לפשוט.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0af7af5-2301-4a1a-b8f0-dee505f99a30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0af7af5-2301-4a1a-b8f0-dee505f99a30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an auto-selected Sentry issue body while preserving existing behavior and overrides.
> 
> - Adds a Sentry-specific Markdown body template in `services/github_issue_action.py` and selects it when `alert_data` contains `sentry_permalink`; otherwise uses the generic template. A user-provided `body_template` still takes precedence.
> - Continues to include `triggered_conditions_list` and `timestamp` in the rendered body; output length is still guarded.
> - Adds unit tests in `tests/test_github_issue_action.py` validating Sentry template selection and ensuring core execution paths remain intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92f78d6b2dd2b2f68e69f56671af5a1446ab49b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->