### PR TITLE
Cursor/code highlighting mapping update 54e1

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -250,8 +250,9 @@
   --md-blockquote-bg: color-mix(in srgb, var(--text-primary, #ffffff) 10%, var(--bg-primary, #1a1c23));
   --md-blockquote-border: color-mix(in srgb, var(--text-primary, #ffffff) 25%, transparent);
   --md-blockquote-color: var(--text-secondary, var(--text-primary, #b0b8d1));
-  --md-table-border: color-mix(in srgb, var(--text-primary, #ffffff) 15%, transparent);
-  --md-table-header-bg: color-mix(in srgb, var(--text-primary, #ffffff) 8%, var(--bg-primary, #1a1c23));
+  --md-table-border: color-mix(in srgb, var(--text-primary, #ffffff) 20%, transparent);
+  /* Table header: 12% mix for clear distinction */
+  --md-table-header-bg: color-mix(in srgb, var(--text-primary, #ffffff) 12%, var(--bg-primary, #1a1c23));
 }
 
 [data-theme="dark"] #md-content code:not(pre code),


### PR DESCRIPTION
✅ תוקן!
הבעיה: בערכת Morass, --bg-tertiary (#333333) היה כמעט זהה ל---bg-primary (#313a36), כך שה-inline code לא בלט.

הפתרון: שיניתי את הגישה להשתמש ב-color-mix עם --text-primary במקום להסתמך על --bg-tertiary:

/* לפני - בעייתי */
background: var(--bg-tertiary);  /* עשוי להיות דומה לרקע */
 
/* אחרי - מובטח ניגודיות */
background: color-mix(in srgb, var(--text-primary) 12%, var(--bg-primary));
תוצאה עם Morass:

אלמנט	לפני	אחרי
רקע עמוד	#313a36	#313a36
inline code	#333333 (כמעט זהה!)	#464e4a ✅
code block	דומה לרקע	#3f4743 ✅
עכשיו ה-inline code יבלוט בכל ערכה מותאמת! 🎉



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances readability and consistency of Markdown code styling across themes.
> 
> - For `data-theme="custom"`, replaces reliance on `--bg-tertiary` with `color-mix` using `--text-primary` for `--md-inline-code-*`, code block backgrounds, borders, headers, and blockquotes/tables for better contrast
> - Adds explicit inline code styles for `dark/dim/nebula` and a dedicated `custom` inline code rule using `color-mix`
> - Separates `pre` styling: `dark/dim/nebula` keep existing vars; `custom` gets `color-mix`-based background/border
> - Minor CSS comments and cleanup without JS/HTML logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afb9ab1b84e73bc3e5b318a5e418a2fa39a4e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->