### PR TITLE
Push api route change

### DIFF
--- a/webapp/push_api.py
+++ b/webapp/push_api.py
@@ -1060,12 +1060,13 @@ def cleanup_subscriptions():
         return jsonify({"ok": False, "error": "Cleanup failed"}), 500
 
 
-@push_bp.route("/subscriptions/delete-all", methods=["DELETE"])
+@push_bp.route("/subscriptions/delete-all", methods=["DELETE", "GET"])
 @require_auth
 def delete_all_subscriptions():
     """Delete ALL push subscriptions for current user.
     
     Use this to completely reset and re-register fresh.
+    Note: GET method temporarily enabled to allow mobile browser access.
     """
     try:
         user_id = _session_user_id()


### PR DESCRIPTION
## ✨ תיאור קצר
הפכנו את הראוט `/api/push/subscriptions/delete-all` לזמין גם בבקשות GET (בנוסף ל-DELETE) באופן זמני. זה מאפשר למשתמש לנקות מנויים ישירות מהדפדפן בנייד, כפי שביקש.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `GET` לרשימת המטודות המותרות בראוט `/api/push/subscriptions/delete-all`.
- הוספת הערה בקוד המציינת שהשינוי הוא זמני ומאפשר גישה מדפדפן נייד.

## 🧪 בדיקות
- המשתמש יבדוק ידנית על ידי כניסה לכתובת ה-URL מהדפדפן בנייד.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג (פתרון זמני לבעיה נקודתית של משתמש)
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (בדיקה ידנית נדרשת)
- [x] תיעוד עודכן (הערה בקוד)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **אבטחה:** באופן זמני, פעולת מחיקה זמינה דרך בקשת GET. פעולות מחיקה אינן מומלצות ב-GET.
- **שימוש:** המשתמש חייב להיות מחובר (עם סשן פעיל) כדי שהפעולה תצליח, עקב בדיקת `@require_auth`.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן להחזיר את הראוט לקבל רק בקשות DELETE על ידי הסרת "GET" מהרשימה.

---
<a href="https://cursor.com/background-agent?bcId=bc-634470fb-a50b-42ef-baad-d219e66bf182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-634470fb-a50b-42ef-baad-d219e66bf182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily broadens access to reset push subscriptions from mobile browsers.
> 
> - `GET` added alongside `DELETE` for `GET/DELETE /api/push/subscriptions/delete-all`
> - Docstring updated to note temporary GET enablement; no other logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fdb325ec17ac88cbc91f8f7c2cfe2ec8ed89bd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->