### PR TITLE
Restore to commit 69ccd73

### DIFF
--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -111,19 +111,16 @@ groups:
         expr: |
           (
             health_latency_ewma
-              > predict_linear(health_latency_ewma[2h], 15m) * 1.35
+              > predict_linear(health_latency_ewma[2h], 15m) * 1.2
           )
-          # Avoid alert noise on small absolute changes.
-          # health_latency_ewma is reported in milliseconds (see /healthz and metrics.py).
-          and (health_latency_ewma > 800)
           # Require enough traffic so the EWMA trend is meaningful.
           # Without this, low-traffic services may get noisy false positives.
           and on(job, instance) (
-            sum by (job, instance) (increase(http_requests_total[2h])) > 400
+            sum by (job, instance) (increase(http_requests_total[2h])) > 200
           )
           and on(job, instance) (time() - process_start_time_seconds > 300)
           and on() ((time() - process_start_time_seconds{job=~".*prometheus.*"} > 600) or absent(process_start_time_seconds{job=~".*prometheus.*"}))
-        for: 20m
+        for: 10m
         labels:
           severity: warning
           component: webapp

--- a/docs/alerts.rst
+++ b/docs/alerts.rst
@@ -142,14 +142,13 @@
      expr: |
        (
          health_latency_ewma
-           > predict_linear(health_latency_ewma[2h], 15m) * 1.35
+           > predict_linear(health_latency_ewma[2h], 15m) * 1.2
        )
-       and (health_latency_ewma > 800)
        and on(job, instance) (
-         sum by (job, instance) (increase(http_requests_total[2h])) > 400
+         sum by (job, instance) (increase(http_requests_total[2h])) > 200
        )
        and on(job, instance) (time() - process_start_time_seconds > 300)
-     for: 20m
+     for: 10m
      labels:
        severity: warning
        component: webapp

--- a/webapp/static/css/codemirror-custom.css
+++ b/webapp/static/css/codemirror-custom.css
@@ -7,16 +7,16 @@
 }
 .cm-editor { min-height: 400px; max-height: 60vh; font-family: 'Fira Code','Consolas',monospace; }
 
-/* View Mode (view_file.html): גלילת דפדפן + CodeMirror auto-height (גם במסך מלא) */
-#codeCard .codemirror-container.cm-autoheight {
+/* View Mode (view_file.html): allow page-level scrolling (auto height) */
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight {
   overflow: visible;
 }
-#codeCard .codemirror-container.cm-autoheight .cm-editor {
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight .cm-editor {
   height: auto;
   min-height: 0;
   max-height: none;
 }
-#codeCard .codemirror-container.cm-autoheight .cm-scroller {
+#codeCard:not(:fullscreen) .codemirror-container.cm-autoheight .cm-scroller {
   height: auto;
   overflow: visible;
 }
@@ -48,9 +48,9 @@ html[dir="rtl"] .editor-info-primary { margin-left:0; margin-right:auto; }
 
 /* View Mode (view_file.html): responsive font sizing
    - Mobile: match basic code view font-size (12px)
-   - Tablet/Desktop: match basic code view font-size (14px) */
+   - Tablet/Desktop: slightly smaller than default (13px) */
 #codeMirrorContainer .cm-editor {
