### PR TITLE
Cursor/code highlighting mapping update 54e1

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -2461,10 +2461,27 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
     // Mermaid: רנדר דיאגרמות בקוד fence ```mermaid
     try {
       if (!window.mermaid) throw new Error('mermaid missing');
-      // Choose Mermaid theme based on current data-theme
+      // Choose Mermaid theme based on actual background brightness
       const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
-      const darkThemes = ['dark', 'dim', 'nebula', 'ocean', 'forest', 'high-contrast', 'custom'];
-      const mermaidTheme = darkThemes.includes(currentTheme) ? 'dark' : 'default';
+      const knownDarkThemes = ['dark', 'dim', 'nebula', 'ocean', 'forest', 'high-contrast'];
+      const knownLightThemes = ['classic', 'rose-pine-dawn'];
+      let mermaidTheme = 'dark';
+      if (knownLightThemes.includes(currentTheme)) {
+        mermaidTheme = 'default';
+      } else if (currentTheme === 'custom') {
+        // For custom themes, check actual background color brightness
+        const bgColor = getComputedStyle(document.documentElement).getPropertyValue('--bg-primary').trim();
+        if (bgColor) {
+          const hex = bgColor.replace('#', '');
+          if (hex.length >= 6) {
+            const r = parseInt(hex.substr(0, 2), 16);
+            const g = parseInt(hex.substr(2, 2), 16);
+            const b = parseInt(hex.substr(4, 2), 16);
+            const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+            mermaidTheme = brightness > 128 ? 'default' : 'dark';
+          }
+        }
+      }
       window.mermaid.initialize({ 
         startOnLoad: false, 
         securityLevel: 'strict',


### PR DESCRIPTION
✅ הוחזר!
החזרתי את בלוקי הקוד לערכים המקוריים:

משתנה	עכשיו (הוחזר)
--md-code-bg	var(--code-bg, var(--bg-secondary))
--md-code-header-bg	var(--bg-tertiary)
--md-code-shell-bg	var(--bg-secondary)
--md-code-copy-bg	var(--bg-tertiary)
מה נשאר עם color-mix (כי הם היו הבעיה המקורית):

✅ Inline code (`קוד`) - 12%
✅ Blockquotes (ציטוטים) - 10%
✅ Table headers (כותרות טבלאות) - 12%


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability and consistency for Markdown preview in the custom theme.
> 
> - Custom theme: adjust inline code color to blend with `--primary`, switch `--md-code-border` to `--glass-border`, and use theme vars for `--md-code-shell-bg`/`--md-code-header-bg`
> - Pre/code blocks in custom theme now use `--code-bg`/`--code-border` instead of color-mix
> - Add comprehensive Mermaid CSS for custom theme (nodes, edges, labels, sequence diagram elements) to ensure adequate contrast
> - JS: initialize Mermaid with `theme` chosen from `data-theme` (dark vs default) for consistent dark/light rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a3b7015c1913abdc78b1cb5edd86075cf150af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->