### PR TITLE
Metrics collection for slow queries

### DIFF
--- a/monitoring/metrics_storage.py
+++ b/monitoring/metrics_storage.py
@@ -159,9 +159,9 @@ def _flush_locked(now_ts: float) -> None:
 
 
 def flush(force: bool = False) -> None:
-    # זמני (חירום): עצירת כתיבת מטריקות ל-MongoDB כדי לשחרר עומס.
-    # כדי להפעיל מחדש בלי שינוי קוד: DISABLE_METRICS_WRITES=false
-    if str(os.getenv("DISABLE_METRICS_WRITES", "true")).lower() in {"1", "true", "yes", "on"}:
+    # Emergency kill-switch: disable DB writes explicitly when needed.
+    # Default is OFF (i.e., writes are allowed when METRICS_DB_ENABLED=true).
+    if _is_true(os.getenv("DISABLE_METRICS_WRITES")):
         return
     if not _enabled():
         return
@@ -184,9 +184,9 @@ def enqueue_request_metric(
 
     No-ops entirely when METRICS_DB_ENABLED is not true.
     """
-    # זמני (חירום): עצירת כתיבת מטריקות ל-MongoDB כדי לשחרר עומס.
-    # כדי להפעיל מחדש בלי שינוי קוד: DISABLE_METRICS_WRITES=false
-    if str(os.getenv("DISABLE_METRICS_WRITES", "true")).lower() in {"1", "true", "yes", "on"}:
+    # Emergency kill-switch: disable DB writes explicitly when needed.
+    # Default is OFF (i.e., writes are allowed when METRICS_DB_ENABLED=true).
+    if _is_true(os.getenv("DISABLE_METRICS_WRITES")):
         return
     if not _enabled():
         return


### PR DESCRIPTION
## ✨ תיאור קצר
החזרנו את כתיבת המטריקות למסד הנתונים על ידי שינוי ברירת המחדל של משתנה הסביבה `DISABLE_METRICS_WRITES`. השינוי מאפשר למערכת לכתוב מטריקות שוב, כחלק מתהליך איתור בעיות ה-Slow Query, מבלי להפעיל את ה-Scheduler או הבוט.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי ב-`monitoring/metrics_storage.py` כדי להפוך את `DISABLE_METRICS_WRITES` ל-kill-switch אמיתי (כבוי כברירת מחדל), במקום לכבות כתיבת מטריקות תמיד.

## 🧪 בדיקות
- בדקתי את השינוי בקוד באופן ידני. ניסיתי להריץ בדיקות יחידה אך `pytest` לא היה זמין בסביבת העבודה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [x] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (נבדקו ידנית, בדיקות אוטומטיות ירוצו ב-CI)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: החזרת כתיבת המטריקות עשויה להוסיף עומס על MongoDB, אך זהו צעד מכוון לצורך ניטור ופתרון בעיות ה-Slow Query.

## 🔗 קישורים
- Issues קשורים: # (לא קיים Issue ספציפי, אך קשור לדיון על Slow Queries)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן להחזיר את השינוי ב-`monitoring/metrics_storage.py` או להגדיר את משתנה הסביבה `DISABLE_METRICS_WRITES=true` כדי לכבות את כתיבת המטריקות שוב.

---
<a href="https://cursor.com/background-agent?bcId=bc-a03d0e9f-4219-4ad7-90b1-67f73a909fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a03d0e9f-4219-4ad7-90b1-67f73a909fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables metrics persistence while adding a proper opt-in kill-switch.
> 
> - Changes `flush` and `enqueue_request_metric` to use `_is_true(os.getenv("DISABLE_METRICS_WRITES"))` so writes are allowed by default and only disabled when the env var is truthy
> - Updates comments/docs in `monitoring/metrics_storage.py`; no other batching/aggregation logic modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0cd5c3f556989da856bf2330c67300d58505b32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->