### PR TITLE
Admin feature visibility control

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1407,6 +1407,8 @@ def inject_globals():
         'ui_font_scale': font_scale,
         'ui_theme': theme,
         'custom_theme': custom_theme,
+        # הרשאות
+        'user_is_admin': user_is_admin,
         # Feature flags
         'announcement_enabled': WEEKLY_TIP_ENABLED,
         'weekly_tip_enabled': WEEKLY_TIP_ENABLED,
@@ -7818,7 +7820,7 @@ def compare_files_page():
 
 
 @app.route('/tools/code')
-@login_required
+@admin_required
 def code_tools_page():
     """דף ייעודי לכלי קוד (Playground) עם Diff מקצועי."""
     return render_template('code_tools.html')

--- a/webapp/templates/components/editor_components.html
+++ b/webapp/templates/components/editor_components.html
@@ -1,7 +1,8 @@
 {# רכיבי עורך משותפים ל-Upload/Edit #}
 
-{% macro code_tools_toolbar() %}
+{% macro code_tools_toolbar(user_is_admin=False) %}
 {# Code Tools toolbar - Format, Lint, Fix, Playground #}
+{% if user_is_admin %}
 <div class="code-tools-group" data-show-for-language="python">
   <button
     type="button"
@@ -53,10 +54,12 @@
     Playground
   </a>
 </div>
+{% endif %}
 {% endmacro %}
 
-{% macro code_tools_modal() %}
+{% macro code_tools_modal(user_is_admin=False) %}
 {# Bootstrap Modals for Code Tools (results + fix options) #}
+{% if user_is_admin %}
 <div class="modal fade" id="codeToolsModal" tabindex="-1" aria-labelledby="codeToolsModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
     <div class="modal-content">
@@ -73,6 +76,7 @@
     </div>
   </div>
 </div>
+{% endif %}
 {% endmacro %}
 
 {% macro image_uploader(existing_images=[]) %}

--- a/webapp/templates/edit_file.html
+++ b/webapp/templates/edit_file.html
@@ -8,7 +8,9 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/split-view.css') }}?v={{ static_version }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/md_preview.bundle.css') }}?v={{ static_version }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/file-editor.css') }}?v={{ static_version }}">
+{% if user_is_admin %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/code-tools.css') }}?v={{ static_version }}">
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -85,7 +87,7 @@
       <input type="text" name="tags" value="{{ file.tags | join(', ') }}" placeholder="#utils, #repo:owner/name" class="form-field">
     </div>
     <!-- Code Tools toolbar (shared macro) -->
-    {{ code_tools_toolbar() }}
+    {{ code_tools_toolbar(user_is_admin=user_is_admin) }}
     <div id="livePreviewRoot" class="split-view" data-active-panel="editor">
       <div class="split-toolbar">
         <div class="split-toolbar-controls">
@@ -160,10 +162,12 @@
 </div>
 
 <!-- Code Tools Bootstrap Modal (shared macro) -->
-{{ code_tools_modal() }}
+{{ code_tools_modal(user_is_admin=user_is_admin) }}
 {% endblock %}
 {% block extra_js %}
+{% if user_is_admin %}
 <script src="{{ url_for('static', filename='js/code-tools.js') }}?v={{ static_version }}" defer></script>
+{% endif %}
 <script src="{{ url_for('static', filename='js/file-form-manager.js') }}?v={{ static_version }}" defer></script>
 <script src="{{ url_for('static', filename='js/md_preview.bundle.js') }}?v={{ static_version }}" defer></script>
 <script src="{{ url_for('static', filename='js/live-preview.js') }}?v={{ static_version }}" defer></script>

--- a/webapp/templates/upload.html
+++ b/webapp/templates/upload.html
@@ -8,7 +8,9 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/split-view.css') }}?v={{ static_version }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/md_preview.bundle.css') }}?v={{ static_version }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/file-editor.css') }}?v={{ static_version }}">
+{% if user_is_admin %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/code-tools.css') }}?v={{ static_version }}">
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -85,7 +87,7 @@
       <input type="text" name="tags" placeholder="#utils, #repo:owner/name" value="{{ tags_value or '' }}" class="form-field">
     </div>
     <!-- Code Tools toolbar (shared macro) -->
-    {{ code_tools_toolbar() }}
+    {{ code_tools_toolbar(user_is_admin=user_is_admin) }}
     <div id="livePreviewRoot" class="split-view" data-active-panel="editor">
       <div class="split-toolbar">
         <div class="split-toolbar-controls">
@@ -170,10 +172,12 @@
   </form>
 </div>
 <!-- Code Tools Bootstrap Modal (shared macro) -->
-{{ code_tools_modal() }}
+{{ code_tools_modal(user_is_admin=user_is_admin) }}
 {% endblock %}
 {% block extra_js %}
+{% if user_is_admin %}
 <script src="{{ url_for('static', filename='js/code-tools.js') }}?v={{ static_version }}" defer></script>
+{% endif %}
 <script src="{{ url_for('static', filename='js/file-form-manager.js') }}?v={{ static_version }}" defer></script>
 <script src="{{ url_for('static', filename='js/upload-page.js') }}?v={{ static_version }}" defer></script>
 <script src="{{ url_for('static', filename='js/md_preview.bundle.js') }}?v={{ static_version }}" defer></script>


### PR DESCRIPTION
## ✨ תיאור קצר
הפיצ'ר "Code Tools" (כלי עריכת קוד, כולל כפתורי העורך, עמוד ה-Playground וה-API שמאחוריהם) הוגבל למשתמשי אדמין בלבד. שינוי זה מבטיח שרק משתמשים מורשים יוכלו לגשת ולעשות שימוש בכלים אלו, הן ברמת ה-UI והן ברמת השרת.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/) - *הגדרת אדמינים נשארת לפי `ADMIN_USER_IDS`*
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- **חסימת שרת (Backend)**: כל נקודות הקצה תחת `/api/code/*` מחזירות `403 Forbidden` למשתמשים שאינם אדמין (ו-`401 Unauthorized` אם אינם מחוברים).
- **חסימת עמוד (Frontend/Backend)**: עמוד ה-Playground (`/tools/code`) מוגן כעת עם `admin_required`, כך שרק אדמינים יכולים לגשת אליו.
- **הסתרת UI (Frontend)**: כפתורי ה-Format/Lint/Fix, המודל של כלי הקוד וטעינת קבצי ה-CSS/JS הרלוונטיים מופיעים/נטענים בדפי העריכה וההעלאה (`edit_file.html`, `upload.html`) רק אם המשתמש הוא אדמין.
- **הזרקת משתנה גלובלי**: המשתנה `user_is_admin` מוזרק כעת ל-Jinja Templates כדי לאפשר לוגיקת תצוגה מותנית ב-UI.

## 🧪 בדיקות
- **Manual**:
  - נבדק עם משתמש אדמין: כל כלי הקוד (כפתורים, מודל, עמוד Playground) נגישים ופועלים כצפוי.
  - נבדק עם משתמש רגיל (לא אדמין):
    - כפתורי כלי הקוד אינם מוצגים בדפי העריכה/העלאה.
    - ניסיון גישה ישירה ל-`/tools/code` מחזיר `403 Forbidden`.
    - ניסיון קריאה ל-API של כלי הקוד (לדוגמה, `/api/code/format`) מחזיר `403 Forbidden`.
    - ניסיון גישה ללא התחברות מחזיר `401 Unauthorized`.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (הגבלת גישה היא פיצ'ר אבטחה/הרשאות)
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (Manual)
- [ ] תיעוד עודכן (README/Docs) - *הגדרת אדמינים נשארת לפי `ADMIN_USER_IDS`*
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **השפעה אפשרית על פרודקשן, ביצועים, או אבטחה**:
  - **אבטחה**: שיפור אבטחה על ידי הגבלת גישה לכלי קוד פוטנציאליים למשתמשי אדמין בלבד.
  - **ביצועים**: השפעה זניחה, בעיקר מניעת טעינת קבצי JS/CSS ורכיבי UI למשתמשים לא אדמינים.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לגרסה הקודמת של הקוד. השינויים ממוקדים ואינם משפיעים על פונקציונליות ליבה אחרת.

---
<a href="https://cursor.com/background-agent?bcId=bc-39f978eb-32e0-4ba8-bf47-52cce4677045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39f978eb-32e0-4ba8-bf47-52cce4677045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Admin-gates Code Tools across backend and UI**
> 
> - Server: Protects `/api/code/*` via `before_request` (checks `session.user_id` against `ADMIN_USER_IDS`) and secures `/tools/code` with `@admin_required`.
> - Templates: Injects `user_is_admin` into context and updates editor macros to render `code_tools_toolbar`/modal only for admins.
> - Pages: `edit_file.html` and `upload.html` load `code-tools.css`/`code-tools.js` and show controls only when `user_is_admin` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2c22188f52f9608ce4047937c48d3944619505b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->