### PR TITLE
Database maintenance cleanup

### DIFF
--- a/tests/test_webserver_maintenance_cleanup.py
+++ b/tests/test_webserver_maintenance_cleanup.py
@@ -194,6 +194,14 @@ async def test_maintenance_cleanup_allows_token_via_query_param(monkeypatch):
                 payload = await resp.json()
                 assert payload.get("ok") is True
 
+            # Query token should NOT authorize /api/db/*
+            async with session.get(
+                f"http://127.0.0.1:{port}/api/db/pool?token=test-db-health-token"
+            ) as resp_db:
+                assert resp_db.status == 401
+                payload_db = await resp_db.json()
+                assert payload_db.get("error") == "unauthorized"
+
             async with session.get(
                 f"http://127.0.0.1:{port}/api/debug/maintenance_cleanup?token=wrong"
             ) as resp2:


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו endpoint חדש: `GET /api/debug/maintenance_cleanup` שמבצע ניקוי חד-פעמי של לוגים (slow_queries_log, service_metrics) ומחיקת אינדקסים לא חיוניים מקולקציית `code_snippets`. הנתיב מוגן באמצעות Bearer token (DB_HEALTH_TOKEN) כדי להבטיח גישה מאובטחת.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת `GET /api/debug/maintenance_cleanup` ב-`services/webserver.py`.
- ה-endpoint מנקה מסמכים מקולקציות `slow_queries_log` ו-`service_metrics`.
- ה-endpoint מוחק אינדקסים מקולקציית `code_snippets` שאינם ברשימת שמירה (לדוגמה: `_id_`, `search_text_idx`, `user_created_at`).
- הרחבת ה-middleware `db_health_auth_middleware` להגן גם על נתיבי `/api/debug/`.
- הפעלת פעולות ה-DB ב-`asyncio.to_thread` כדי למנוע חסימת ה-event loop.

## 🧪 בדיקות
- יצרנו קובץ בדיקות חדש `tests/test_webserver_maintenance_cleanup.py`.
- הבדיקות כוללות:
  - בדיקה שה-endpoint מוגן ומחזיר 403 אם `DB_HEALTH_TOKEN` לא מוגדר.
  - בדיקה שה-endpoint מבצע בהצלחה ניקוי לוגים ומחיקת אינדקסים לא חיוניים באמצעות אובייקטי Mock ל-DB.
- [x] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - ה-endpoint מבצע פעולות מחיקה ושינוי אינדקסים ישירות ב-DB.
  - מוגן באמצעות `DB_HEALTH_TOKEN` כדי למנוע גישה לא מורשית.
  - הפעולות מבוצעות ב-`asyncio.to_thread` כדי למנוע חסימת ה-event loop של השרת.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR. במקרה של מחיקת אינדקסים שגויה, ייתכן שיהיה צורך לשחזר אינדקסים ידנית או להפעיל מחדש את השירות כדי שיצור אותם מחדש אם הם מוגדרים בקוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f5d9452-ff33-4d37-867d-6d771a420a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f5d9452-ff33-4d37-867d-6d771a420a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a protected maintenance endpoint and strengthens auth for debug routes.
> 
> - **New endpoint**: `GET /api/debug/maintenance_cleanup` (runs in `asyncio.to_thread`) to:
>   - Purge `slow_queries_log` and `service_metrics` documents and report deleted counts
>   - Ensure TTL indexes on log collections (`timestamp`/`ts` with 7d/24h)
>   - Drop non-critical indexes in `code_snippets`, keeping `_id_`, `search_text_idx`, `user_id` (single-field), and unique `user_id+file_name`
> - **Auth middleware**: Extends `db_health_auth_middleware` to cover `/api/debug/` and supports Bearer header with fallback `?token=`; blocks when `DB_HEALTH_TOKEN` unset
> - **Routing/telemetry**: Registers the new route and emits `maintenance_cleanup_*` events
> - **Tests**: New `tests/test_webserver_maintenance_cleanup.py` covering disabled token (403), successful cleanup, and query-param token acceptance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50e408584b48058ba1373cdcca8e47fd0433271b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->