### PR TITLE
Code editor syntax highlighting

### DIFF
--- a/tests/services/test_theme_parser_service.py
+++ b/tests/services/test_theme_parser_service.py
@@ -264,7 +264,7 @@ class TestTokenColorsToCodeMirrorCSS:
         assert ".cm-def" in css
 
     def test_prefix_matching_fallback(self):
-        """בדיקה שסקופים ספציפיים (כמו keyword.control.import.python) נופלים ל-scope הבסיסי."""
+        """בדיקה שסקופים ספציפיים נופלים ל-scope הספציפי ביותר (לא הראשון)."""
         from services.theme_parser_service import _find_codemirror_class
 
         # התאמה מדויקת
@@ -277,14 +277,25 @@ class TestTokenColorsToCodeMirrorCSS:
         assert _find_codemirror_class("keyword.control.flow.if") == ".cm-keyword"
         assert _find_codemirror_class("entity.name.function.method.call") == ".cm-def"
 
-        # הערה: constant.numeric.integer.decimal יכול לקבל גם .cm-number וגם .cm-atom
-        # בגלל שהלולאה מחזירה התאמה ראשונה (constant או constant.numeric)
-        result = _find_codemirror_class("constant.numeric.integer.decimal")
-        assert result in [".cm-number", ".cm-atom"]
+        # 🔑 בדיקה קריטית: constant.numeric.integer.decimal צריך לקבל .cm-number
+        # כי "constant.numeric" הוא הספציפי ביותר (ארוך יותר מ-"constant")
+        assert _find_codemirror_class("constant.numeric.integer.decimal") == ".cm-number"
+        assert _find_codemirror_class("constant.numeric.float") == ".cm-number"
 
-        # variable.language.this יכול להתאים ל-variable או variable.language.this
-        result = _find_codemirror_class("variable.language.this.js")
-        assert result in [".cm-variable", ".cm-variable-2"]
+        # constant.language צריך לקבל .cm-atom (יש מיפוי ספציפי)
+        assert _find_codemirror_class("constant.language.boolean.true") == ".cm-atom"
+
+        # variable.language.this צריך לקבל .cm-variable-2 (יש מיפוי ספציפי)
+        assert _find_codemirror_class("variable.language.this.js") == ".cm-variable-2"
+
+        # 🔑 בדיקה קריטית: support.class.component צריך לקבל .cm-tag (JSX)
+        # כי "support.class.component" הוא ספציפי יותר מ-"support.class"
+        assert _find_codemirror_class("support.class.component") == ".cm-tag"
+        assert _find_codemirror_class("support.class.component.MyButton") == ".cm-tag"
+
+        # אבל support.class רגיל צריך להיות .cm-type
+        assert _find_codemirror_class("support.class") == ".cm-type"
+        assert _find_codemirror_class("support.class.builtin") == ".cm-type"
 
         # סקופים לא מוכרים צריכים להחזיר None
         assert _find_codemirror_class("unknown.scope.here") is None


### PR DESCRIPTION
## ✨ תיאור קצר
הרחבנו משמעותית את מילון המיפוי (`TOKEN_TO_CODEMIRROR_MAP`) ב-`theme_parser_service.py` והוספנו בדיקות יחידה חדשות. שינוי זה מאפשר צביעת קוד מלאה ומדויקת (Full Syntax Highlighting) בעורך הקוד (CodeMirror) בעת ייבוא ערכות נושא, בדומה לאופן שבו קוד נצבע ב-VS Code.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- הרחבת מילון `TOKEN_TO_CODEMIRROR_MAP` מ-20 ל-73 סקופים, כולל קטגוריות רבות כמו Comments, Strings, Keywords, Storage, Functions, Variables, Constants, Types/Classes, Operators, Tags, Punctuation, ו-Errors.
- הוספת 3 בדיקות יחידה חדשות ב-`test_theme_parser_service.py` המאמתות את מיפוי הסקופים המורחבים, לוגיקת ה-Prefix Matching וטיפול בסגנונות פונט (italic, bold, underline).

## 🧪 בדיקות
כל 35 בדיקות היחידה עברו בהצלחה.
- [x] Unit

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שיפור משמעותי בחווית המשתמש בעת ייבוא ערכות נושא, עם צביעת קוד עשירה ומדויקת יותר.
- אין סיכונים ידועים, השינוי הוא בעיקר הרחבת מיפוי קיים.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לחזור לגרסה קודמת של הקבצים `services/theme_parser_service.py` ו-`tests/services/test_theme_parser_service.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-987ae699-f4ca-402a-9b83-c1dae13b72c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-987ae699-f4ca-402a-9b83-c1dae13b72c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances syntax highlighting generation by broadening VS Code scope → CodeMirror class coverage and adding smarter scope resolution.
> 
> - Significantly expands `TOKEN_TO_CODEMIRROR_MAP` to cover more categories (comments, strings, keywords/storage, functions, variables, constants, types/classes, operators, attributes/properties, tags, punctuation, errors)
> - Adds `_find_codemirror_class` with prefix matching so specific scopes (e.g., `keyword.control.import.python`) fall back to base mappings
> - `generate_codemirror_css_from_tokens` supports `fontStyle` variants (`italic`, `bold`, `underline`) when emitting CSS
> - New unit tests validate extended mappings, prefix-matching behavior, and font-style handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1be7af8d87659b448f3eac0680c0109c12131dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->