### PR TITLE
Code tools button placement

### DIFF
--- a/webapp/static/css/code-tools.css
+++ b/webapp/static/css/code-tools.css
@@ -4,10 +4,11 @@
 
 /* ---------- Toolbar integration (edit_file.html) ---------- */
 .code-tools-group {
-  display: flex !important;
+  display: flex;
   align-items: center;
   gap: 0.4rem;
   flex-wrap: wrap;
+  margin-bottom: 0.75rem;
 }
 
 .code-tools-group .btn {

--- a/webapp/static/js/code-tools.js
+++ b/webapp/static/js/code-tools.js
@@ -57,9 +57,6 @@ const CodeToolsIntegration = {
 
     // דיבאג: הדפסת השפה שזוהתה
     console.log('[CodeToolsIntegration] updateToolsVisibility - detected language:', language);
-    
-    // 🔔 דיבאג ויזואלי למובייל - הסר את השורה הזו לאחר הבדיקה!
-    alert('JS Debug: Language detected: ' + language + '\nToolsGroup found: ' + (toolsGroup ? 'YES' : 'NO'));
 
     if (toolsGroup) {
       // כרגע תומכים רק ב-Python (case-insensitive)

--- a/webapp/templates/edit_file.html
+++ b/webapp/templates/edit_file.html
@@ -84,6 +84,38 @@
       <label>תגיות</label>
       <input type="text" name="tags" value="{{ file.tags | join(', ') }}" placeholder="#utils, #repo:owner/name" class="form-field">
     </div>
+    <!-- Code Tools toolbar - מחוץ ל-split-toolbar כדי להיות גלוי תמיד -->
+    <div class="code-tools-group" data-show-for-language="python">
+      <button type="button" class="btn btn-sm btn-outline" id="btn-format-code" title="עיצוב קוד (Ctrl+Shift+F)">
+        <i class="fas fa-magic"></i>
+        עיצוב
+      </button>
+      <button type="button" class="btn btn-sm btn-outline" id="btn-lint-code" title="בדיקת איכות (Ctrl+Shift+L)">
+        <i class="fas fa-check-circle"></i>
+        Lint
+      </button>
+      <div class="dropdown">
+        <button type="button" class="btn btn-sm btn-outline dropdown-toggle" id="btn-auto-fix">
+          <i class="fas fa-wrench"></i>
+          תיקון
+        </button>
+        <div class="dropdown-menu">
+          <button class="dropdown-item" data-level="safe">🛡️ בטוח (whitespace)</button>
+          <button class="dropdown-item" data-level="cautious">⚠️ זהיר (+imports)</button>
+          <button class="dropdown-item" data-level="aggressive">🔥 אגרסיבי (מלא)</button>
+        </div>
+      </div>
+      <a
+        href="/tools/code"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-sm btn-outline-secondary"
+        title="🪄 Playground"
+      >
+        <i class="fas fa-external-link-alt"></i>
+        Playground
+      </a>
+    </div>
     <div id="livePreviewRoot" class="split-view" data-active-panel="editor">
       <div class="split-toolbar">
         <div class="split-toolbar-controls">
@@ -97,38 +129,6 @@
             <span class="split-toggle__text">Live Preview</span>
           </button>
           <span class="split-toolbar-hint">Ctrl+Shift+Enter</span>
-        </div>
-        <!-- הוסף ל-split-toolbar -->
-        <div class="code-tools-group" data-show-for-language="python">
-          <button type="button" class="btn btn-sm btn-outline" id="btn-format-code" title="עיצוב קוד (Ctrl+Shift+F)">
-            <i class="fas fa-magic"></i>
-            עיצוב
-          </button>
-          <button type="button" class="btn btn-sm btn-outline" id="btn-lint-code" title="בדיקת איכות (Ctrl+Shift+L)">
-            <i class="fas fa-check-circle"></i>
-            Lint
-          </button>
-          <div class="dropdown">
-            <button type="button" class="btn btn-sm btn-outline dropdown-toggle" id="btn-auto-fix">
-              <i class="fas fa-wrench"></i>
-              תיקון
-            </button>
-            <div class="dropdown-menu">
-              <button class="dropdown-item" data-level="safe">🛡️ בטוח (whitespace)</button>
-              <button class="dropdown-item" data-level="cautious">⚠️ זהיר (+imports)</button>
-              <button class="dropdown-item" data-level="aggressive">🔥 אגרסיבי (מלא)</button>
-            </div>
-          </div>
-          <a
-            href="/tools/code"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn btn-sm btn-outline-secondary"
-            title="🪄 Playground"
-          >
-            <i class="fas fa-external-link-alt"></i>
-            Playground
-          </a>
         </div>
         <div class="split-tabs" role="tablist" aria-label="חלונות תצוגה">
           <button type="button" role="tab" aria-selected="true" data-panel-target="editor">עורך</button>


### PR DESCRIPTION
## ✨ תיאור קצר
כפתורי ה-Code Tools לא הופיעו בקבצי פייתון מכיוון שהוצבו בטעות בתוך ה-`split-toolbar`, שמוסתר בקבצים אלו. העברתי את הכפתורים למיקום גלוי תמיד, וניקיתי קוד דיבאג ו-CSS מיותר.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- `webapp/templates/edit_file.html`: העברת ה-`div` של `.code-tools-group` מתוך ה-`split-toolbar` למיקום עצמאי מעל `#livePreviewRoot`.
- `webapp/static/js/code-tools.js`: הסרת ה-`alert` של הדיבאג.
- `webapp/static/css/code-tools.css`: הסרת ה-`!important` מה-`display: flex` והוספת `margin-bottom` לריווח.

## 🧪 בדיקות
- בדקתי ידנית את הופעת כפתורי ה-Code Tools בקבצי פייתון בעורך, ואישרתי שהם גלויים ופועלים כצפוי.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש בקבצי פייתון. סיכון נמוך מאוד, השינוי הוא בעיקר ארגוני ב-HTML וניקוי קוד.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ריוורט ה-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc61d016-fa08-4acd-84a1-4d7740883b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc61d016-fa08-4acd-84a1-4d7740883b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes Code Tools visible in the editor for Python files and cleans minor debug/CSS.
> 
> - Moves `code-tools-group` in `edit_file.html` to a standalone section above `#livePreviewRoot` (outside `split-toolbar`) so it’s always rendered
> - JS (`code-tools.js`): removes debug `alert`, keeps console logs, and ensures tools are shown only for Python by clearing inline `display` when applicable
> - CSS (`code-tools.css`): removes `!important` from `display: flex` and adds `margin-bottom` for spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b441da1a76239787afbfb9c975505ae9251eca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->