### PR TITLE
Public theme button color

### DIFF
--- a/tests/test_shared_theme_service.py
+++ b/tests/test_shared_theme_service.py
@@ -94,6 +94,30 @@ def test_create_success_filters_colors_and_saves_syntax_css():
     assert 'data-theme-type="custom"' in db.shared_themes.docs[0].get("syntax_css", "")
 
 
+def test_create_fixes_unreadable_primary_button_text_contrast():
+    """
+    Regression: imported themes can end up with white-on-white button text after publish.
+    Shared theme creation should auto-fix to --primary when contrast is too low.
+    """
+    db = _MockDB()
+    svc = SharedThemeService(db)
+    ok, theme_id = svc.create(
+        slug="white_btn",
+        name="White Button",
+        created_by=123,
+        colors={
+            "--primary": "#667eea",
+            "--bg-primary": "#000000",
+            "--btn-primary-bg": "#ffffff",
+            "--btn-primary-color": "#ffffff",
+        },
+    )
+    assert ok is True
+    assert theme_id == "white_btn"
+    saved = db.shared_themes.docs[0]["colors"]
+    assert saved["--btn-primary-color"] == "#667eea"
+
+
 def test_create_duplicate_slug_rejected():
     db = _MockDB()
     db.shared_themes.docs = [{"_id": "cyber_purple", "is_active": True}]


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג שבו כפתורי קישור (ראשיים ומשניים) בערכות ציבוריות מאבדים את צבע הטקסט שלהם, במיוחד בערכות מיובאות. הוספנו בדיקת ניגודיות אוטומטית בעת פרסום ערכה, ואם צבע הטקסט של הכפתור אינו קריא, הוא מוחלף לצבע הראשי של הערכה כדי להבטיח קריאות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת פונקציות לחישוב ניגודיות (WCAG) ב־`services/shared_theme_service.py`.
- הטמעת לוגיקה ב־`_maybe_fix_button_text_contrast` לתיקון אוטומטי של צבע טקסט כפתור ראשי (ו־hover) אם הניגודיות מול הרקע נמוכה מ־2.2, תוך שימוש ב־`--primary` כ־fallback אם הוא משפר את הניגודיות ל־3.0 ומעלה.
- שילוב התיקון בתהליכי יצירה ועדכון של ערכות ציבוריות ב־`SharedThemeService.create` ו־`SharedThemeService.update`.

## 🧪 בדיקות
- [x] Unit
- [ ] Integration
- [ ] Manual

הוספתי בדיקת יחידה חדשה ב־`tests/test_shared_theme_service.py` שמוודאת שהתיקון האוטומטי של ניגודיות עובד כמצופה במקרה של טקסט לבן על רקע לבן.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקת היחידה החדשה עוברת)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  השינוי משפיע על תהליך פרסום ועדכון ערכות ציבוריות. במקרים נדירים, הוא עשוי לשנות אוטומטית את צבע טקסט הכפתור הראשי אם הניגודיות המקורית נמוכה מאוד. הסיכון נמוך שכן המטרה היא לשפר קריאות ולמנוע מצב של טקסט "נעלם".

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
  - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  החזרה לאחור של ה־PR. ערכות ציבוריות קיימות לא יושפעו, אך ערכות חדשות שפורסמו עם ניגודיות נמוכה יחזרו להציג טקסט לא קריא.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef14a3c9-3604-43ef-9d0e-ec4a6e59f682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef14a3c9-3604-43ef-9d0e-ec4a6e59f682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures readable primary button text in shared themes by auto-correcting low-contrast cases at save time.
> 
> - Adds WCAG luminance/contrast helpers (`_relative_luminance_srgb`, `_contrast_ratio`) using `normalize_color_to_rgba`
> - Introduces `_maybe_fix_button_text_contrast` to replace `--btn-primary-color` (and hover) with `--primary` when contrast vs bg is too low
> - Applies the fix in `SharedThemeService.create` and `update` after color validation
> - Adds unit test verifying white-on-white button text is corrected in `tests/test_shared_theme_service.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96749c4933507d8d58c5d464db9a25b3e2428f46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->