### PR TITLE
UI and playground integration fixes

### DIFF
--- a/webapp/static/css/code-tools.css
+++ b/webapp/static/css/code-tools.css
@@ -299,6 +299,46 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
+.code-tools-container .panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.code-tools-container .panel-header-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.85rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-primary, #ffffff);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.code-tools-container .panel-header-actions .btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.code-tools-container .panel-header-actions .btn.copied {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.code-tools-container .panel-header-actions .copy-icon {
+  font-size: 1rem;
+}
+
+@media (max-width: 600px) {
+  .code-tools-container .panel-header-actions .copy-text {
+    display: none;
+  }
+}
+
 .code-tools-container .panel-title {
   font-weight: 700;
 }

--- a/webapp/static/js/code-tools-page.js
+++ b/webapp/static/js/code-tools-page.js
@@ -365,6 +365,34 @@
     btnFormat?.addEventListener('click', runFormat);
     btnLint?.addEventListener('click', runLint);
 
+    // Copy output to clipboard
+    const btnCopy = document.getElementById('btn-copy-output');
+    btnCopy?.addEventListener('click', async () => {
+      const code = getDoc(outputEditor);
+      if (!code.trim()) {
+        showStatus('אין קוד להעתקה', 'warning');
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(code);
+        btnCopy.classList.add('copied');
+        const iconEl = btnCopy.querySelector('.copy-icon');
+        const textEl = btnCopy.querySelector('.copy-text');
+        if (iconEl) iconEl.textContent = '✓';
+        if (textEl) textEl.textContent = 'הועתק!';
+        showStatus('הקוד הועתק ללוח', 'success');
+
+        setTimeout(() => {
+          btnCopy.classList.remove('copied');
+          if (iconEl) iconEl.textContent = '📋';
+          if (textEl) textEl.textContent = 'העתק';
+        }, 2000);
+      } catch (e) {
+        showStatus('לא הצלחנו להעתיק', 'error');
+      }
+    });
+
     document.querySelectorAll('.dropdown-item[data-level]').forEach((btn) => {
       btn.addEventListener('click', () => runFix(btn.dataset.level));
     });

--- a/webapp/static/js/code-tools.js
+++ b/webapp/static/js/code-tools.js
@@ -49,12 +49,14 @@ const CodeToolsIntegration = {
    * הצגת/הסתרת כלים לפי שפה
    */
   updateToolsVisibility() {
-    const language = this.languageSelect?.value || 'text';
+    const rawLanguage = this.languageSelect?.value || 'text';
+    const language = String(rawLanguage).toLowerCase().trim();
     const toolsGroup = document.querySelector('.code-tools-group');
 
     if (toolsGroup) {
-      // כרגע תומכים רק ב-Python
-      toolsGroup.style.display = language === 'python' ? 'flex' : 'none';
+      // כרגע תומכים רק ב-Python (case-insensitive)
+      const isPython = language === 'python' || language === 'py';
+      toolsGroup.style.display = isPython ? 'flex' : 'none';
     }
   },
 

--- a/webapp/templates/code_tools.html
+++ b/webapp/templates/code_tools.html
@@ -59,6 +59,12 @@
     <div class="panel output-panel">
       <div class="panel-header">
         <span class="panel-title">תוצאה</span>
+        <div class="panel-header-actions">
+          <button id="btn-copy-output" class="btn btn-sm btn-outline" title="העתק תוצאה">
+            <span class="copy-icon">📋</span>
+            <span class="copy-text">העתק</span>
+          </button>
+        </div>
         <div class="view-toggle">
           <button class="view-btn active" data-view="code">קוד</button>
           <button class="view-btn" data-view="diff">Diff</button>


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו מספר פערים בממשק המשתמש לאחר הדיפלוי: הופעלו כפתורי העיצוב (Formatting) בעורך הקבצים הראשי, נוסף כפתור "העתק" נוח לדף ה-Playground, וקישור הגישה המהירה ל-Playground מהעורך נהיה גלוי.

## 📦 שינויים עיקריים
- [x] קוד (Backend) - *הערה: השינויים הם בעיקר Frontend/JS/CSS/HTML, אך נופלים תחת קטגוריית "קוד" כללית.*
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- **תיקון הצגת כפתורי Code Tools בעורך:** שינינו את לוגיקת בדיקת השפה ב-`webapp/static/js/code-tools.js` להשוואה case-insensitive (תומך ב-"python", "Python", "py") כדי להבטיח שהכלים יוצגו כראוי.
- **הוספת כפתור "העתק" ב-Playground:**
    - הוספנו כפתור "העתק" ל-`webapp/templates/code_tools.html` בפאנל התוצאה.
    - הוספנו עיצוב מתאים ב-`webapp/static/css/code-tools.css`, כולל התאמה למובייל ואפקט חזותי להעתקה מוצלחת.
    - הטמענו את לוגיקת ההעתקה ללוח ב-`webapp/static/js/code-tools-page.js` באמצעות `navigator.clipboard.writeText()`.
- **הצגת קישור ל-Playground מהעורך:** הקישור היה קיים אך מוסתר; תיקון הצגת כפתורי ה-Code Tools (הסעיף הראשון) פתר גם את בעיה זו.

## 🧪 בדיקות
- בוצעו בדיקות ידניות בממשק המשתמש לוודא:
    - כפתורי העיצוב מופיעים בעורך עבור קבצי Python.
    - כפתור "העתק" מופיע ב-Playground, מעתיק את התוכן ללוח ומציג משוב ויזואלי.
    - הקישור ל-Playground נגיש ומוביל לדף הנכון.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינויים אלו הם בעיקרם צד לקוח (Frontend) ואינם צפויים להשפיע באופן מהותי על ביצועי השרת או אבטחה. הסיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לגרסה הקודמת של הקבצים שנערכו. השינויים הם נקודתיים ואינם משפיעים על מבנה הנתונים או לוגיקת השרת.

---
<a href="https://cursor.com/background-agent?bcId=bc-45d97cee-edf1-425c-a7bd-564a8eb46292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45d97cee-edf1-425c-a7bd-564a8eb46292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves usability of the Code Tools and Playground.
> 
> - Update `code-tools.js` to normalize language and show tools when language is `python` or `py` (case-insensitive)
> - Add a "Copy" action in `code_tools.html` output panel; implement clipboard copy/feedback in `code-tools-page.js` (success state, auto-reset)
> - Add styles in `code-tools.css` for `panel-header-actions`, button states, and responsive hiding of copy text on small screens
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5322f82d4bfad12a652ce5f690d649138bb9c3f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->