### PR TITLE
File view button colors

### DIFF
--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -425,35 +425,24 @@
 }
 
 .file-actions .btn-primary.btn-icon {
-    background: rgba(255, 255, 255, 0.95) !important;
-    color: #667eea !important;
-    border: 1px solid rgba(102, 126, 234, 0.35) !important;
-    border-radius: 12px !important;
-    padding: 12px 20px !important;
-    display: inline-flex !important;
+    /* חשוב: אין כאן צבעים קשיחים — כפתורי primary יורשים צבעים מהערכה דרך .btn-primary */
+    border-radius: 12px;
+    padding: 12px 20px;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     font-size: 15px;
     font-weight: 500;
     white-space: nowrap;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     transition: all 0.2s ease;
 }
 
 .file-actions .btn-primary.btn-icon:hover {
-    background: rgba(255, 255, 255, 1) !important;
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
 }
 
 .file-actions .btn-primary.btn-icon:active {
     transform: translateY(0);
-}
-
-.file-actions .btn-primary.btn-icon .fas,
-.file-actions .btn-primary.btn-icon i,
-.file-actions .btn-primary.btn-icon svg {
-    color: #667eea;
 }
 
 .file-actions__list .btn.file-action--hidden {


### PR DESCRIPTION
## ✨ תיאור קצר
הסרתי הגדרות צבע קשיחות מכפתורי "ערוך" ו"העתק קוד" בעמוד תצוגת קובץ (`view_file.html`). כעת הכפתורים יורשים את צבעי הרקע והטקסט מהערכה הפעילה דרך משתני ה-CSS של `.btn-primary`, מה שמשפר את עקביות העיצוב.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- הוסרו הגדרות `background`, `color`, `border`, `box-shadow` קשיחות מה-CSS המקומי של `.file-actions .btn-primary.btn-icon` ב־`webapp/templates/view_file.html`.
- הוסרה הגדרת צבע קשיחה לאייקונים בתוך הכפתורים.
- נוספה הערה ב-CSS המקומי המציינת שהצבעים יורשים מהערכה.

## 🧪 בדיקות
- נבדק ידנית על ידי צפייה בעמוד הקובץ עם ערכות נושא שונות (classic, dark, shared) כדי לוודא שהכפתורים מקבלים את הצבעים הנכונים מהערכה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [x] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שינוי ויזואלי בלבד, צפוי לשפר עקביות עיצובית. סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback על ידי היפוך הקומיט.

---
<a href="https://cursor.com/background-agent?bcId=bc-1255f0f5-5088-43cb-89ef-203ad179eef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1255f0f5-5088-43cb-89ef-203ad179eef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns file view primary action buttons with theme styling by removing local hardcoded colors.
> 
> - In `view_file.html`, stripped `background`, `color`, `border`, and `box-shadow` from ``.file-actions .btn-primary.btn-icon`` and simplified hover/active states
> - Removed explicit icon color rules within these buttons so icons inherit color
> - Added a CSS comment clarifying that colors come from `.btn-primary` (theme)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f9f8cde02d01e0fff9dc235cc27c1fd85d9987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->