### PR TITLE
Markdown rendering issue highlighter

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -18,6 +18,7 @@
   border: none; /* ביטול מסגרת (שנתפסה כ"סגולה") */
   padding: 14px; /* ריווח אחיד ועדין – לא מרחיק את הבלוק מהגבול */
   transition: background-color 0.3s ease, color 0.3s ease;
+  --md-mark-bg: #fff2a8;
   --md-inline-code-bg: #f6f8fa;
   --md-inline-code-border: #d0d7de;
   --md-inline-code-color: #1f2328;
@@ -63,6 +64,7 @@
 }
 
 [data-theme="dark"] #md-content {
+  --md-mark-bg: rgba(220, 204, 68, 0.28);
   --md-inline-code-bg: rgba(255, 255, 255, 0.08);
   --md-inline-code-border: rgba(255, 255, 255, 0.2);
   --md-inline-code-color: #e9ecff;
@@ -100,6 +102,7 @@
 }
 
 [data-theme="dim"] #md-content {
+  --md-mark-bg: rgba(220, 204, 68, 0.25);
   --md-inline-code-bg: rgba(236, 239, 244, 0.08);
   --md-inline-code-border: rgba(236, 239, 244, 0.18);
   --md-inline-code-color: #eceff4;
@@ -137,6 +140,7 @@
 }
 
 [data-theme="nebula"] #md-content {
+  --md-mark-bg: rgba(220, 204, 68, 0.28);
   --md-inline-code-bg: rgba(248, 248, 242, 0.08);
   --md-inline-code-border: rgba(248, 248, 242, 0.2);
   --md-inline-code-color: #f8f8f2;
@@ -174,6 +178,7 @@
 }
 
 :root[data-theme="rose-pine-dawn"] #md-content {
+  --md-mark-bg: rgba(234, 157, 52, 0.28);
   --md-inline-code-bg: rgba(244, 219, 214, 0.9);
   --md-inline-code-border: rgba(180, 99, 122, 0.4);
   --md-inline-code-color: #4a2c2a;
