### PR TITLE
Cursor/feature implementation from guide 7675

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -1417,43 +1417,60 @@
           if (!res.ok || !data || !data.ok) {
             throw new Error((data && data.error) || 'load_failed');
           }
-
-          // מוסיפים Shared themes ל-dropdown (כדי לשמור את ה-UI כמו שהיה)
           const themes = Array.isArray(data.themes) ? data.themes : [];
+          const builtin = themes.filter(t => t && t.type === 'builtin' && t.id);
           const shared = themes.filter(t => t && t.type === 'shared' && t.id);
+          const custom = themes.filter(t => t && t.type === 'custom' && t.id);
 
-          // נקה optgroup ישן אם כבר קיים (למניעת כפילות)
-          try {
-            const existing = themeSel.querySelector('optgroup[data-kind="shared"]');
-            if (existing) existing.remove();
-          } catch (_) {}
+          // שמור את הערכה הנוכחית כדי לבחור נכון אחרי רינדור
+          const currentTheme = (document.documentElement.getAttribute('data-theme') || 'classic').trim().toLowerCase();
 
-          if (shared.length > 0) {
+          // בונים את הרשימה מחדש (במקרה של כשל נשאיר את הסטטי מהשרת)
+          themeSel.innerHTML = '';
+
+          function addOptGroup(label, items, kind) {
+            if (!items || !items.length) return;
             const og = document.createElement('optgroup');
-            og.label = 'ערכות ציבוריות';
-            og.setAttribute('data-kind', 'shared');
+            og.label = label;
 
-            for (const t of shared) {
-              const opt = document.createElement('option');
+            for (const t of items) {
               const id = String(t.id || '').trim();
-              opt.value = `shared:${id}`;
+              if (!id) continue;
+
+              const opt = document.createElement('option');
+              if (kind === 'shared') opt.value = `shared:${id}`;
+              else if (kind === 'custom') opt.value = `custom:${id}`;
+              else opt.value = id;
+
+              const name = String(t.name || id);
               const featured = !!t.is_featured;
-              opt.textContent = (featured ? '⭐ ' : '') + String(t.name || id);
+              opt.textContent = (featured ? '⭐ ' : '') + name;
               og.appendChild(opt);
             }
 
-            // הוסף optgroup לפני סוף הרשימה
             themeSel.appendChild(og);
           }
 
-          // אם המשתמש כרגע על shared:..., נסמן אותה כ-selected
-          try {
-            const currentTheme = (document.documentElement.getAttribute('data-theme') || 'classic').trim().toLowerCase();
-            if (currentTheme.startsWith('shared:')) {
-              const has = Array.from(themeSel.options).some(o => o.value === currentTheme);
-              if (has) themeSel.value = currentTheme;
-            }
-          } catch (_) {}
+          addOptGroup('ערכות מובנות', builtin, 'builtin');
+          addOptGroup('ערכות ציבוריות', shared, 'shared');
+          addOptGroup('הערכות שלי', custom, 'custom');
+
+          // בחירה פעילה:
+          // - shared:* => shared:<id>
+          // - custom => custom:<id> לפי is_active
+          // - builtin => id
+          let selectedValue = '';
+          if (currentTheme.startsWith('shared:')) {
+            selectedValue = currentTheme;
+          } else if (currentTheme === 'custom') {
+            const activeCustom = custom.find(t => t && t.is_active === true && t.id);
+            selectedValue = activeCustom ? `custom:${String(activeCustom.id).trim()}` : '';
+          } else {
+            selectedValue = currentTheme;
+          }
+
+          const hasSelected = Array.from(themeSel.options).some(o => o.value === selectedValue);
+          themeSel.value = hasSelected ? selectedValue : 'classic';
         } catch (err) {
           console.error('Error loading themes:', err);
         }
@@ -1588,7 +1605,15 @@
           return;
         }
 
-        // builtin/custom דרך ui_prefs ואז רענון (כדי למנוע דליפת syntax_css בין shared/custom)
+        // ערכה מותאמת (custom:<id>) עוברת דרך activate
+        if (nextTheme.toLowerCase().startsWith('custom:')) {
+          const id = nextTheme.slice('custom:'.length).trim();
+          if (!id) return;
+          await selectTheme(id, 'custom');
+          return;
+        }
+
+        // builtin
         await selectTheme(nextTheme, 'builtin');
       });
 

--- a/webapp/templates/settings/theme_builder.html
+++ b/webapp/templates/settings/theme_builder.html
@@ -960,6 +960,10 @@
     let currentThemes = [];
     let selectedThemeId = null;
     let isNewTheme = false;
+    // מגן נגד מצב ביניים בזמן טעינת ערכה: מונע "פרסום" של נתונים ישנים מהטופס
+    let isThemeLoading = false;
+    // מזהה הערכה שהטופס כרגע מייצג בפועל (אחרי fetch + loadThemeIntoForm)
+    let loadedThemeId = null;
     let hasUnsavedChanges = false;
     let currentThemeSyntaxCss = '';
 
@@ -1558,14 +1562,21 @@
 
         selectedThemeId = themeId;
         isNewTheme = false;
+        isThemeLoading = true;
+        loadedThemeId = null;
         renderThemesList();
 
         setFormDisabled(true);
