### PR TITLE
Mute slow mongo logs

### DIFF
--- a/tests/test_database_manager_profiler_independent.py
+++ b/tests/test_database_manager_profiler_independent.py
@@ -1,0 +1,142 @@
+import os
+import pytest
+
+
+class _DummyLogger:
+    def __init__(self):
+        self.records = []
+
+    def warning(self, msg, extra=None):
+        self.records.append(("warning", msg, extra or {}))
+
+    def error(self, msg, extra=None):
+        self.records.append(("error", msg, extra or {}))
+
+
+def test_db_manager_profiler_runs_when_slow_mongo_disabled(monkeypatch):
+    """
+    אם DB_SLOW_MS=0 (כלומר slow_mongo מושתק), הפרופיילר עדיין צריך לעבוד
+    לפי PROFILER_SLOW_THRESHOLD_MS.
+    """
+    monkeypatch.setenv("BOT_TOKEN", "x")
+    monkeypatch.setenv("MONGODB_URL", "mongodb://localhost:27017/db")
+
+    # Disable slow_mongo logs
+    monkeypatch.setenv("DB_SLOW_MS", "0")
+
+    # Enable profiler and set low threshold to trigger easily
+    monkeypatch.setenv("PROFILER_ENABLED", "true")
+    monkeypatch.setenv("PROFILER_SLOW_THRESHOLD_MS", "0.1")
+
+    # Ensure DB is not disabled
+    monkeypatch.setenv("DISABLE_DB", "0")
+    monkeypatch.setenv("SPHINX_MOCK_IMPORTS", "0")
+
+    import database.manager as dm
+
+    # Force pymongo available path and inject fake monitoring API
+    monkeypatch.setattr(dm, "_PYMONGO_AVAILABLE", True)
+
+    registered = {}
+
+    class _Monitoring:
+        class CommandListener:
+            pass
+
+        def register(self, listener):
+            registered["listener"] = listener
+
+    monkeypatch.setattr(dm, "_pymongo_monitoring", _Monitoring(), raising=False)
+
+    # Ensure registration block runs
+    monkeypatch.setattr(dm, "_MONGO_MONITORING_REGISTERED", False, raising=False)
+
+    # Stub MongoClient to avoid real connections
+    class _Coll:
+        def create_indexes(self, *a, **k):
+            return None
+
+        def list_indexes(self, *a, **k):
+            return []
+
+    class _DB:
+        def __init__(self):
+            self.code_snippets = _Coll()
+            self.large_files = _Coll()
+            self.backup_ratings = _Coll()
+            self.internal_shares = _Coll()
+
+        def __getitem__(self, name):
+            return _Coll()
+
+        def __getattr__(self, name):
+            return _Coll()
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def __getitem__(self, name):
+            return _DB()
+
+        @property
+        def admin(self):
+            class _Admin:
+                def command(self, *a, **k):
+                    return {"ok": 1}
+
+            return _Admin()
+
+    monkeypatch.setattr(dm, "MongoClient", _Client)
+
+    # Avoid heavy index creation
+    monkeypatch.setattr(dm.DatabaseManager, "_create_indexes", lambda self: None)
+
+    # Patch the module logger to capture warning/error
+    dlog = _DummyLogger()
+    monkeypatch.setattr(dm, "logger", dlog)
+
+    # Patch profiler service class used by DatabaseManager (imported lazily)
+    called = {"count": 0}
+
+    class _DummyProfiler:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def record_slow_query(self, **kwargs):
+            called["count"] += 1
+            return None
+
+    import services.query_profiler_service as qps
+
+    monkeypatch.setattr(qps, "PersistentQueryProfilerService", _DummyProfiler)
+
+    # Act: init manager to register listener
+    dm.DatabaseManager()
+    listener = registered.get("listener")
+    assert listener is not None
+
+    # Provide request context via started()
+    class _StartedEvent:
+        request_id = 123
+        command_name = "find"
+        database_name = "db"
+        command = {"find": "users", "filter": {"user_id": 1}}
+
+    listener.started(_StartedEvent())
+
+    # Trigger succeeded with duration above profiler threshold
+    class _SucceededEvent:
+        request_id = 123
+        duration_micros = 500.0  # 0.5 ms
+        command_name = "find"
+        database_name = "db"
+
+    listener.succeeded(_SucceededEvent())
+
+    # Assert: profiler ran even though slow_mongo is disabled
+    assert called["count"] == 1
+
+    # Assert: no slow_mongo warning was emitted
+    assert not any(level == "warning" and msg == "slow_mongo" for level, msg, _ in dlog.records)
+


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקנתי את ההתנהגות של לוגי `slow_mongo` כך שיופיעו רק כאשר `DB_SLOW_MS` מוגדר לערך חיובי, וברירת המחדל שלו היא 0 (מכובה). זה פותר את בעיית הרעש בלוגים ב-Render ומאפשר שליטה מלאה דרך משתנה סביבה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הפרדה בין סף ההפעלה של לוגי `slow_mongo` (שנשלט ע"י `DB_SLOW_MS`) לבין סף ההקלטה של הפרופיילר (שנשלט ע"י `PROFILER_SLOW_THRESHOLD_MS`).
- ברירת המחדל של `DB_SLOW_MS` עבור לוגי `slow_mongo` היא כעת 0 (מכובה), בהתאם לתיעוד.
- הפרופיילר ממשיך להשתמש בברירת מחדל של 100ms, עם תמיכה לאחור ב-`DB_SLOW_MS` אם `PROFILER_SLOW_THRESHOLD_MS` לא מוגדר.

## 🧪 בדיקות
- בדקתי ידנית את ההתנהגות עם משתני סביבה שונים.
- הרצתי את הטסט של `slow_mongo` והוא עבר.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: השינוי מפחית את רעש הלוגים ומשפר את בהירותם, ללא השפעה מהותית על ביצועים או אבטחה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: Rollback רגיל של ה-PR. אין שינויים במסד נתונים או תלויות חיצוניות.

---
<a href="https://cursor.com/background-agent?bcId=bc-5622facf-0149-486d-bdc4-19865b2d6e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5622facf-0149-486d-bdc4-19865b2d6e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines MongoDB monitoring by decoupling slow log emission from profiling thresholds.
> 
> - Introduces `_slow_mongo_log_threshold_ms()` so `DB_SLOW_MS` exclusively governs `slow_mongo` warnings (default `0` → disabled)
> - Keeps profiler controlled by `PROFILER_SLOW_THRESHOLD_MS`; falls back to `DB_SLOW_MS` only if it’s set to a positive value; default remains `100ms`
> - Updates listener to use `DB_SLOW_MS` for warning logs and a separate profiler threshold (`_profiler_threshold_ms()`); skips profiler recording when below profiler threshold
> - No schema or API changes; localized to `database/manager.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c465585804d1a02b253cbb3dfdee33b422717d0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->