### PR TITLE
Markdown html code highlighting

### DIFF
--- a/services/styled_export_service.py
+++ b/services/styled_export_service.py
@@ -597,6 +597,7 @@ def get_pygments_style_for_theme(theme_id: str, theme_category: str = "dark") ->
 def generate_pygments_css(
     style_name: str = "monokai",
     css_class: str = ".highlight",
+    theme_category: str = "dark",
 ) -> str:
     """
     מייצר CSS להדגשת תחביר באמצעות Pygments.
@@ -604,6 +605,7 @@ def generate_pygments_css(
     Args:
         style_name: שם ה-Pygments style (לדוגמה: 'monokai', 'default', 'github-dark')
         css_class: ה-CSS class שמשמש לעטיפת הקוד (ברירת מחדל: '.highlight')
+        theme_category: קטגוריית הערכה ('dark' או 'light') - משמש לבחירת fallback מתאים
 
     Returns:
         מחרוזת CSS עם הגדרות הצבעים להדגשת תחביר
@@ -617,9 +619,21 @@ def generate_pygments_css(
         try:
             style = get_style_by_name(style_name)
         except Exception:
-            # אם לא נמצא, השתמש ב-monokai כברירת מחדל
-            logger.warning("Pygments style '%s' not found, using monokai", style_name)
-            style = get_style_by_name("monokai")
+            # אם לא נמצא, השתמש ב-fallback לפי הקטגוריה
+            # 🔒 הגנה מפני None
+            category = (theme_category or "dark").lower()
+            fallback_style = (
+                PYGMENTS_STYLE_LIGHT_FALLBACK
+                if category == "light"
+                else PYGMENTS_STYLE_DARK_FALLBACK
+            )
+            logger.warning(
+                "Pygments style '%s' not found, using %s fallback for %s theme",
+                style_name,
+                fallback_style,
+                category,
+            )
+            style = get_style_by_name(fallback_style)
 
         # יצירת ה-formatter עם ה-style
         formatter = HtmlFormatter(style=style, cssclass=css_class.lstrip("."))
@@ -751,7 +765,10 @@ def render_styled_html(
 
         # ייצור ה-CSS
         # 🔒 CSS מ-Pygments הוא בטוח (מיוצר פנימית), אבל נעביר דרך sanitize בכל מקרה
-        syntax_css = sanitize_css(generate_pygments_css(pygments_style, ".highlight"))
+        # מעבירים את הקטגוריה כדי לבחור fallback מתאים אם ה-style לא נמצא
+        syntax_css = sanitize_css(
+            generate_pygments_css(pygments_style, ".highlight", theme_category)
+        )
 
     # ייבוא מאוחר כדי לאפשר שימוש בפונקציות אחרות גם בלי Flask (למשל בטסטים)
     from flask import render_template

--- a/tests/test_styled_export.py
+++ b/tests/test_styled_export.py
@@ -133,10 +133,16 @@ class TestPygmentsCssGeneration:
         assert "color:" in css or "background:" in css
 
     @pytest.mark.skipif(not HAS_PYGMENTS, reason="Pygments not installed")
-    def test_generate_pygments_css_fallback_on_invalid_style(self):
-        """fallback ל-monokai כשהסגנון לא קיים"""
-        css = generate_pygments_css("nonexistent-style-xyz", ".highlight")
+    def test_generate_pygments_css_fallback_dark_on_invalid_style(self):
+        """fallback ל-monokai (dark) כשהסגנון לא קיים וקטגוריה כהה"""
+        css = generate_pygments_css("nonexistent-style-xyz", ".highlight", "dark")
         assert css  # אמור להחזיר CSS גם כשהסגנון לא קיים
+
+    @pytest.mark.skipif(not HAS_PYGMENTS, reason="Pygments not installed")
+    def test_generate_pygments_css_fallback_light_on_invalid_style(self):
+        """fallback ל-default (light) כשהסגנון לא קיים וקטגוריה בהירה"""
+        css = generate_pygments_css("nonexistent-style-xyz", ".highlight", "light")
+        assert css  # אמור להחזיר CSS מתאים לערכה בהירה
 
     @pytest.mark.skipif(not HAS_PYGMENTS, reason="Pygments not installed")
     def test_generate_pygments_css_default_style(self):


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון פיצ'ר ייצוא Markdown ל-HTML כך שבלוקי קוד יכללו הדגשת תחביר (צבעים). הבעיה נבעה מחוסר ב-CSS מתאים להדגשת התחביר, והפתרון הוא יצירת CSS דינמי באמצעות Pygments והזרקתו ל-HTML.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות:
- שילוב ספריית Pygments לייצור CSS דינמי להדגשת תחביר.
- מיפוי ערכות נושא קיימות לסגנונות Pygments מתאימים.
- פונקציה חדשה `generate_pygments_css` המייצרת את ה-CSS הנדרש.
- עדכון הפונקציה `render_styled_html` להזרקת ה-CSS שנוצר ל-HTML הסופי, אם אין `syntax_css` מוגדר מראש בערכה.
- עדכון `get_export_theme` להחזרת `id` ו-`category` של הערכה לצורך בחירת סגנון Pygments נכון.

## 🧪 בדיקות
- כל 17 הטסטים הקיימים עברו בהצלחה. נוספו 9 טסטים חדשים לבדיקת הפונקציונליות החדשה:
  - 6 טסטים ב-`TestPygmentsCssGeneration` לבדיקת יצירת CSS דינמי ו-fallback.
  - 3 טסטים ב-`TestGetExportThemeWithMetadata` לוודא שה-metadata של הערכה מוחזר כראוי.
- כל 26 הטסטים עברו בהצלחה.
- [x] Unit

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (ראו .cursorrules)
- [ ] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: הסיכון נמוך. במקרה של כשל בייצור ה-CSS, הדגשת התחביר לא תופיע, אך המסמך עדיין יוצג. קיימת מערכת fallback ל-Pygments style.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR זה. השינויים הם בעיקרם תוספתיים ואינם משנים התנהגות קיימת באופן שובר תאימות.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ca91fa3-0c13-45b6-ac79-ae6fb7cc3800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ca91fa3-0c13-45b6-ac79-ae6fb7cc3800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables syntax-highlighted code in exported HTML by generating CSS dynamically when a theme lacks `syntax_css`.
> 
> - Add Pygments integration (`HAS_PYGMENTS`, `generate_pygments_css`, `get_pygments_style_for_theme`) with dark/light fallbacks and theme→style mapping
> - Update `render_styled_html` to inject sanitized Pygments CSS for `.highlight` when needed
> - Extend `get_export_theme` to include `id` and `category` for correct style selection; preserve existing presets and fallback
> - Add targeted tests for Pygments CSS generation and theme metadata in `tests/test_styled_export.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25462bedbc33a59b9681b04e7f9c755c2a744da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->