### PR TITLE
Review and fix background jobs monitor guide

### DIFF
--- a/GUIDES/BACKGROUND_JOBS_MONITOR_GUIDE.md
+++ b/GUIDES/BACKGROUND_JOBS_MONITOR_GUIDE.md
@@ -326,6 +326,12 @@ from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
+
+class JobAlreadyRunningError(Exception):
+    """נזרק כאשר מנסים להפעיל Job שכבר רץ"""
+    pass
+
+
 class JobTracker:
     """מעקב אחרי הרצות Jobs"""
     
@@ -380,14 +386,9 @@ class JobTracker:
             emit_event("job_started", severity="info", job_id=job_id, run_id=run.run_id)
         except Exception:
             pass
-        
+
         return run
 
-
-class JobAlreadyRunningError(Exception):
-    """נזרק כאשר מנסים להפעיל Job שכבר רץ"""
-    pass
-    
     def update_progress(
         self,
         run_id: str,


### PR DESCRIPTION
Move the exception class definition outside of JobTracker.start_run() and place it before the JobTracker class. This fixes a critical indentation bug where update_progress, add_log, complete_run and other methods were incorrectly nested inside the Exception class.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the `services/job_tracker.py` code sample in the guide to fix an indentation/structure issue.
> 
> - Move `JobAlreadyRunningError` to top-level (above `JobTracker`) and remove the duplicate/inline definition
> - Ensure `start_run()` cleanly returns `run` and is not mis-indented
> 
> These changes prevent methods like `update_progress` from being inadvertently nested and clarify the sample’s intended API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25e9dc03fa64490d3a4d614a6517e78b0658197. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->