### PR TITLE
Code tools visibility fix

### DIFF
--- a/webapp/static/css/code-tools.css
+++ b/webapp/static/css/code-tools.css
@@ -4,7 +4,7 @@
 
 /* ---------- Toolbar integration (edit_file.html) ---------- */
 .code-tools-group {
-  display: flex;
+  display: flex !important;
   align-items: center;
   gap: 0.4rem;
   flex-wrap: wrap;

--- a/webapp/static/js/code-tools.js
+++ b/webapp/static/js/code-tools.js
@@ -57,6 +57,9 @@ const CodeToolsIntegration = {
 
     // דיבאג: הדפסת השפה שזוהתה
     console.log('[CodeToolsIntegration] updateToolsVisibility - detected language:', language);
+    
+    // 🔔 דיבאג ויזואלי למובייל - הסר את השורה הזו לאחר הבדיקה!
+    alert('JS Debug: Language detected: ' + language + '\nToolsGroup found: ' + (toolsGroup ? 'YES' : 'NO'));
 
     if (toolsGroup) {
       // כרגע תומכים רק ב-Python (case-insensitive)


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון בעיה שבה כפתורי ה-Code Tools לא הופיעו בעורך הקבצים. השינוי מבטיח שהכפתורים גלויים כברירת מחדל ב-CSS, וה-JavaScript מסתיר אותם רק אם השפה אינה פייתון, מה שמגביר את אמינות התצוגה. נוספו גם הודעות דיבאג לקונסול.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
-   **היפוך לוגיקת נראות ב-JS**: במקום לחשוף כפתורים עבור פייתון, ה-JS כעת מסתיר אותם רק אם השפה *אינה* פייתון. אם השפה היא פייתון, ה-inline `display` מוסר כדי לאפשר ל-CSS לקבוע את התצוגה (`display: flex`).
-   **הוספת הודעות דיבאג**: נוספו `console.log` לפונקציה `updateToolsVisibility` המציגות את השפה שזוהתה ואת מצב הנראות של הכפתורים, כולל אזהרה אם האלמנט `.code-tools-group` לא נמצא.
-   **הנחת עבודה**: ה-CSS עבור `.code-tools-group` כבר אינו מכיל `display: none`, כך שהכפתורים גלויים כברירת מחדל.

## 🧪 בדיקות
הבדיקה בוצעה ידנית בדפדפן.
- [ ] Unit
- [ ] Integration
- [x] Manual

**תיאור בדיקה ידנית**:
1.  פתח את עורך הקבצים עם קובץ פייתון.
2.  ודא שכפתורי ה-Code Tools מופיעים.
3.  פתח את קונסול המפתחים (F12) וודא שהודעות הדיבאג מופיעות ומציגות את השפה הנכונה ("python") ואת מצב הנראות ("visible").
4.  פתח את עורך הקבצים עם קובץ שאינו פייתון (לדוגמה, `txt`).
5.  ודא שכפתורי ה-Code Tools אינם מופיעים.
6.  ודא שהודעות הדיבאג מציגות את השפה הנכונה ואת מצב הנראות ("hidden").

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקה ידנית)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
-   **השפעה חיובית**: שיפור אמינות הצגת כפתורי ה-Code Tools וחווית המשתמש.
-   **סיכון נמוך**: השינוי בלוגיקת ה-JS הוא קטן וממוקד, וכולל מנגנון גיבוי (גלוי כברירת מחדל).

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
-   תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback פשוט על ידי היפוך הקומיט הנוכחי.

---
<a href="https://cursor.com/background-agent?bcId=bc-f066e305-4311-491a-a4d4-4ce510e96757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f066e305-4311-491a-a4d4-4ce510e96757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of Code Tools display by inverting visibility logic and adding diagnostics.
> 
> - In `code-tools.js` `updateToolsVisibility`, buttons are now shown by default; `display: none` is applied only when language isn’t `python`/`py`, and inline `display` is removed for Python to defer to CSS
> - Adds `console.log` for detected language and visibility state, and a `console.warn` when `.code-tools-group` is missing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f131dba527425a0df9fd9e81e32aaa7c2247b13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->