### PR TITLE
Autoflake integration for code cleaning

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -22,6 +22,7 @@ safety>=3.0.0
 ruff
 pip-audit
 pre-commit>=3.6.0
+autoflake>=2.3.0  # Deep cleaning - unused imports & variables removal
 
 # Build tools for local/dev
 poetry-core>=1.0.0

--- a/tests/test_code_formatter_service.py
+++ b/tests/test_code_formatter_service.py
@@ -161,6 +161,46 @@ class TestAutoFix:
 
             ast.parse(result.fixed_code)
 
+    @pytest.mark.skipif(not CodeFormatterService().is_tool_available("autoflake"), reason="autoflake not available")
+    def test_autoflake_removes_unused_imports(self, service):
+        """בדיקה ש-autoflake מסיר imports לא בשימוש."""
+        code_with_unused_import = """import os
+import sys
+
+def hello():
+    print("Hello world")
+"""
+        result = service.auto_fix(code_with_unused_import, level="cautious")
+
+        assert result.success
+        # וודא ש-imports שלא בשימוש הוסרו
+        assert "import os" not in result.fixed_code
+        assert "import sys" not in result.fixed_code
+        # וודא שהפונקציה נשארה
+        assert "def hello" in result.fixed_code
+        assert "Hello world" in result.fixed_code
+
+    @pytest.mark.skipif(not CodeFormatterService().is_tool_available("autoflake"), reason="autoflake not available")
+    def test_autoflake_removes_unused_variables(self, service):
+        """בדיקה ש-autoflake מסיר משתנים לא בשימוש."""
+        code_with_unused_var = """def process():
+    unused_var = 42
+    result = 10
+    return result
+"""
+        result = service.auto_fix(code_with_unused_var, level="cautious")
+
+        assert result.success
+        # וודא שמשתנה לא בשימוש הוסר
+        assert "unused_var" not in result.fixed_code
+        # וודא שמשתנים בשימוש נשארו
+        assert "result" in result.fixed_code
+
+    def test_autoflake_tool_availability(self, service):
+        """בדיקה שכלי autoflake מופיע ברשימת הכלים."""
+        tools = service.get_available_tools()
+        assert "autoflake" in tools
+
 
 class TestDiff:
     """בדיקות diff."""


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו אינטגרציה לכלי `autoflake` לשירות עיצוב הקוד. כעת, בנוסף לתיקוני עיצוב (Black/isort), המערכת תבצע "ניקוי עמוק" על ידי הסרת imports ומשתנים שאינם בשימוש, מה שישפר את ציון איכות הקוד.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [x] DevOps/CI/CD

פירוט נקודות:
- הוספת `autoflake` לקובץ `requirements/development.txt`.
- עדכון `services/code_formatter_service.py`:
    - הוספת `autoflake` לרשימת הכלים הנתמכים.
    - הוספת מתודה חדשה `_run_autoflake` לביצוע ניקוי עמוק.
    - עדכון פונקציית `auto_fix` להפעלת `autoflake` **לפני** `isort` ו-`black` ברמות `cautious` ו-`aggressive`.
- הוספת בדיקות יחידה חדשות ב-`tests/test_code_formatter_service.py` עבור `autoflake` (הסרת imports ומשתנים לא בשימוש, ובדיקת זמינות הכלי).

## 🧪 בדיקות
כל הבדיקות הקיימות עברו בהצלחה. נוספו בדיקות יחידה ספציפיות ל-autoflake שגם הן עברו בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual (בדיקה ידנית של הפונקציונליות בוצעה במהלך הפיתוח)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
הסיכון נמוך. `autoflake` מופעל רק כחלק מתהליך התיקון האוטומטי (ברמות `cautious` ו-`aggressive`), והוא נועד להסיר קוד מת בלבד. במקרה של תקלה, ניתן לבטל את השינוי או להשבית את הכלי.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
    - [המדריך המקורי](https://github.com/amirbiron/CodeBot/blob/288b681b41e77210a56b423b72d11b0d767c0ab0/FEATURE_SUGGESTIONS/IMPLEMENTATION_GUIDE_1.1_1.2.md)
    - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
במקרה תקלה, ניתן לבצע rollback לגרסה הקודמת של הקוד. השינויים הם בעיקר הוספת כלי ותלות, כך שהחזרה לאחור פשוטה יחסית.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a879ef2-11d5-4ca9-9cf5-d679b971bac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a879ef2-11d5-4ca9-9cf5-d679b971bac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces deep-cleaning via `autoflake` and updates the Python formatting pipeline order for safer import handling.
> 
> - Adds `autoflake` to `requirements/development.txt`
> - Detects `autoflake` in `_check_tools_availability()` and exposes via `get_available_tools()`
> - New `_run_autoflake` to remove unused imports/variables and duplicate dict keys (stdin-based, isolated env)
> - Updates `auto_fix` sequence: `autopep8` → `autoflake` (cautious/aggressive) → `isort` → `black` (aggressive); warns but continues on `autoflake` failures
> - Tests: skip-if-absent unit tests for removing unused imports/variables and tool availability in `tests/test_code_formatter_service.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27c431125d794b4bfed1bec70d7f6fc2152393dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->