-        const theme = await fetchThemeDetails(themeId);
-        if (theme) {
-            loadThemeIntoForm(theme);
+        try {
+            const theme = await fetchThemeDetails(themeId);
+            if (theme) {
+                loadThemeIntoForm(theme);
+                loadedThemeId = themeId;
+            }
+        } finally {
+            isThemeLoading = false;
+            setFormDisabled(false);
         }
-        setFormDisabled(false);
 
         hasUnsavedChanges = false;
         updateFormButtons();
@@ -1631,6 +1642,8 @@
 
         selectedThemeId = null;
         isNewTheme = true;
+        isThemeLoading = false;
+        loadedThemeId = null;
         currentThemeSyntaxCss = '';
         renderThemesList();
 
@@ -1704,6 +1717,7 @@
         if (publishModal) {
             publishModal.hidden = true;
             try { publishModal.style.display = ''; } catch (e) {}
+            try { delete publishModal.dataset.themeId; } catch (e) {}
         }
         try { if (publishForm) publishForm.reset(); } catch (e) {}
     }
@@ -1712,6 +1726,11 @@
         publishBtn.addEventListener('click', () => {
             if (!selectedThemeId || isNewTheme) {
                 showToast('כדי לפרסם צריך לבחור ערכה קיימת (לא "ערכה חדשה")', 'error');
+                return;
+            }
+            // בזמן טעינה הטופס עדיין מייצג ערכה קודמת — מונעים פתיחת מודאל כדי לא לפרסם נתונים ישנים
+            if (isThemeLoading || loadedThemeId !== selectedThemeId) {
+                showToast('טוען את פרטי הערכה... נסה שוב בעוד רגע', 'info');
                 return;
             }
 
@@ -1730,6 +1749,7 @@
             if (publishSlugEl) publishSlugEl.value = suggestedSlug || '';
 
             if (publishModal) {
+                try { publishModal.dataset.themeId = String(selectedThemeId); } catch (e) {}
                 publishModal.hidden = false;
                 // "נוקשות" נגד CSS חיצוני שעשוי להסתיר overlays
                 try { publishModal.style.display = 'flex'; } catch (e) {}
@@ -1749,6 +1769,16 @@
     if (publishForm) {
         publishForm.addEventListener('submit', async (e) => {
             e.preventDefault();
+
+            const expectedThemeId = (publishModal && publishModal.dataset) ? publishModal.dataset.themeId : null;
+            if (!expectedThemeId || !selectedThemeId || String(expectedThemeId) !== String(selectedThemeId)) {
+                showToast('הערכה השתנתה מאז פתיחת החלון. פתח את חלון הפרסום מחדש.', 'error');
+                return;
+            }
+            if (isThemeLoading || loadedThemeId !== selectedThemeId) {
+                showToast('הערכה עדיין נטענת. נסה שוב בעוד רגע.', 'info');
+                return;
+            }
 
             const slug = (document.getElementById('publishSlug')?.value || '').trim().toLowerCase();
             const name = (document.getElementById('publishName')?.value || '').trim();


### PR DESCRIPTION

תיקנתי עוד שתי נקודות שיכולות לגרום בדיוק לתחושה של “לא מגיב”, גם אם אין קשר לגלילה חלקה:

בזמן טעינת ערכה/בחירה (setFormDisabled(true)): הקוד היה מכבה את כל הכפתורים בטופס. הוספתי חריג כך ש־publishThemeBtn לעולם לא יינעל—כדי שתמיד יהיה אפשר ללחוץ ולקבל לפחות הודעת שגיאה (“צריך לבחור ערכה קיימת”) ולא כפתור מת.
פתיחת מודאל “נוקשה” יותר: בנוסף ל־publishModal.hidden = false הוספתי גם publishModal.style.display = 'flex' (וגם איפוס display בסגירה) כדי להתגונן נגד כל CSS חיצוני שמסתיר overlays.
אם אחרי זה עדיין לא נפתח—זה כמעט בטוח אומר שיש שגיאת JS כללית בדף שמונעת מהסקריפט לרוץ (ואז גם שאר היכולות של הבונה אמורות להיות תקולות). במקרה כזה, הדבר היחיד שאני צריך ממך כדי לסגור את זה ב-100% הוא צילום/הדבקה של השגיאה מה־Console (DevTools) בזמן לחיצה על הכפתור.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Replace theme selection grid with a single `select#themeSelect`; dynamically appends shared themes as an `optgroup`, and routes selection via `selectTheme` to the correct endpoints (`/api/ui_prefs`, shared apply, custom activate) with full-page refresh for CSS injection.
> - Remove theme-cards markup/styles/JS and old race/rollback logic; simplify local persistence and `data-theme`/`data-theme-type` handling.
> - Theme Builder (admin): enable `publishThemeBtn` (never disabled by form state) and rework modal to `.publish-modal` classes to avoid CSS conflicts; explicitly force `display: flex` on open and reset on close.
> - Improve publish UX: clearer error when no existing theme is selected, auto-fill name/slug, and include `syntax_css` in `/api/themes/publish` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01fcd928c977b63ecb0a30fad6d36cfd6c5136b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->