### PR TITLE
Simplify Dockerfile to run only worker script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,13 +190,8 @@ except Exception as e: \
     sys.exit(1);"
 
 # פקודת הפעלה - מריץ Worker (אם דגל מופעל) ואת ה-WebApp
-RUN chmod +x scripts/start_with_worker.sh scripts/start_webapp.sh scripts/run_all.sh
-
-# ברירת מחדל: הרצת WebApp + AI Explain (שני תהליכים באותו קונטיינר)
-# ניתן לעקוף ב-Render/Docker דרך ENV:
-#   START_COMMAND="scripts/start_with_worker.sh"  (למצב bot/worker הישן)
-ENV START_COMMAND="scripts/run_all.sh"
-CMD ["sh", "-c", "${START_COMMAND}"]
+RUN chmod +x scripts/start_with_worker.sh
+CMD ["sh", "-c", "scripts/start_with_worker.sh"]
 
 ######################################
 # שלב dev נפרד הוסר; משתמשים באותו בסיס בטוח


### PR DESCRIPTION
Removed default command for running WebApp and AI Explain. Updated to only run the worker script.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies container startup to run only the worker.
> 
> - Replaces env-driven `START_COMMAND`/`scripts/run_all.sh` with direct `CMD scripts/start_with_worker.sh`
> - Drops chmod and startup paths for `start_webapp.sh` and `run_all.sh`; retains chmod for `start_with_worker.sh`
> - No changes to healthcheck or build/runtime dependencies
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d80020c4e9c646a42291e4d3167fe5f685197542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->