### PR TITLE
Dashboard alert id fallback

### DIFF
--- a/services/observability_dashboard.py
+++ b/services/observability_dashboard.py
@@ -1417,8 +1417,10 @@ def fetch_alerts(
     except Exception:
         tags_map = {}
     for alert in alerts:
-        uid = alert.get("alert_uid")
-        alert["tags"] = tags_map.get(uid, []) if uid else []
+        # FIX: Use the same fallback logic as storage to match the ID
+        raw_uid = alert.get("alert_uid") or alert.get("uid") or alert.get("id") or alert.get("_id")
+        uid_str = str(raw_uid or "").strip()
+        alert["tags"] = tags_map.get(uid_str, [])
 
     alert_uids = [alert.get("alert_uid") for alert in alerts if alert.get("alert_uid")]
     if alert_uids:

--- a/tests/test_observability_dashboard_tags_merge.py
+++ b/tests/test_observability_dashboard_tags_merge.py
@@ -1,0 +1,70 @@
+import importlib
+
+
+def test_fetch_alerts_tags_map_uid_fallback_stringifies_id(monkeypatch):
+    """
+    בדיקה ממוקדת: ה-UI מחפש תגיות במפה לפי מפתח str.
+
+    בפועל, לפעמים מגיעים מזהים מסוג int/ObjectId וכו'. לכן אנחנו מוודאים
+    שהמיזוג בדשבורד ממיר ל-str (כמו ב-storage) לפני ה-lookup.
+    """
+    svc = importlib.import_module("services.observability_dashboard")
+
+    # avoid cache affecting assertions
+    monkeypatch.setattr(svc, "_cache_get", lambda *_a, **_k: None, raising=True)
+    monkeypatch.setattr(svc, "_cache_set", lambda *_a, **_k: None, raising=True)
+
+    # provide one alert with a non-string ID
+    def _fake_fetch_alerts(**_kwargs):
+        return (
+            [
+                {
+                    "id": 123,
+                    "timestamp": "2025-01-01T00:00:00Z",
+                    "name": "CPU High",
+                    "summary": "demo",
+                    "alert_type": "cpu_high",
+                    "severity": "critical",
+                }
+            ],
+            1,
+        )
+
+    monkeypatch.setattr(svc.alerts_storage, "fetch_alerts", _fake_fetch_alerts, raising=True)
+    monkeypatch.setattr(svc, "_fallback_alerts", lambda **_k: ([], 0), raising=True)
+
+    # force a non-string alert_uid to simulate upstream variability
+    monkeypatch.setattr(svc, "_build_alert_uid", lambda alert: alert.get("id"), raising=True)
+
+    # keep fetch_alerts lightweight
+    monkeypatch.setattr(svc, "get_quick_fix_actions", lambda *_a, **_k: [], raising=True)
+    monkeypatch.setattr(svc, "_describe_alert_graph", lambda *_a, **_k: None, raising=True)
+    monkeypatch.setattr(
+        svc.incident_story_storage,
+        "get_stories_by_alert_uids",
+        lambda _uids: {},
+        raising=True,
+    )
+
+    # tags map keys are strings (as produced by storage)
+    monkeypatch.setattr(
+        svc.alert_tags_storage,
+        "get_tags_map_for_alerts",
+        lambda _alerts: {"123": ["tag-a"]},
+        raising=True,
+    )
+
+    payload = svc.fetch_alerts(
+        start_dt=None,
+        end_dt=None,
+        severity=None,
+        alert_type=None,
+        endpoint=None,
+        search=None,
+        page=1,
+        per_page=50,
+    )
+
+    assert payload["total"] == 1
+    assert payload["alerts"][0]["tags"] == ["tag-a"]
+


### PR DESCRIPTION
## ✨ תיאור קצר
עדכנו את `services/observability_dashboard.py` כך שישתמש בלוגיקת Fallback עקבית למזהי התראות (UID) בעת שליפת תגיות מהמפה. שינוי זה מבטיח שהתגיות יוצגו נכון ב-Dashboard, גם כאשר מזהה ההתראה מגיע בפורמטים שונים (למשל, `int` במקום `str`) או משדות שונים (`uid`, `id`, `_id`).

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עדכון הפונקציה `fetch_alerts` ב-`services/observability_dashboard.py` לשימוש בלוגיקת Fallback זהה ל-`alert_tags_storage` עבור מזהי התראות (`alert_uid` / `uid` / `id` / `_id`) ונירמול ל-`str().strip()` לפני שליפה ממפת התגיות.
- הוספת בדיקת יחידה חדשה ב-`tests/test_observability_dashboard_tags_merge.py` המאמתת שהמיזוג עובד גם כאשר מזהה ההתראה אינו מחרוזת.

## 🧪 בדיקות
- בדיקת יחידה חדשה `test_fetch_alerts_tags_map_uid_fallback_stringifies_id` נוספה ועוברת.
- בדיקות יחידה קיימות ב-`test_alert_tags_storage` רצו ועברו.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: סיכון נמוך. השינוי משפר את אמינות הצגת התגיות ב-Dashboard ואינו צפוי להשפיע לרעה על ביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-87994f3f-e231-4862-9b52-c7917109d4b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87994f3f-e231-4862-9b52-c7917109d4b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures alert tags render reliably by aligning dashboard UID lookup with storage behavior.
> 
> - In `fetch_alerts`, derive `uid_str` from `alert_uid`/`uid`/`id`/`_id` and `str().strip()` before `tags_map` lookup
> - Adds `tests/test_observability_dashboard_tags_merge.py` to verify stringification and fallback ID matching
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4785b6ec5b8b52e0d56db9841f65193a0bdd02a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->