### PR TITLE
Advanced view theme alignment

### DIFF
--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -971,7 +971,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
         <div id="codeBasicContainer">
             {{ highlighted_code|safe }}
         </div>
-        <div id="codeMirrorContainer" hidden aria-label="תצוגת קוד מתקדמת"></div>
+        <div id="codeMirrorContainer" class="codemirror-container" hidden aria-label="תצוגת קוד מתקדמת"></div>
     </div>
     {% if raw_code is defined %}
     <textarea id="rawCode" style="position: absolute; left: -9999px; height: 0; opacity: 0;">{{ raw_code }}</textarea>


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנתי את תצוגת הקוד ה"מתקדם" כך שתופיע עם אותו Theme והדגשת תחביר כמו בעמוד העורך (CodeMirror). השינוי פותר חוסר עקביות בתצוגה שבה התצוגה המתקדמת הופיעה עם Theme שונה וללא הדגשת תחביר.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות:
- **`webapp/static/js/view-codemirror-toggle.js`**:
    - יישרתי את לוגיקת בחירת ה־theme ל־`dark` כדי שתתאים להתנהגות העורך, שמטעין תמיד `oneDark`.
    - הוספתי פונקציית `normalizeLanguage` לטיפול בשמות שפות מגוונים (כמו "Python 3", "C#") והמרתם לפורמט תקין עבור CodeMirror, מה שמשפר את אמינות הדגשת התחביר.
- **`webapp/templates/view_file.html`**:
    - הוספתי את המחלקה `codemirror-container` ל־`#codeMirrorContainer` כדי להבטיח שהסטיילינג יתאים לזה של העורך.

## 🧪 בדיקות
- בדקתי ידנית בדפדפן, השוויתי את תצוגת ה"מתקדם" לתצוגת העורך ואימתתי שה־Theme והדגשת התחביר זהים.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי (ניתן לצרף צילום מסך המדגים את התיקון)

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שיפור חווית משתמש בלבד, ללא סיכונים ידועים לביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: # (הבקשה המקורית של המשתמש)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לשני הקומיטים שבוצעו. הסיכון נמוך.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cbd35c1-525d-4444-862c-c51c11c7fe0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cbd35c1-525d-4444-862c-c51c11c7fe0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves consistency between the advanced (CodeMirror) view and the editor.
> 
> - Forces `dark` theme via `resolveEffectiveThemeForEditorParity()` and applies it in `createReadOnlyCodeMirror`
> - Adds `normalizeLanguage()` and uses it in `resolveLanguage` to handle aliases/versions (e.g., `Python 3`, `C#`) for reliable syntax highlighting
> - Template: adds `codemirror-container` class to `#codeMirrorContainer` for styling parity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 253d2017ff373f7ea55451ce5d77c7b7be8e84bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->