### PR TITLE
View codemirror auto height

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -6,6 +6,20 @@
   overflow: hidden;
 }
 .cm-editor { min-height: 400px; max-height: 60vh; font-family: 'Fira Code','Consolas',monospace; }
+
+/* View Mode (view_file.html): allow page-level scrolling (auto height) */
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight {
+  overflow: visible;
+}
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight .cm-editor {
+  height: auto;
+  min-height: 0;
+  max-height: none;
+}
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight .cm-scroller {
+  height: auto;
+  overflow: visible;
+}
 /* Modified: Default to row layout for tablets/desktop */
 .editor-switcher { display:flex; flex-direction:column; align-items: stretch; gap:.5rem; margin:.5rem 0; padding:.65rem; background: rgba(255,255,255,0.05); border-radius:8px; }
 .editor-switcher-row { display:flex; justify-content:flex-start; align-items:center; gap:clamp(.5rem,1.5vw,1.25rem); flex-wrap:nowrap; width:100%; min-height:48px; }

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -219,7 +219,7 @@
 }
 
 #codeCard.is-advanced .code-container {
-    overflow: hidden;
+    overflow: visible;
 }
 
 #codeCard:fullscreen #codeMirrorContainer .cm-editor {
@@ -971,7 +971,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
         <div id="codeBasicContainer">
             {{ highlighted_code|safe }}
         </div>
-        <div id="codeMirrorContainer" class="codemirror-container" hidden aria-label="תצוגת קוד מתקדמת"></div>
+        <div id="codeMirrorContainer" class="codemirror-container cm-autoheight" hidden aria-label="תצוגת קוד מתקדמת"></div>
     </div>
     {% if raw_code is defined %}
     <textarea id="rawCode" style="position: absolute; left: -9999px; height: 0; opacity: 0;">{{ raw_code }}</textarea>


### PR DESCRIPTION
## ✨ תיאור קצר
שינינו את התנהגות CodeMirror במצב צפייה (View) כך שיציג גובה אוטומטי שמתרחב לפי כמות השורות, והגלילה תהיה של הדף כולו במקום גלילה פנימית. זה משפר את חווית המשתמש ומיישר קו עם תצוגת הקוד הבסיסית.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הוספת כללי CSS חדשים (`.cm-autoheight`) ב-`webapp/static/css/codemirror-custom.css` לביטול `max-height`, הגדרת `height: auto` ו-`overflow: visible` עבור `.cm-editor` ו-`.cm-scroller` במצב View.
- הוספת המחלקה `cm-autoheight` ל-`#codeMirrorContainer` ב-`webapp/templates/view_file.html`.
- שינוי `overflow: hidden` ל-`overflow: visible` עבור `#codeCard.is-advanced .code-container` ב-`webapp/templates/view_file.html`.

## 🧪 בדיקות
נבדק ידנית בדפדפן במצב View, וכן במצב עריכה ובמצב מסך מלא כדי לוודא שאין פגיעה בהם.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה חיובית על חווית המשתמש במצב View. סיכון נמוך, השינויים ממוקדים למצב View ואינם משפיעים על מצב עריכה או מסך מלא.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
החזרת ה-PR (revert) תחזיר את המצב לקדמותו.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b520b83-f30e-436c-938c-36f3c990b63f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b520b83-f30e-436c-938c-36f3c990b63f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the CodeMirror "View" experience by letting the page scroll instead of the editor, avoiding inner scrollbars.
> 
> - Adds `.cm-autoheight` CSS under `#codeCard:not(:fullscreen)` to set `height: auto`, remove `max-height`, and make `.cm-editor`/`.cm-scroller` `overflow: visible`
> - Applies `cm-autoheight` class to `#codeMirrorContainer` in `view_file.html`
> - Changes `#codeCard.is-advanced .code-container` `overflow` from `hidden` to `visible`
> - Fullscreen rules remain: editor still fills available height in fullscreen
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ef3e98a11c0bce2338baa4988b926867fa8fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->