### PR TITLE
Large files feature bugs

### DIFF
--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -224,7 +224,7 @@
             {% elif category_filter == 'favorites' %}
             | קטגוריה: מועדפים
             {% elif category_filter == 'large' %}
-            | קטגוריה: קבצים גדולים (מעל 100KB)
+            | קטגוריה: קבצים גדולים
             {% elif category_filter == 'recent' %}
             | קטגוריה: נפתחו לאחרונה
             {% elif category_filter == 'other' %}

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -744,6 +744,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
 
     <div class="file-actions" data-file-actions>
         <div class="file-actions__list" data-actions-list>
+            {% if not file.is_large %}
             <button id="favoriteBtn"
                     class="btn btn-secondary btn-icon"
                     data-overflow-id="favorite"
@@ -763,6 +764,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
                 <i class="fas fa-edit"></i>
                 ערוך
             </a>
+            {% endif %}
             <button onclick="copyCode()" class="btn btn-primary btn-icon copy-button"
                     data-overflow-id="copy"
                     data-overflow-priority="3"
@@ -832,6 +834,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
                         <span>🔗 למקור{% if file.source_url_host %} ({{ file.source_url_host }}){% endif %}</span>
                     </button>
                     {% endif %}
+                    {% if not file.is_large %}
                     <button type="button"
                             class="file-actions__menu-item"
                             data-menu-action="compare"
@@ -844,6 +847,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
                     <button type="button" class="file-actions__menu-item danger" data-menu-action="trash">
                         <span>🗑️ העבר לסל</span>
                     </button>
+                    {% endif %}
                 </div>
                 <div class="file-actions__menu-divider" data-dynamic-divider hidden></div>
                 <div class="file-actions__menu-section" data-dynamic-actions></div>


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון שגיאת "File must be non-empty" בהורדה/צפייה של קבצים גדולים בבוט, ויישור הגדרת "קבצים גדולים" בין הבוט ל-WebApp. בנוסף, שופרה חווית המשתמש ב-WebApp עבור קבצים גדולים על ידי הסתרת פעולות לא רלוונטיות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [x] מסד נתונים/מיגרציות (שינוי לוגיקת שליפה)
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- **בוט טלגרם:** בפעולות "הורד" ו"צפה בקובץ" עבור קבצים גדולים, מתבצעת כעת שליפה מפורשת של תוכן הקובץ המלא מה-DB (במקום להסתמך על קאש חלקי), ונוספה הודעת שגיאה ידידותית אם התוכן עדיין ריק.
- **WebApp:** קטגוריית "קבצים גדולים" (`/files?category=large`) מציגה כעת קבצים מאוסף `large_files` (בדומה לבוט), במקום לסנן קבצים מעל 100KB מתוך `code_snippets`.
- **WebApp:** הופעלו יכולות צפייה, הורדה ותצוגה מקדימה (preview/html/md) עבור קבצים מהאוסף `large_files`.
- **WebApp:** בעמוד צפייה בקובץ (`view_file`), פעולות שאינן רלוונטיות לקבצים גדולים (כמו מועדפים, עריכה, היסטוריה, השוואת גרסאות, העברה לסל) הוסתרו.
- **Backend:** פונקציות שליפת קבצים (למשל `_get_user_any_file_by_id`) עודכנו לתמוך בשליפה הן מ`code_snippets` והן מ`large_files`.

## 🧪 בדיקות
- **בוט:** נבדק תפריט "קבצים גדולים", הורדה וצפייה בקובץ `FEATURE_REMINDERS.md` עבדו בהצלחה בניסיון הראשון.
- **WebApp:** נבדק עמוד `/files?category=large`, הרשימה תואמת לבוט, ופעולות צפייה/הורדה/תצוגה מקדימה עובדות על קבצים גדולים.
- **WebApp:** נבדק עמוד `view_file` עבור קובץ גדול, ופעולות לא רלוונטיות הוסתרו.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (יישור הגדרת קבצים גדולים ב-WebApp ותמיכה בפעולות)
- [x] fix: תיקון באג (שגיאת "File must be non-empty" בבוט)
- [ ] docs: שינוי תיעוד בלבד
- [x] refactor: שינוי קוד ללא שינוי התנהגות (שינויים ב-`_get_user_any_file_by_id` ובשליפת תוכן)
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה חיובית על חווית המשתמש בבוט וב-WebApp. סיכון נמוך, השינויים מתמקדים בשליפת נתונים וב-UI.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
חזרה לגרסה קודמת של הקוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3719b7b-d8d6-4aa1-bd84-013cf22da973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3719b7b-d8d6-4aa1-bd84-013cf22da973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns large-file behavior across bot and webapp and fixes empty-content errors.
> 
> - **Bot (Telegram):** Add `_fetch_full_large_file_content` to retrieve full content/ language from DB with ownership checks; use it in `view_large_file` and `download_large_file` with clear error messages and proper `BytesIO` handling.
> - **WebApp (backend):** New `_get_user_any_file_by_id` to fetch by ID from `code_snippets` or `large_files`; applied in `view_file`, `file_preview`, `download_file`, `html_preview`, `raw_html`, `md_preview`. Content access now prefers `code` or `content`; ETag computed from either.
> - **Files listing:** Category `large` now queries the `large_files` collection (with fallback to size filter); language distinct aligned for `large`.
> - **View page UX:** For large files, suppress version, favorites, edit, history, compare, and trash actions; templates updated (`files.html`, `view_file.html`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61cec4306aa9a5d90d08e33ea93ef9f11cfea4a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->