### PR TITLE
Telegram message not modified

### DIFF
--- a/database/manager.py
+++ b/database/manager.py
@@ -794,6 +794,12 @@ class DatabaseManager:
     def get_selected_repo(self, user_id: int) -> Optional[str]:
         return self._get_repo().get_selected_repo(user_id)
 
+    def save_selected_folder(self, user_id: int, folder_path: Optional[str]) -> bool:
+        return self._get_repo().save_selected_folder(user_id, folder_path)
+
+    def get_selected_folder(self, user_id: int) -> Optional[str]:
+        return self._get_repo().get_selected_folder(user_id)
+
     def save_user(self, user_id: int, username: Optional[str] = None) -> bool:
         return self._get_repo().save_user(user_id, username)
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import functools
 import inspect
 import logging
 import asyncio
+import warnings
 from typing import Any, Optional, TypedDict
 try:
     from typing import NotRequired  # type: ignore[attr-defined]
@@ -24,6 +25,10 @@ except ImportError:  # pragma: no cover
                 return item
         NotRequired = _NotRequiredShim  # type: ignore[misc,assignment]
 from datetime import datetime
+
+# הפחתת רעש בלוגים: DeprecationWarnings ספרייתיים (למשל httplib2/pyparsing)
+# לא משפיע על התנהגות ריצה, רק על פלט אזהרות.
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"httplib2\.auth")
 
 import signal
 import socket

--- a/src/infrastructure/composition/files_facade.py
+++ b/src/infrastructure/composition/files_facade.py
@@ -203,6 +203,26 @@ class FilesFacade:
         except Exception:
             return None
 
+    def save_selected_folder(self, user_id: int, folder_path: Optional[str]) -> bool:
+        try:
+            db = self._get_db()
+            fn = getattr(db, "save_selected_folder", None)
+            if callable(fn):
+                return bool(fn(user_id, folder_path))
+        except Exception:
+            return False
+        return False
+
+    def get_selected_folder(self, user_id: int) -> Optional[str]:
+        try:
+            db = self._get_db()
+            fn = getattr(db, "get_selected_folder", None)
+            if callable(fn):
+                return fn(user_id)
+        except Exception:
+            return None
+        return None
+
     def get_github_token(self, user_id: int) -> Optional[str]:
         try:
             db = self._get_db()


### PR DESCRIPTION
## ✨ תיאור קצר
תיקונים לבעיות שדווחו במנגנוני גיבוי/שחזור ודפדפן הריפו בטלגרם. התיקונים כוללים שמירה עקבית של תיקיית יעד, שחזור גיבויים למיקום הנכון בריפו, מניעת שגיאות "Message is not modified" בלחיצות חוזרות, וסינון אזהרות מיותרות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [x] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- **שמירת תיקיית יעד:** נוספה יכולת לשמור ולטעון תיקיית יעד נבחרת (`selected_folder`) למסד הנתונים דרך ה-`FilesFacade`, מה שמבטיח שהבחירה נשמרת בין סשנים.
- **שחזור גיבויים:** שופרה לוגיקת שחזור מגיבויים שמורים לריפו, כך שהגיבויים נפרסים לתיקייה המקורית ממנה נוצרו (אם קיימת), ולא תמיד לשורש הריפו. נוספה הצגת נתיב הגיבוי בתפריט.
- **מניעת שגיאות UI:** הוטמע שימוש ב-`TelegramUtils.safe_edit_message_text` וב-`query.answer()` ב-`show_repo_browser` כדי למנוע שגיאות "BadRequest: Message is not modified" בלחיצות חוזרות על אלמנטים זהים.
- **סינון אזהרות:** נוסף פילטר ל-`DeprecationWarning` מ-`httplib2.auth` כדי להפחית רעש בלוגים.

## 🧪 בדיקות
- **Manual**:
    - נבדקה שמירה וטעינה של תיקיית יעד נבחרת (root ותיקיית משנה).
    - נבדק שחזור גיבוי שנוצר מתיקיית משנה - הקבצים שוחזרו לתיקייה הנכונה.
    - נבדק שחזור גיבוי שנוצר מ-root - הקבצים שוחזרו ל-root.
    - נבדקה לחיצה כפולה על שם תיקייה בדפדפן הריפו - לא נזרקה שגיאת "Message is not modified".
    - נבדק שה-DeprecationWarnings לא מופיעים בלוגים.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על חווית המשתמש במנגנוני גיבוי/שחזור ודפדפן הריפו.
- סיכון נמוך: השינויים במנגנון השחזור נבדקו ידנית, אך תמיד קיים סיכון קטן לשחזור שגוי במקרים קצה.

## 🔗 קישורים
- Issues קשורים: #85256315 (Sentry ID)
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע rollback לגרסה הקודמת. השינויים במסד הנתונים (הוספת `selected_folder`) הם אופציונליים ואינם שוברים תאימות לאחור.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d545a6b-8bd9-4e10-9c63-abae58fd8473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d545a6b-8bd9-4e10-9c63-abae58fd8473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances GitHub repo interactions, backup restore accuracy, and Telegram UI robustness.
> 
> - Adds `selected_folder` persistence: DB repo + manager + `FilesFacade` with normalization, load/save in `GitHubMenuHandler` across flows
> - Backup restore: display backup path in menus and restore ZIPs to original repo prefix via `restore_zip_file_to_repo(dest_prefix)`
> - Telegram UI: use `query.answer()` and `TelegramUtils.safe_edit_message_text` in `show_repo_browser` to prevent "Message is not modified" errors
> - Minor: early `query.answer()` to reduce stale queries, suppress `DeprecationWarning` from `httplib2.auth` in `main.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aae708c1f28351ea08345a0d256303918e986b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->