@@ -216,6 +221,7 @@
 [data-theme^="shared:"] #md-content {
   background: var(--bg-primary, var(--md-surface, #1a1c23));
   color: var(--text-primary, var(--md-text, #e5eaf7));
+  --md-mark-bg: color-mix(in srgb, var(--warning, #DCCC44) 30%, transparent);
   /* Inline code: mix 12% of text color into background for visible contrast */
   --md-inline-code-bg: color-mix(in srgb, var(--text-primary, #ffffff) 12%, var(--bg-primary, #1a1c23));
   --md-inline-code-border: color-mix(in srgb, var(--text-primary, #ffffff) 20%, transparent);
@@ -255,6 +261,14 @@
   --md-table-border: color-mix(in srgb, var(--text-primary, #ffffff) 20%, transparent);
   /* Table header: 12% mix for clear distinction */
   --md-table-header-bg: color-mix(in srgb, var(--text-primary, #ffffff) 12%, var(--bg-primary, #1a1c23));
+}
+
+/* Highlight ("marker") syntax: ==text== -> <mark>text</mark> */
+#md-content mark {
+  background: var(--md-mark-bg, #fff2a8);
+  color: inherit;
+  padding: 0 0.15em;
+  border-radius: 0.25em;
 }
 
 /* Mermaid diagrams - ensure readable colors for custom/shared themes */
@@ -2096,6 +2110,65 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
       // לא לבצע הדגשה בשלב ה-render של markdown-it; נבצע post-process עם hljs
       highlight: function (_str, _lang) { return ''; }
     })
+    // תמיכה בהדגשת "טוש" בתחביר Markdown: ==טקסט== -> <mark>טקסט</mark>
+    ;(function enableMarkdownMark(){
+      try {
+        function markdownItMarkPlugin(mdInstance) {
+          function isSpace(code) {
+            return code === 0x20 /* space */ || code === 0x0A /* \n */ || code === 0x09 /* \t */;
+          }
+          function isEscaped(src, pos) {
+            // pos הוא תחילת הסוגריים "==" (כלומר התו הראשון)
+            let backslashes = 0;
+            let i = pos - 1;
+            while (i >= 0 && src.charCodeAt(i) === 0x5C /* \ */) { backslashes += 1; i -= 1; }
+            return (backslashes % 2) === 1;
+          }
+          function tokenize(state, silent) {
+            const start = state.pos;
+            const max = state.posMax;
+            const src = state.src;
+
+            if (start + 4 > max) return false; // מינימום: ==a==
+            if (src.charCodeAt(start) !== 0x3D || src.charCodeAt(start + 1) !== 0x3D) return false; // "=="
+
+            const next = src.charCodeAt(start + 2);
+            if (isSpace(next)) return false; // לא פותחים הדגשה עם רווח מיד אחרי
+
+            // חיפוש סוגר תואם
+            let end = start + 2;
+            while (true) {
+              end = src.indexOf('==', end);
+              if (end < 0 || end + 2 > max) return false;
+              if (end === start + 2) { end += 2; continue; } // "====" לא שימושי
+              if (isSpace(src.charCodeAt(end - 1))) { end += 2; continue; } // לא סוגרים עם רווח לפני
+              if (isEscaped(src, end)) { end += 2; continue; } // סוגר עם escape
+              break;
+            }
+
+            if (silent) return true;
+
+            // פתיחה
+            const open = state.push('mark_open', 'mark', 1);
+            open.markup = '==';
+
+            // תוכן פנימי – נותן ל-markdown-it לפרש גם **, _, קישורים וכו'
+            const inner = src.slice(start + 2, end);
+            state.md.inline.parse(inner, state.md, state.env, state.tokens);
+
+            // סגירה
+            const close = state.push('mark_close', 'mark', -1);
+            close.markup = '==';
+
+            state.pos = end + 2;
+            return true;
+          }
+
+          mdInstance.inline.ruler.before('emphasis', 'mark', tokenize);
+        }
+        md.use(markdownItMarkPlugin);
+      } catch(_) {}
+    })();
     if (window.markdownitEmoji) md.use(window.markdownitEmoji);
     if (window.markdownitTaskLists) md.use(window.markdownitTaskLists, { label: true, enabled: true });
     // עוגני כותרות – הגדרה יציבה למניעת רגרסיות בין גרסאות התוסף


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו תמיכה בתחביר Markdown חדש `==טקסט==` כדי לאפשר הדגשת טקסט (בדומה ל"טוש") ב-Markdown preview. שינוי זה מאפשר למשתמשים להדגיש תוכן מבלי להפעיל HTML גולמי, ובכך שומר על אבטחה.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת תוסף `markdown-it` מותאם אישית ב־`webapp/templates/md_preview.html` לזיהוי תחביר `==טקסט==`.
- המרת `==טקסט==` לתגית `<mark>טקסט</mark>` ב־Markdown preview.
- הוספת הגדרות CSS לתגית `<mark>` עבור ערכות נושא שונות, כולל תמיכה ב-`--md-mark-bg` עבור התאמה אישית.
- השארת `html: false` ב־`markdown-it` למניעת XSS.

## 🧪 בדיקות
בדקתי ידנית את הרינדור של `==טקסט מודגש בטוש==` וגם `==**טקסט מודגש**==` ב-Markdown preview, והם מוצגים כראוי עם הדגשה.
- [ ] Unit
- [ ] Integration
- [X] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [X] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [X] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [X] בדיקות רצות ועוברות (בדיקה ידנית)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [X] אין סודות/מפתחות בקוד
- [X] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [X] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
הסיכון נמוך. השינוי הוא בצד הלקוח בלבד ואינו משפיע על לוגיקת השרת או מסד הנתונים. שמירה על `html: false` מונעת סיכוני XSS.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:

## 🧯 סיכון / החזרה לאחור (Rollback)
במקרה תקלה, ניתן לבצע Rollback על ידי החזרת הקובץ `webapp/templates/md_preview.html` לגרסתו הקודמת.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e0c8263-23a3-4261-86e5-6418b8d10c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e0c8263-23a3-4261-86e5-6418b8d10c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables non-HTML highlight (“marker”) syntax in Markdown preview.
> 
> - Adds a custom `markdown-it` inline plugin in `md_preview.html` to parse `==...==` into `mark_open/mark_close`, handling escapes and nested inline content
> - Introduces `--md-mark-bg` and styles `#md-content mark`; sets theme-specific values for light/dark/dim/nebula/rose-pine-dawn/custom themes
> - Keeps `html: false` and existing rendering pipeline intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 437e385211464f802ab340df1a9b179b0368554e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->