### PR TITLE
Language badge styling update

### DIFF
--- a/webapp/static/css/lang-badge.css
+++ b/webapp/static/css/lang-badge.css
@@ -1,0 +1,168 @@
+/* ============================================
+   🏷️ Language Badge Styling (GitHub-style)
+   ============================================
+   
+   עיצוב תגיות שפה עם נקודה צבעונית בסגנון GitHub.
+   תואם לכל ערכות הנושא (Dark/Light/Ocean וכו').
+   
+   שימוש:
+   <span class="lang-badge" data-lang="python">Python</span>
+*/
+
+/* --- 1. עיצוב המעטפת (מתאים לכל ה-Themes) --- */
+.lang-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    
+    /* משתמשים בטוקנים של המערכת כדי להתאים לכל ערכה (Dark/Light/Ocean) */
+    background-color: transparent; 
+    border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3)); 
+    color: var(--text-primary, inherit);
+    
+    padding: 2px 8px;
+    border-radius: 12px; /* פינות עגולות יותר למראה מודרני */
+    font-size: 0.8em;
+    font-family: 'Consolas', 'Monaco', monospace;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+/* --- 2. הנקודה הצבעונית --- */
+.lang-badge::before {
+    content: '';
+    display: block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    /* אם אין צבע מוגדר לשפה, משתמשים באפור ברירת מחדל */
+    background-color: var(--badge-color, #858585); 
+    flex-shrink: 0;
+}
+
+/* --- 3. מיפוי שפות מורחב (Top 50 Languages) --- */
+
+/* Web & Scripting */
+.lang-badge[data-lang="js"], 
+.lang-badge[data-lang="javascript"] { --badge-color: #f1e05a; }
+.lang-badge[data-lang="ts"],
+.lang-badge[data-lang="typescript"] { --badge-color: #3178c6; }
+.lang-badge[data-lang="html"]       { --badge-color: #e34c26; }
+.lang-badge[data-lang="css"]        { --badge-color: #563d7c; }
+.lang-badge[data-lang="php"]        { --badge-color: #4F5D95; }
+.lang-badge[data-lang="python"],
+.lang-badge[data-lang="py"]         { --badge-color: #3572A5; }
+.lang-badge[data-lang="ruby"],
+.lang-badge[data-lang="rb"]         { --badge-color: #701516; }
+
+/* Backend & Systems */
+.lang-badge[data-lang="java"]       { --badge-color: #b07219; }
+.lang-badge[data-lang="c"]          { --badge-color: #555555; }
+.lang-badge[data-lang="cpp"],
+.lang-badge[data-lang="c++"]        { --badge-color: #f34b7d; }
+.lang-badge[data-lang="csharp"],
+.lang-badge[data-lang="c#"],
+.lang-badge[data-lang="cs"]         { --badge-color: #178600; }
+.lang-badge[data-lang="go"]         { --badge-color: #00ADD8; }
+.lang-badge[data-lang="rust"],
+.lang-badge[data-lang="rs"]         { --badge-color: #dea584; }
+.lang-badge[data-lang="swift"]      { --badge-color: #F05138; }
+.lang-badge[data-lang="kotlin"]     { --badge-color: #A97BFF; }
+
+/* Data & Config */
+.lang-badge[data-lang="json"]       { --badge-color: #292929; }
+.lang-badge[data-lang="yaml"],
+.lang-badge[data-lang="yml"]        { --badge-color: #cb171e; }
+.lang-badge[data-lang="xml"]        { --badge-color: #0060ac; }
+.lang-badge[data-lang="sql"]        { --badge-color: #e38c00; }
+.lang-badge[data-lang="markdown"],
+.lang-badge[data-lang="md"]         { --badge-color: #083fa1; }
+.lang-badge[data-lang="dockerfile"] { --badge-color: #384d54; }
+.lang-badge[data-lang="shell"],
+.lang-badge[data-lang="bash"],
+.lang-badge[data-lang="sh"]         { --badge-color: #89e051; }
+
+/* Others */
+.lang-badge[data-lang="lua"]        { --badge-color: #000080; }
+.lang-badge[data-lang="r"]          { --badge-color: #198CE7; }
+.lang-badge[data-lang="perl"]       { --badge-color: #0298c3; }
+.lang-badge[data-lang="dart"]       { --badge-color: #00B4AB; }
+.lang-badge[data-lang="scala"]      { --badge-color: #c22d40; }
+.lang-badge[data-lang="elixir"]     { --badge-color: #6e4a7e; }
+.lang-badge[data-lang="haskell"]    { --badge-color: #5e5086; }
+
+/* Additional common languages */
+.lang-badge[data-lang="vue"]        { --badge-color: #41b883; }
+.lang-badge[data-lang="react"],
+.lang-badge[data-lang="jsx"],
+.lang-badge[data-lang="tsx"]        { --badge-color: #61dafb; }
+.lang-badge[data-lang="svelte"]     { --badge-color: #ff3e00; }
+.lang-badge[data-lang="angular"]    { --badge-color: #dd0031; }
+.lang-badge[data-lang="scss"],
+.lang-badge[data-lang="sass"]       { --badge-color: #c6538c; }
+.lang-badge[data-lang="less"]       { --badge-color: #1d365d; }
+.lang-badge[data-lang="graphql"]    { --badge-color: #e10098; }
+.lang-badge[data-lang="toml"]       { --badge-color: #9c4121; }
+.lang-badge[data-lang="ini"]        { --badge-color: #d1dbe0; }
+.lang-badge[data-lang="makefile"]   { --badge-color: #427819; }
+.lang-badge[data-lang="cmake"]      { --badge-color: #064f8c; }
+
+/* Mobile Development */
+.lang-badge[data-lang="objective-c"],
+.lang-badge[data-lang="objc"]       { --badge-color: #438eff; }
+.lang-badge[data-lang="flutter"]    { --badge-color: #02569b; }
+
+/* Functional & Other */
+.lang-badge[data-lang="clojure"]    { --badge-color: #db5855; }
+.lang-badge[data-lang="erlang"]     { --badge-color: #B83998; }
+.lang-badge[data-lang="f#"],
+.lang-badge[data-lang="fsharp"]     { --badge-color: #b845fc; }
+.lang-badge[data-lang="ocaml"]      { --badge-color: #3be133; }
+.lang-badge[data-lang="julia"]      { --badge-color: #a270ba; }
+.lang-badge[data-lang="nim"]        { --badge-color: #ffc200; }
+.lang-badge[data-lang="zig"]        { --badge-color: #ec915c; }
+.lang-badge[data-lang="v"]          { --badge-color: #5d87bf; }
+
+/* DevOps & Infrastructure */
+.lang-badge[data-lang="terraform"],
+.lang-badge[data-lang="tf"]         { --badge-color: #844fba; }
+.lang-badge[data-lang="ansible"]    { --badge-color: #1a1918; }
+.lang-badge[data-lang="puppet"]     { --badge-color: #302b6d; }
+.lang-badge[data-lang="helm"]       { --badge-color: #0f1689; }
+
+/* Text & Documentation */
+.lang-badge[data-lang="tex"],
+.lang-badge[data-lang="latex"]      { --badge-color: #3D6117; }
+.lang-badge[data-lang="rst"],
+.lang-badge[data-lang="restructuredtext"] { --badge-color: #141414; }
+.lang-badge[data-lang="asciidoc"]   { --badge-color: #73a0c5; }
+
+/* Database */
+.lang-badge[data-lang="plsql"]      { --badge-color: #dad8d8; }
+.lang-badge[data-lang="mongodb"]    { --badge-color: #13aa52; }
+.lang-badge[data-lang="redis"]      { --badge-color: #a51f17; }
+
+/* --- 4. התאמות לערכות נושא ספציפיות --- */
+
+/* High Contrast: נקודות בוהקות יותר */
+:root[data-theme="high-contrast"] .lang-badge {
+    border-color: var(--text-primary, #ffffff);
+}
+
+:root[data-theme="high-contrast"] .lang-badge::before {
+    box-shadow: 0 0 2px currentColor;
+}
+
+/* Light themes: גבול כהה יותר */
+:root[data-theme="ocean"] .lang-badge,
+:root[data-theme="rose-pine-dawn"] .lang-badge {
+    border-color: rgba(0, 0, 0, 0.2);
+}
+
+/* Dark themes: גבול בהיר יותר */
+:root[data-theme="dark"] .lang-badge,
+:root[data-theme="dim"] .lang-badge,
+:root[data-theme="nebula"] .lang-badge,
+:root[data-theme="classic"] .lang-badge {
+    border-color: rgba(255, 255, 255, 0.2);
+}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1409,6 +1409,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/codemirror-custom.css') }}?v={{ static_version }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/markdown-enhanced.css') }}?v={{ static_version }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/global_search.css') }}?v={{ static_version }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/lang-badge.css') }}?v={{ static_version }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/high-contrast.css') }}?v={{ static_version }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dark-mode.css') }}?v={{ static_version }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/theme-mask.css') }}?v={{ static_version }}">

--- a/webapp/templates/files.html
+++ b/webapp/templates/files.html
@@ -331,7 +331,7 @@
                     <div style="min-width:0;">
                         <h3 title="{{ file.file_name }}" style="margin: 0; font-size: 1.25rem; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; text-overflow:ellipsis; word-break:break-word; max-width:100%;">{{ file.file_name }}</h3>
                         <div style="display: flex; gap: 1rem; margin-top: 0.5rem;">
-                            <span class="badge">{{ file.language }}</span>
+                            <span class="lang-badge" data-lang="{{ file.language|lower }}">{{ file.language }}</span>
                             <span style="opacity: 0.7; font-size: 0.9rem;">{{ file.lines }} שורות</span>
                             <span style="opacity: 0.7; font-size: 0.9rem;">{{ file.size }}</span>
                         </div>

--- a/webapp/templates/html_preview.html
+++ b/webapp/templates/html_preview.html
@@ -46,7 +46,7 @@
             <div>
                 <h1 style="margin: 0;">תצוגת דפדפן: {{ file.file_name }}</h1>
                 <div style="display: flex; gap: 1rem; margin-top: 0.5rem;">
-                    <span class="badge">{{ file.language }}</span>
+                    <span class="lang-badge" data-lang="{{ file.language|lower }}">{{ file.language }}</span>
                 </div>
             </div>
         </div>

--- a/webapp/templates/shared_files.html
+++ b/webapp/templates/shared_files.html
@@ -16,7 +16,7 @@
           <div style="display:flex; flex-direction:column; min-width:0;">
             <strong title="{{ item.file_name }}" style="display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; text-overflow:ellipsis; word-break:break-word; max-width:100%;">{{ item.file_name }}</strong>
             <div style="display:flex; gap:.5rem; flex-wrap:wrap; opacity:.8; font-size:.9rem;">
-              <span class="badge">{{ item.language }}</span>
+              <span class="lang-badge" data-lang="{{ item.language|lower }}">{{ item.language }}</span>
               <span class="badge">{{ item.lines }} שורות</span>
               {% if item.size %}<span class="badge">{{ item.size }}</span>{% endif %}
             </div>

--- a/webapp/templates/trash.html
+++ b/webapp/templates/trash.html
@@ -48,7 +48,7 @@
                             <div style="min-width:0;">
                                 <div style="font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;" title="{{ it.file_name }}">{{ it.file_name }}</div>
                                 <div style="opacity:0.8; font-size:0.9rem; display:flex; gap:0.5rem; flex-wrap:wrap;">
-                                    <span class="badge">{{ it.language }}</span>
+                                    <span class="lang-badge" data-lang="{{ it.language|lower }}">{{ it.language }}</span>
                                     {% if it.version %}
                                     <span class="badge" style="opacity:0.9;">v{{ it.version }}</span>
                                     {% endif %}

--- a/webapp/templates/view_file.html
+++ b/webapp/templates/view_file.html
@@ -739,7 +739,7 @@ body.telegram-mini-app .file-title { font-size: 1.125rem; }
             <div class="file-title-wrap">
                 <h1 class="file-title">{{ file.file_name }}</h1>
                 <div class="file-subrow">
-                    <span class="badge">{{ file.language }}</span>
+                    <span class="lang-badge" data-lang="{{ file.language|lower }}">{{ file.language }}</span>
                     <span class="muted">גרסה {{ file.version }}</span>
                 </div>
             </div>


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו עיצוב חדש לתגיות שפה (Language Badges) ברחבי המערכת, בסגנון GitHub, הכולל נקודה צבעונית ייחודית לכל שפה. השינוי משפר את חווית המשתמש ומאפשר זיהוי מהיר יותר של סוגי קבצים.

## 📦 שינויים עיקריים
- [x] קוד (Backend) - שינויים ב-Frontend (CSS ו-HTML)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- **קובץ CSS חדש**: `webapp/static/css/lang-badge.css` המגדיר את העיצוב החדש לתגיות השפה, כולל נקודה צבעונית (למעלה מ-50 שפות נתמכות) והתאמה לכל ערכות הנושא.
- **שילוב CSS**: הוספת הקישור לקובץ ה-CSS החדש ב-`webapp/templates/base.html`.
- **עדכון תבניות HTML**: החלפת תגיות `<span class="badge">` קיימות ב-`<span class="lang-badge" data-lang="...">` בקבצים:
    - `files.html`
    - `view_file.html`
    - `trash.html`
    - `shared_files.html`
    - `html_preview.html`

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [ ] Unit
- [ ] Integration
- [x] Manual - בוצעה בדיקה ויזואלית של העיצוב החדש בעמודי הקבצים השונים ב-staging, כולל בדיקה של שפות שונות וערכות נושא שונות (Dark/Light/Ocean/High-Contrast). כל התגיות הוצגו כראוי.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (שיפור ויזואלי)
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות עברו)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: השינוי הוא ויזואלי בלבד ואינו צפוי להשפיע על ביצועים או אבטחה. הסיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-commit זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-b774dc85-3a3c-43b9-8115-b2641a5995be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b774dc85-3a3c-43b9-8115-b2641a5995be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub-style language badge with a colored dot and theme-aware styling.
> 
> - New `webapp/static/css/lang-badge.css` with language→color mapping (50+ langs) and theme overrides
> - Include stylesheet in `base.html`
> - Replace language `<span class="badge">` with `<span class="lang-badge" data-lang="...">` in `files.html`, `view_file.html`, `trash.html`, `shared_files.html`, and `html_preview.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc660d23e544cce4f3ddee834c0cce36f55e843. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->