### PR TITLE
Profiler service normalization and index

### DIFF
--- a/database/manager.py
+++ b/database/manager.py
@@ -557,6 +557,8 @@ class DatabaseManager:
             ], name="lang_tags_date_idx"),
             IndexModel([("code", TEXT), ("description", TEXT), ("file_name", TEXT)], name="full_text_search_idx"),
             IndexModel([("deleted_expires_at", ASCENDING)], name="deleted_ttl", expireAfterSeconds=0),
+            # אינדקס לשאילתות שמסננות לפי is_active ומיון לפי created_at (ביצועים)
+            IndexModel([("is_active", ASCENDING), ("created_at", DESCENDING)], name="active_recent_idx"),
         ]
 
         large_files_indexes = [


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את לוגיקת הנרמול ב-Profiler Service כדי למנוע קריסות בניתוח שאילתות `aggregate` (בעיקר עם `$sort` ומערכים באופרטורים). בנוסף, הוספנו אינדקס חדש ל-`code_snippets` לשיפור ביצועים דרמטי בשאילתות סינון לפי `is_active`.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [x] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- **Profiler Service (`services/query_profiler_service.py`)**:
    - הוספת Whitelisting למפתחות `$sort` ו-`$orderby` כדי לשמר ערכי 1/-1 (כיוון מיון).
    - שמירה על אורך מערכים באופרטורים (כמו `$eq`, `$in`, `$or`, `$and`) ונרמול רקורסיבי של האיברים בפנים, ללא כיווץ המערך.
    - העברת `parent_key` לפונקציה `normalize_value` כדי לספק הקשר לנרמול.
- **Database Manager (`database/manager.py`)**:
    - הוספת אינדקס `active_recent_idx` על `("is_active", ASCENDING), ("created_at", DESCENDING)` ל-collection `code_snippets`.
- **Tests (`tests/test_query_profiler_service.py`)**:
    - הוספת טסט ייעודי `test_normalize_query_shape_preserves_sort_direction` לוודא את התנהגות הנרמול ב-$sort.

## 🧪 בדיקות
- בדיקות Unit: כל 17 הטסטים עברו בהצלחה, כולל טסט חדש עבור לוגיקת ה-$sort.
- בדיקות Manual: בוצעו בדיקות ידניות של שאילתות `aggregate` עם `$sort` ומערכים כדי לוודא שהפרופיילר אינו קורס. נבדקה גם שאילתת `is_active` ב-`code_snippets` לוודא שיפור ביצועים.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג (נרמול פרופיילר)
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [x] perf: שיפור ביצועים (אינדקס)
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **תיקון נרמול הפרופיילר**: צפוי למנוע קריסות ולשפר את דיוק ניתוח השאילתות. סיכון נמוך, השפעה חיובית.
- **הוספת אינדקס**: צפוי לשפר משמעותית את ביצועי השאילתות על `code_snippets` שמסננות לפי `is_active`. סיכון נמוך, השפעה חיובית על ביצועים.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback לגרסה הקודמת. הסרת האינדקס תתבצע אוטומטית ב-Rollback של הקוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b573880-004d-42ad-9364-3906bcb17793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b573880-004d-42ad-9364-3906bcb17793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances query profiling robustness and adds a performance index.
> 
> - **Profiler normalization** (`services/query_profiler_service.py`): preserves `$sort`/`$orderby` directions (1/-1), keeps array lengths, and passes `parent_key` context for nested structures; entry normalization updated accordingly.
> - **Database index** (`database/manager.py`): adds `active_recent_idx` on `("is_active", ASCENDING), ("created_at", DESCENDING)` to speed `code_snippets` filtering/sorting.
> - **Tests** (`tests/test_query_profiler_service.py`): new test ensures `$sort` direction is preserved and related cases covered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cde67be9f986026fcf60e5e25f18b1134a12068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->