### PR TITLE
Observability dashboard data

### DIFF
--- a/internal_alerts.py
+++ b/internal_alerts.py
@@ -478,10 +478,13 @@ def emit_internal_alert(name: str, severity: str = "info", summary: str = "", **
             "summary": str(summary),
         }
         if details_payload:
-            rec["details"] = {
-                k: (str(v) if not isinstance(v, (int, float, bool)) else v)
-                for k, v in details_payload.items()
-            }
+            def _coerce_detail_value(v: Any) -> Any:
+                # חשוב: לא להפוך dict/list למחרוזות — זה שובר את תצוגת ה-Observability.
+                if v is None or isinstance(v, (dict, list, int, float, bool)):
+                    return v
+                return str(v)
+
+            rec["details"] = {k: _coerce_detail_value(v) for k, v in details_payload.items()}
         _ALERTS.append(rec)
         is_drill = _is_drill(details_payload)
         if internal_alerts_total is not None:


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-43c7c507-8b94-443f-9ba6-f8b175316435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43c7c507-8b94-443f-9ba6-f8b175316435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves alert detail handling to retain structured data for dashboards and storage.
> 
> - internal_alerts: when recording `details`, keep `dict`/`list`/primitives as-is and only stringify non-primitive values to avoid breaking Observability rendering
> - monitoring/alerts_storage: refactors `_sanitize_details` recursion to treat `dict`/`list`/`tuple` specially with cycle protection; at depth limit, return empty containers instead of stringifying; converts tuples to lists for Mongo compatibility and defers generic string fallback until after container handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a13001fbd70646f091282aec338be4e54667e2ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->