-  font-size: 14px;
+  font-size: 13px;
 }
 @media (max-width: 768px){
   .cm-editor { max-height: 50vh; font-size: 14px; }

--- a/webapp/static/js/view-codemirror-toggle.js
+++ b/webapp/static/js/view-codemirror-toggle.js
@@ -247,29 +247,10 @@
         viewInstance.focus();
       } catch (_) {}
       try {
-        const EditorView = window.CodeMirror6 && window.CodeMirror6.EditorView;
-        // CM6: הדרך ה"נכונה" לגלול היא באמצעות effect (EditorView.scrollIntoView).
-        // נשמור fallback אם ה-bundle לא חושף את הפונקציה הזו מסיבה כלשהי.
-        const scrollEffect =
-          EditorView && typeof EditorView.scrollIntoView === 'function'
-            ? EditorView.scrollIntoView(m.from, { y: 'center' })
-            : null;
-
-        viewInstance.dispatch(
-          scrollEffect
-            ? {
-                selection: { anchor: m.from, head: m.to },
-                // CM6 expects a StateEffect (or array). We pass it as an array for maximum compatibility.
-                effects: [scrollEffect],
-                // Fallback safety: if the bundle ignores effects for some reason, still request scroll.
-                scrollIntoView: true,
-              }
-            : {
-                selection: { anchor: m.from, head: m.to },
-                // Fallback when EditorView.scrollIntoView isn't available (or CM6 isn't exposed fully)
-                scrollIntoView: true,
-              }
-        );
+        viewInstance.dispatch({
+          selection: { anchor: m.from, head: m.to },
+          scrollIntoView: true,
+        });
       } catch (_) {}
       updateCmCount();
     }

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -6,14 +6,6 @@
 <style id="syntax-css"></style>
 <style>
 
-/* כדי שכאשר קופצים לתוצאה, היא לא תסתתר מתחת ל-toolbar הדביק */
-html {
-    scroll-padding-top: 96px;
-}
-@media (max-width: 768px) {
-    html { scroll-padding-top: 140px; }
-}
-
 .source {
     background: #1e1e1e !important;
     border-radius: 10px;
@@ -215,11 +207,10 @@ html {
     }
 }
 
-/* מסך מלא: משאירים גלילה "אינסופית" של הדפדפן (ללא גובה קשיח).
-   אחרת, height קשיח עלול לגרום לכך שלא מגיעים ממש לשורות האחרונות. */
+/* כאשר הכרטיס במסך מלא – הקוד יתפוס כמעט את כל הגובה */
 #codeCard:fullscreen .code-container {
-    height: auto;
-    overflow: visible;
+    height: calc(100vh - 120px);
+    overflow: auto;
 }
 
 /* View Mode: CodeMirror (תצוגה מתקדמת) */
@@ -228,19 +219,16 @@ html {
 }
 
 #codeCard.is-advanced .code-container {
-    /* משאירים את העמוד "אינסופי" עם גלילת דפדפן;
-       ה-toolbar דביק בעזרת position: sticky */
     overflow: visible;
 }
 
-/* במסך מלא (כמו מחוץ למסך מלא): תן ל-CodeMirror להתארך לפי התוכן */
 #codeCard:fullscreen #codeMirrorContainer .cm-editor {
-    height: auto;
+    height: 100%;
     max-height: none;
 }
+
 #codeCard:fullscreen #codeMirrorContainer .cm-scroller {
-    height: auto;
-    overflow: visible;
+    height: 100%;
 }
 
 .file-header {


### PR DESCRIPTION
This PR restores the repository to commit `69ccd73a92a1522e14b2384718f7e1bc4d8481bf` by recreating its tree on top of `main`.

נוצר אוטומטית דרך בוט CodeBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Prometheus alerts:** Relaxed `AppLatencyEWMARegression` sensitivity in `alerts.yml` (multiplier `1.35→1.2`, traffic gate `400→200`, duration `20m→10m`) and removed the small-change guard; mirrored in `docs/alerts.rst`.
> - **Code viewer UX:** Improved fullscreen behavior in `view_file.html` and `codemirror-custom.css` (`#codeCard:fullscreen` now uses fixed viewport height with internal scroll; non-fullscreen auto-height scoped with `:not(:fullscreen)`).
> - **CodeMirror search/scroll:** Simplified CM6 dispatch in `view-codemirror-toggle.js` to rely on `scrollIntoView: true` when focusing matches.
> - **Styling tweaks:** Slightly smaller desktop font for view-mode CodeMirror (`14px→13px`); removed global `html` scroll-padding from `view_file.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a74e5f60aac261c5e6dd716be3662c56d8062422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->