### PR TITLE
Code mirror font adjustment

### DIFF
--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -45,8 +45,16 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
 .cm-activeLineGutter { background: rgba(100,100,255,0.2); }
 .cm-editor.cm-focused { outline: 2px solid rgba(100,100,255,0.5); }
 .cm-selectionBackground { background-color: rgba(100,100,255,0.3) !important; }
+
+/* View Mode (view_file.html): responsive font sizing
+   - Mobile: match basic code view font-size (12px)
+   - Tablet/Desktop: slightly smaller than default (13px) */
+#codeMirrorContainer .cm-editor {
+  font-size: 13px;
+}
 @media (max-width: 768px){
   .cm-editor { max-height: 50vh; font-size: 14px; }
+  #codeMirrorContainer .cm-editor { font-size: 12px; }
   /* Mobile fix: prevent last lines from being hidden by browser UI / safe-area */
   .cm-editor .cm-scroller {
     padding-bottom: 80px !important;


### PR DESCRIPTION
## ✨ תיאור קצר
- עדכנתי את גודל הפונט של CodeMirror בעמוד תצוגת הקוד (`view_file.html`) כדי שיהיה רספונסיבי.
- בנייד, גודל הפונט הותאם ל-12px (זהה לתצוגת הקוד הבסיסית), ובדסקטופ/טאבלט הוקטן ל-13px.

## 📦 שינויים עיקריים
- [x] קוד (Backend) - (שינוי קבצי CSS)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת כללי CSS ספציפיים ל-`#codeMirrorContainer .cm-editor` בקובץ `webapp/static/css/codemirror-custom.css`.
- שימוש ב-Media Query (`@media (max-width: 768px)`) להגדרת `font-size: 12px` למובייל.
- הגדרת `font-size: 13px` כברירת מחדל לדסקטופ/טאבלט.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual
  - בוצעה בדיקה ויזואלית ידנית על גדלי מסך שונים (מובייל ודסקטופ) כדי לוודא שהפונט משתנה כצפוי ואינו משפיע על עמוד העריכה.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - השפעה מינימלית, השינוי הוא ויזואלי בלבד ומשפיע רק על תצוגת קוד CodeMirror בעמוד הצפייה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - ביטול השינויים בקובץ `webapp/static/css/codemirror-custom.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ced560a-d85c-4b73-88cb-9db577eb88c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ced560a-d85c-4b73-88cb-9db577eb88c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes CodeMirror font sizing in view mode for readability across devices.
> 
> - Adds responsive font rules in `webapp/static/css/codemirror-custom.css` targeting `#codeMirrorContainer .cm-editor`
> - Sets desktop/tablet font-size to `13px`; overrides to `12px` under `@media (max-width: 768px)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87aaad67b9e34137e918c513c052a2b0aed0389b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->