### PR TITLE
App latency warning disable

### DIFF
--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -113,6 +113,11 @@ groups:
             health_latency_ewma
               > predict_linear(health_latency_ewma[2h], 15m) * 1.2
           )
+          # Require enough traffic so the EWMA trend is meaningful.
+          # Without this, low-traffic services may get noisy false positives.
+          and on(job, instance) (
+            sum by (job, instance) (increase(http_requests_total[2h])) > 200
+          )
           and on(job, instance) (time() - process_start_time_seconds > 300)
           and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
         for: 10m

--- a/docs/alerts.rst
+++ b/docs/alerts.rst
@@ -144,6 +144,9 @@
          health_latency_ewma
            > predict_linear(health_latency_ewma[2h], 15m) * 1.2
        )
+       and on(job, instance) (
+         sum by (job, instance) (increase(http_requests_total[2h])) > 200
+       )
        and on(job, instance) (time() - process_start_time_seconds > 300)
      for: 10m
      labels:


### PR DESCRIPTION
## ✨ תיאור קצר
שיניתי את חוק ההתראה `AppLatencyEWMARegression` ב-Prometheus כך שיפעל רק כאשר יש מספיק תעבורה בשירות. זה נועד להפחית רעש (false positives) משירותים עם מעט נתונים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת תנאי ל-`AppLatencyEWMARegression` ב-`docker/prometheus/alerts.yml` המחייב `sum by (job, instance) (increase(http_requests_total[2h])) > 200` כדי שההתראה תידלק.
- עדכון התיעוד ב-`docs/alerts.rst` כדי לשקף את השינוי בחוק ההתראה.

## 🧪 בדיקות
- בדקתי את תקינות קובץ ה-Prometheus rules (באופן לוגי).
- הרצתי את בדיקות ה-Unit של הפרויקט (`pytest`) לאחר התקנת התלויות, והן עברו בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [x] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית: הפחתת התראות שווא (false positives) משירותים עם תעבורה נמוכה.
- סיכון נמוך: ההתראה עדיין תפעל כרגיל בשירותים עם תעבורה מספקת.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור: ביטול השינויים בקבצים `docker/prometheus/alerts.yml` ו-`docs/alerts.rst`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7854641-d710-4c96-9d2d-1e2a43f3dc59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7854641-d710-4c96-9d2d-1e2a43f3dc59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a traffic gate to reduce false positives for the EWMA-based app latency alert.
> 
> - Update `docker/prometheus/alerts.yml`: `AppLatencyEWMARegression` now requires `sum by (job, instance) (increase(http_requests_total[2h])) > 200` (with comments) before comparing `health_latency_ewma` to `predict_linear(...)`
> - Update `docs/alerts.rst`: reflect the same condition in the documented rule
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42f03bc2a4246c08eefe6bd0cf541987369c24d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->