### PR TITLE
Alert system data integrity

### DIFF
--- a/monitoring/alerts_storage.py
+++ b/monitoring/alerts_storage.py
@@ -377,9 +377,13 @@ def compute_error_signature(error_data: Dict[str, Any]) -> str:
                         v = d.get(k)
                         if v not in (None, ""):
                             try:
-                                return str(v).strip()
+                                stripped = str(v).strip()
+                                # חשוב: אם הערך הוא whitespace בלבד, אל תעצור את החיפוש.
+                                if stripped:
+                                    return stripped
                             except Exception:
-                                return ""
+                                # אם ההמרה נכשלת, נמשיך למפתח הבא (fail-open)
+                                continue
                 except Exception:
                     continue
             # Recurse into a small allowlist of common nesting keys to avoid scanning huge dicts.

--- a/tests/test_alerts_storage_error_signature_enrichment.py
+++ b/tests/test_alerts_storage_error_signature_enrichment.py
@@ -135,6 +135,14 @@ def test_compute_error_signature_finds_sentry_issue_id_inside_error_data():
     assert len(sig) == 16
 
 
+def test_compute_error_signature_ignores_whitespace_sentry_issue_id_and_falls_back_to_issue_id():
+    from monitoring.alerts_storage import compute_error_signature
+
+    sig = compute_error_signature({"error_data": {"sentry_issue_id": "   ", "issue_id": "12345"}})
+    assert sig
+    assert len(sig) == 16
+
+
 def test_enrich_alert_with_signature_does_not_trust_is_new_error_without_hash(monkeypatch):
     """
     הגנה מפני payloads שמגיעים עם is_new_error=True מראש (למשל sentry_polling),


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-fd60299d-3d87-47e2-962d-7f9c35bce86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd60299d-3d87-47e2-962d-7f9c35bce86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens error signature stability and enrichment logic for alerts.
> 
> - `compute_error_signature`: Adds deep search for `sentry_issue_id` (supports nested under `error_data/details/metadata/...`) and uses it first when present.
> - `enrich_alert_with_signature`: Treats existing `is_new_error` as authoritative only if an existing `error_signature_hash` is present; otherwise consults `is_new_error(signature)`; maintains non-destructive updates and cleans empty fields when no signal.
> - `record_alert`: Calls `enrich_alert_with_signature` on raw `details` before `_sanitize_details` to avoid losing nested structure needed for signature.
> - Tests: New cases cover nested Sentry ID detection, not trusting `is_new_error` without a hash, and existing behaviors around sanitization and idempotency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcccc723289015f9e96125a142c966d2215d3a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->