### PR TITLE
Restore to commit 5d786c3

### DIFF
--- a/webapp/static/css/dark-mode.css
+++ b/webapp/static/css/dark-mode.css
@@ -1,28 +1,6 @@
 /* Dark Mode Styles - Comprehensive Theme Support */
 
 /* ============================================
-   Custom Theme Fallbacks
-   ============================================ */
-
-/* Ensure --text-muted has a good fallback for custom themes */
-[data-theme="custom"] {
-    --text-muted: color-mix(in srgb, var(--text-primary, #ffffff) 60%, transparent);
-}
-
-/* Fix placeholder text color for custom themes */
-[data-theme="custom"] input::placeholder,
-[data-theme="custom"] textarea::placeholder {
-    color: color-mix(in srgb, var(--text-primary, #ffffff) 50%, transparent);
-    opacity: 1;
-}
-
-/* Fix select option colors for custom themes (for browsers that support it) */
-[data-theme="custom"] select option {
-    background: var(--bg-secondary, #1e1e2e);
-    color: var(--text-primary, #ffffff);
-}
-
-/* ============================================
    Base Elements
    ============================================ */
 
@@ -50,17 +28,15 @@
 }
 
 [data-theme="dark"] .glass-card,
-[data-theme="dim"] .glass-card,
-[data-theme="custom"] .glass-card {
-    background: var(--card-bg, var(--glass, rgba(255,255,255,0.08)));
-    border: 1px solid var(--card-border, var(--glass-border, rgba(255,255,255,0.1)));
+[data-theme="dim"] .glass-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
     color: var(--text-primary);
 }
 
 [data-theme="dark"] .glass-card:hover,
-[data-theme="dim"] .glass-card:hover,
-[data-theme="custom"] .glass-card:hover {
-    background: var(--glass-hover, rgba(255,255,255,0.12));
+[data-theme="dim"] .glass-card:hover {
+    background: var(--glass-hover);
 }
 
 /* ============================================
@@ -101,49 +77,37 @@
     color: var(--text-secondary);
 }
 
-/* Text muted class */
-[data-theme="dark"] .text-muted,
-[data-theme="dim"] .text-muted,
-[data-theme="nebula"] .text-muted,
-[data-theme="custom"] .text-muted {
-    color: var(--text-muted, var(--text-secondary)) !important;
-}
-
 /* ============================================
    Buttons
    ============================================ */
 
 [data-theme="dark"] .btn-primary,
 [data-theme="dim"] .btn-primary,
-[data-theme="nebula"] .btn-primary,
-[data-theme="custom"] .btn-primary {
-    background: var(--btn-primary-bg, var(--primary, #6366f1));
-    color: var(--btn-primary-color, #ffffff);
-    border: 1px solid var(--btn-primary-border, transparent);
-    box-shadow: var(--btn-primary-shadow, none);
+[data-theme="nebula"] .btn-primary {
+    background: var(--btn-primary-bg);
+    color: var(--btn-primary-color);
+    border: 1px solid var(--btn-primary-border);
+    box-shadow: var(--btn-primary-shadow);
 }
 
 [data-theme="dark"] .btn-primary:hover,
 [data-theme="dim"] .btn-primary:hover,
-[data-theme="nebula"] .btn-primary:hover,
-[data-theme="custom"] .btn-primary:hover {
-    background: var(--btn-primary-hover-bg, var(--primary-dark, #5558e3));
-    box-shadow: var(--btn-primary-hover-shadow, none);
+[data-theme="nebula"] .btn-primary:hover {
+    background: var(--btn-primary-hover-bg);
+    box-shadow: var(--btn-primary-hover-shadow);
 }
 
 [data-theme="dark"] .btn-secondary,
 [data-theme="dim"] .btn-secondary,
-[data-theme="nebula"] .btn-secondary,
-[data-theme="custom"] .btn-secondary {
-    background: var(--glass, rgba(255,255,255,0.08));
+[data-theme="nebula"] .btn-secondary {
+    background: var(--glass);
     color: var(--text-primary);
-    border: 1px solid var(--glass-border, rgba(255,255,255,0.15));
+    border: 1px solid var(--glass-border);
 }
 
 [data-theme="dark"] .btn-secondary:hover,
 [data-theme="dim"] .btn-secondary:hover,
-[data-theme="nebula"] .btn-secondary:hover,
-[data-theme="custom"] .btn-secondary:hover {
+[data-theme="nebula"] .btn-secondary:hover {
     background: var(--glass-hover);
     border-color: var(--primary);
 }

--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -572,23 +572,12 @@
         </div>
       </div>
       <div>
-        <select
-          id="themeSelect"
-          class="filter-select"
-          aria-label="בחר ערכת נושא"
-          style="padding: 0.5rem 0.75rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: var(--text-primary);"
-        >
-          <option value="classic" {% if ui_theme == 'classic' %}selected{% endif %}>קלאסי{% if ui_theme == 'classic' %} (נוכחית){% endif %}</option>
-          <option value="ocean" {% if ui_theme == 'ocean' %}selected{% endif %}>אוקיינוס{% if ui_theme == 'ocean' %} (נוכחית){% endif %}</option>
-          <option value="rose-pine-dawn" {% if ui_theme == 'rose-pine-dawn' %}selected{% endif %}>🌹 Rose Pine Dawn{% if ui_theme == 'rose-pine-dawn' %} (נוכחית){% endif %}</option>
-          <option value="dark" {% if ui_theme == 'dark' %}selected{% endif %}>🌙 חשוך{% if ui_theme == 'dark' %} (נוכחית){% endif %}</option>
-          <option value="dim" {% if ui_theme == 'dim' %}selected{% endif %}>🌆 מעומעם{% if ui_theme == 'dim' %} (נוכחית){% endif %}</option>
-          <option value="nebula" {% if ui_theme == 'nebula' %}selected{% endif %}>🌌 Nebula{% if ui_theme == 'nebula' %} (נוכחית){% endif %}</option>
-          <option value="high-contrast" {% if ui_theme == 'high-contrast' %}selected{% endif %}>ניגודיות גבוהה{% if ui_theme == 'high-contrast' %} (נוכחית){% endif %}</option>
-          {% if custom_theme and custom_theme.is_active %}
-          <option value="custom" {% if ui_theme == 'custom' %}selected{% endif %}>🎨 {{ custom_theme.name if custom_theme.name else 'Custom' }}{% if ui_theme == 'custom' %} (נוכחית){% endif %}</option>
-          {% endif %}
-        </select>
+        <div id="themeCardsContainer" aria-label="בחר ערכת נושא">
+          <div style="opacity: 0.8; padding: 0.5rem 0;">
+            <i class="fas fa-spinner fa-spin"></i>
+            טוען ערכות...
+          </div>
+        </div>
         <div style="margin-top: 0.75rem; opacity: 0.85; font-size: 0.95rem;">
           <a class="btn btn-secondary btn-icon" href="/settings/theme-builder">
             <i class="fas fa-palette"></i>
@@ -864,6 +853,85 @@
     .glass-card h4 {
       margin: 0 0 0.5rem 0;
       color: var(--text-primary); /* שימוש במשתנה במקום צבע קבוע */
+    }
+
+    /* Theme Cards (Shared Theme Library) */
+    .theme-group {
+      margin-bottom: 1.5rem;
+    }
+    .theme-group h4 {
+      margin: 0 0 0.75rem 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .theme-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+    .theme-card {
+      background: var(--glass);
+      border: 2px solid transparent;
+      border-radius: 12px;
+      padding: 0.75rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    .theme-card:hover {
+      background: var(--glass-hover);
+      transform: translateY(-2px);
+    }
+    .theme-card.active {
+      border-color: var(--primary);
+      background: color-mix(in srgb, var(--primary) 15%, transparent);
+    }
+    .theme-card-preview {
+      height: 60px;
+      border-radius: 8px;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--glass-border) 80%, transparent);
+    }
+    .theme-card-info {
+      text-align: center;
+    }
+    .theme-card-name {
+      font-weight: 600;
+      color: var(--text-primary);
+      font-size: 0.9rem;
+    }
+    .theme-card-badges {
+      margin-top: 0.5rem;
+      display: flex;
+      gap: 0.25rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    /* scoped badge styling for theme cards only */
+    .theme-card-badges .badge {
+      display: inline-block;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      gap: 0;
+    }
+    .theme-card-badges .badge.featured {
+      background: linear-gradient(135deg, #fbbf24, #f59e0b);
+      color: #000;
+      border: none;
+    }
+    .theme-card-badges .badge.shared {
+      background: var(--primary);
+      color: white;
+      border: none;
     }
 
     /* Toggle switch */
@@ -1407,73 +1475,95 @@
       const btnMinus = document.getElementById('fontMinus');
       const btnPlus = document.getElementById('fontPlus');
       const themeSel = document.getElementById('themeSelect');
+      const themeCardsContainer = document.getElementById('themeCardsContainer');
+
       // ========== Theme Selection (Shared Theme Library) ==========
-      // מחזירים את ה-UI למצב הישן: Dropdown, אבל ממלאים אותו דינמית מהשרת (כולל Shared + כל ה-Custom של המשתמש).
       async function loadThemesList() {
-        if (!themeSel) return;
+        if (!themeCardsContainer) return;
         try {
           const res = await fetch('/api/themes/list');
           const data = await res.json();
-          if (!res.ok || !data || !data.ok) throw new Error((data && data.error) || 'load_failed');
-
-          const themes = Array.isArray(data.themes) ? data.themes : [];
-          const builtin = themes.filter(t => t && t.type === 'builtin');
-          const shared = themes.filter(t => t && t.type === 'shared');
-          const custom = themes.filter(t => t && t.type === 'custom');
-
-          // שמור בחירה נוכחית כדי לא "לקפוץ" בזמן רינדור מחדש
-          const html = document.documentElement;
-          const currentTheme = ((html.getAttribute('data-theme') || 'classic') + '').trim().toLowerCase();
-
-          // ניקוי options קיימים
-          themeSel.innerHTML = '';
-
-          function addOptGroup(label, items, kind) {
-            if (!items || !items.length) return;
-            const og = document.createElement('optgroup');
-            og.label = label;
-            for (const t of items) {
-              const opt = document.createElement('option');
-              const id = String(t.id || '').trim();
-              if (!id) continue;
-
-              if (kind === 'shared') opt.value = `shared:${id}`;
-              else if (kind === 'custom') opt.value = `custom:${id}`;
-              else opt.value = id;
-
-              const name = String(t.name || id);
-              const featured = !!t.is_featured;
-              opt.textContent = (kind === 'shared' ? '🌟 ' : kind === 'custom' ? '🎨 ' : '') + (featured ? '⭐ ' : '') + name;
-              og.appendChild(opt);
-            }
-            themeSel.appendChild(og);
+          if (!res.ok || !data || !data.ok) {
+            throw new Error((data && data.error) || 'load_failed');
           }
-
-          addOptGroup('ערכות מובנות', builtin, 'builtin');
-          addOptGroup('ערכות ציבוריות', shared, 'shared');
-          addOptGroup('הערכות שלי', custom, 'custom');
-
-          // בחירה פעילה:
-          // - shared:* => shared:<id>
-          // - custom => custom:<id> לפי is_active
-          // - builtin => id
-          let selectedValue = '';
-          if (currentTheme.startsWith('shared:')) {
-            selectedValue = currentTheme;
-          } else if (currentTheme === 'custom') {
-            const activeCustom = custom.find(t => t && t.is_active === true && t.id);
-            selectedValue = activeCustom ? `custom:${String(activeCustom.id).trim()}` : 'custom';
-          } else {
-            selectedValue = currentTheme;
-          }
-
-          // אם אין התאמה (למשל custom בלי id), נ fallback ל-classic
-          const hasSelected = Array.from(themeSel.options).some(o => o.value === selectedValue);
-          themeSel.value = hasSelected ? selectedValue : 'classic';
+          renderThemeCards(data.themes || []);
         } catch (err) {
           console.error('Error loading themes:', err);
-          // השאר את ה-options הסטטיים שכבר ברירת מחדל מהשרת
+          themeCardsContainer.innerHTML = '<div style="opacity:0.8">שגיאה בטעינת ערכות</div>';
         }
+      }
+
+      function escapeHtmlTheme(str) {
+        const div = document.createElement('div');
+        div.textContent = String(str || '');
+        return div.innerHTML;
+      }
+
+      function isThemeActive(theme) {
+        const currentTheme = (document.documentElement.getAttribute('data-theme') || 'classic').trim().toLowerCase();
+        if (!theme) return false;
+        // חשוב: custom נחשב פעיל רק אם גם ה-DB מסמן is_active וגם בפועל הנתון שמרונדר הוא data-theme="custom"
+        // אחרת (למשל כש-shared נבחר והעדכון לבטל custom נכשל) נקבל שתי ערכות פעילות ב-UI.
+        if (theme.type === 'custom') return (currentTheme === 'custom') && (theme.is_active === true);
+        if (theme.type === 'shared') return currentTheme === `shared:${theme.id}`;
+        return currentTheme === String(theme.id || '').trim().toLowerCase();
+      }
+
+      function renderThemeCard(theme) {
+        const active = isThemeActive(theme);
+        const badges = [];
+
+        if (theme && theme.is_featured) badges.push('<span class="badge featured">⭐ מומלץ</span>');
+        if (theme && theme.type === 'shared') badges.push('<span class="badge shared">ציבורי</span>');
+
+        return `
+          <div class="theme-card ${active ? 'active' : ''}"
+               data-theme-id="${escapeHtmlTheme(theme.id)}"
+               data-theme-type="${escapeHtmlTheme(theme.type)}">
+            <div class="theme-card-preview" style="background: var(--theme-preview-${escapeHtmlTheme(theme.id)}, var(--bg-primary))">
+              ${active ? '<i class="fas fa-check-circle"></i>' : ''}
+            </div>
+            <div class="theme-card-info">
+              <div class="theme-card-name">${escapeHtmlTheme(theme.name)}</div>
+              ${badges.length ? '<div class="theme-card-badges">' + badges.join('') + '</div>' : ''}
+            </div>
+          </div>
+        `;
+      }
+
+      function renderThemeCards(themes) {
+        if (!themeCardsContainer) return;
+
+        const builtin = themes.filter(t => t && t.type === 'builtin');
+        const shared = themes.filter(t => t && t.type === 'shared');
+        const custom = themes.filter(t => t && t.type === 'custom');
+
+        let html = '';
+        html += '<div class="theme-group"><h4>ערכות מובנות</h4><div class="theme-cards">';
+        for (const theme of builtin) html += renderThemeCard(theme);
+        html += '</div></div>';
+
+        if (shared.length > 0) {
+          html += '<div class="theme-group"><h4>ערכות ציבוריות</h4><div class="theme-cards">';
+          for (const theme of shared) html += renderThemeCard(theme);
+          html += '</div></div>';
+        }
+
+        if (custom.length > 0) {
+          html += '<div class="theme-group"><h4>הערכות שלי</h4><div class="theme-cards">';
+          for (const theme of custom) html += renderThemeCard(theme);
+          html += '</div></div>';
+        }
+
+        themeCardsContainer.innerHTML = html;
+
+        themeCardsContainer.querySelectorAll('.theme-card').forEach((card) => {
+          card.addEventListener('click', () => {
+            const id = card.dataset.themeId;
+            const type = card.dataset.themeType;
+            selectTheme(id, type);
+          });
+        });
       }
 
       function persistLocalTheme(theme) {
@@ -1540,7 +1630,7 @@
           location.reload();
         }
       }
-      
+
       // טען את הרשימה בעליית הדף
       loadThemesList();
       
@@ -1594,24 +1684,93 @@
       });
 
       if (themeSel) themeSel.addEventListener('change', async function(){
-        const raw = String(themeSel.value || '').trim();
-        if (!raw) return;
+        const html = document.documentElement;
+        const prevTheme = ((html.getAttribute('data-theme') || 'classic') + '').trim().toLowerCase();
+        const nextTheme = ((themeSel.value || '') + '').trim().toLowerCase();
 
-        // value encoding:
-        // - builtin: "<id>"
-        // - shared: "shared:<id>"
-        // - custom: "custom:<id>"
-        if (raw.startsWith('shared:')) {
-          const id = raw.slice('shared:'.length).trim();
-          return selectTheme(id, 'shared');
-        }
-        if (raw.startsWith('custom:')) {
-          const id = raw.slice('custom:'.length).trim();
-          return selectTheme(id, 'custom');
+        const allowed = (window.__ckThemeRipple && Array.isArray(window.__ckThemeRipple.allowedThemes))
+          ? window.__ckThemeRipple.allowedThemes
+          : ['classic','ocean','rose-pine-dawn','dark','dim','nebula','high-contrast','custom'];
+
+        const isAllowed = (t) => !!t && allowed.indexOf(t) !== -1;
+        if (!isAllowed(nextTheme)) {
+          alert('ערכת נושא לא נתמכת');
+          try { themeSel.value = prevTheme; } catch(_) {}
+          return;
         }
 
-        // builtin
-        return selectTheme(raw, 'builtin');
+        // ניהול תחרות (race): רק הפעולה האחרונה רשאית לבצע rollback/cancel
+        const opState = window.__ckThemeSelectOp = window.__ckThemeSelectOp || { seq: 0, controller: null, intendedTheme: null };
+        const opId = (opState.seq = (Number(opState.seq) || 0) + 1);
+        opState.intendedTheme = nextTheme;
+        try {
+          if (opState.controller && typeof opState.controller.abort === 'function') {
+            opState.controller.abort();
+          }
+        } catch(_) {}
+        try {
+          opState.controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+        } catch(_) {
+          opState.controller = null;
+        }
+
+        function persistLocal(theme){
+          try { localStorage.setItem('user_theme', theme); } catch(_) {}
+          try {
+            if (theme === 'dark' || theme === 'dim') {
+              localStorage.setItem('dark_mode_preference', theme);
+            } else if (theme === 'classic') {
+              localStorage.setItem('dark_mode_preference', 'light');
+            } else {
+              localStorage.removeItem('dark_mode_preference');
+            }
+          } catch(_) {}
+        }
+
+        function applyNow(theme){
+          try { html.setAttribute('data-theme', theme); } catch(_) {}
+        }
+
+        try {
+          // שמירה מקומית לפני הכל (כדי לסנכרן טאבים ולהחזיק גם אם הרשת נופלת)
+          persistLocal(nextTheme);
+
+          // אפקט ripple + החלפה בסוף האנימציה
+          if (typeof window.applyThemeChangeWithRipple === 'function') {
+            window.applyThemeChangeWithRipple(nextTheme, themeSel, applyNow);
+          } else {
+            applyNow(nextTheme);
+          }
+
+          const fetchOpts = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ theme: nextTheme })
+          };
+          try {
+            if (opState.controller && opState.controller.signal) {
+              fetchOpts.signal = opState.controller.signal;
+            }
+          } catch(_) {}
+
+          const res = await fetch('/api/ui_prefs', fetchOpts);
+          const data = await res.json();
+          if (!data.ok) throw 0;
+        } catch (e) {
+          // אם זו לא הפעולה האחרונה – לא עושים rollback (אחרת נשבור בחירה חדשה)
+          const aborted = !!(e && (e.name === 'AbortError' || String(e).toLowerCase().includes('abort')));
+          const stillLatest = (window.__ckThemeSelectOp && window.__ckThemeSelectOp.seq === opId);
+          const stillIntended = (window.__ckThemeSelectOp && window.__ckThemeSelectOp.intendedTheme === nextTheme);
+          if (aborted || !stillLatest || !stillIntended) {
+            return;
+          }
+          // rollback: בטל אנימציה אם רצה, והחזר את הערך הקודם
+          try { if (window.__ckThemeRipple && typeof window.__ckThemeRipple.cancel === 'function') window.__ckThemeRipple.cancel(); } catch(_) {}
+          persistLocal(prevTheme);
+          applyNow(prevTheme);
+          try { themeSel.value = prevTheme; } catch(_) {}
+          alert('שגיאה בעדכון ערכת הנושא');
+        }
       });
 
       // Bookmarks toggle visibility controls

--- a/webapp/templates/settings/theme_builder.html
+++ b/webapp/templates/settings/theme_builder.html
@@ -228,7 +228,7 @@
                     מחק ערכה
                 </button>
                 {% if is_admin %}
-                <button type="button" class="btn btn-warning" id="publishThemeBtn">
+                <button type="button" class="btn btn-warning" id="publishThemeBtn" disabled>
                     <i class="fas fa-share-alt"></i>
                     פרסם לכולם
                 </button>
@@ -1675,15 +1675,18 @@
         const saveBtn = document.getElementById('saveThemeBtn');
         const activateBtn = document.getElementById('activateThemeBtn');
         const deleteBtn = document.getElementById('deleteThemeBtn');
+        const publishBtn = document.getElementById('publishThemeBtn');
 
         if (isNewTheme) {
             if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-plus"></i> צור ערכה';
             if (activateBtn) activateBtn.disabled = true;
             if (deleteBtn) deleteBtn.disabled = true;
+            if (publishBtn) publishBtn.disabled = true;
         } else {
             if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-save"></i> שמור שינויים';
             if (activateBtn) activateBtn.disabled = !selectedThemeId;
             if (deleteBtn) deleteBtn.disabled = !selectedThemeId;
+            if (publishBtn) publishBtn.disabled = !selectedThemeId;
         }
     }
 
@@ -1704,7 +1707,7 @@
     if (publishBtn) {
         publishBtn.addEventListener('click', () => {
             if (!selectedThemeId || isNewTheme) {
-                showToast('כדי לפרסם צריך לבחור ערכה קיימת (לא "ערכה חדשה")', 'error');
+                showToast('יש לבחור ערכה קיימת קודם', 'error');
                 return;
             }
 


### PR DESCRIPTION
This PR restores the repository to commit `5d786c37e5e0e7bd453b630e941f7e59b64ebe1c` by recreating its tree on top of `main`.

נוצר אוטומטית דרך בוט CodeBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes theme selection and cleans up dark-mode styling.
> 
> - Replaces `select#themeSelect` with a dynamic card-based gallery (`#themeCardsContainer`) that loads from `GET /api/themes/list`, groups by Built-in/Shared/Custom, shows badges, and applies themes via `selectTheme` (supports `shared`, `custom`, and `builtin` paths)
> - Adds theme-card styles and minimal JS helpers (`isThemeActive`, `renderThemeCard(s)`, safe HTML escaping) and click handlers to activate themes; shows loading/error states
> - Streamlines dark/dim/nebula CSS in `static/css/dark-mode.css`: removes custom fallback rules and redundant defaults, unifies `glass-card`, buttons, inputs, hover, and other components to use theme variables consistently
> - In Theme Builder (`settings/theme_builder.html`): disables `publishThemeBtn` until a theme is selected, updates button state logic, and tweaks validation/toast text for publish flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01497c0857d6e8d43bfd22b5501680c2838f91a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->