### PR TITLE
Cursor/markdown html code highlighting cf9f

### DIFF
--- a/webapp/templates/export/styled_document.html
+++ b/webapp/templates/export/styled_document.html
@@ -410,8 +410,15 @@
                 background: #f5f5f5;
             }
 
-            code {
+            code,
+            pre code {
                 color: #333;
+            }
+
+            /* דריסת צבעי syntax highlighting בהדפסה */
+            .highlight pre code,
+            .highlight code span {
+                color: #333 !important;
             }
         }
     </style>


### PR DESCRIPTION
סיכום כל השינויים
1. services/styled_export_service.py:
א. הוספת Pygments imports ומיפוי:

from pygments.formatters import HtmlFormatter
from pygments.styles import get_style_by_name
 
THEME_TO_PYGMENTS_STYLE = {
    "tech-guide-dark": "monokai",
    "github-dark": "github-dark",
    "clean-light": "default",
    # ...
}
ב. פונקציה חדשה generate_pygments_css():

מייצרת CSS דינמי באמצעות Pygments
תומכת ב-fallback לפי קטגוריית הערכה (dark/light)
ג. עדכון get_export_theme():

מחזירה גם id ו-category לשימוש בייצור CSS דינמי
ד. עדכון render_styled_html():

אם אין syntax_css בערכה → מייצר CSS דינמי מ-Pygments
ה. הגנה מפני None:

בכל המקומות שמקבלים category יש הגנה מפני null מ-MongoDB
2. webapp/templates/export/styled_document.html:
תיקון CSS:

/* לפני - דורס את הצבעים של syntax highlighting */
code {
    color: var(--code-text, #d4d4d4);
}
 
/* אחרי - רק לקוד ללא highlighting */
pre:not(.highlight) code {
    color: var(--code-text, #d4d4d4);
}
3. tests/test_styled_export.py:
11 טסטים חדשים לכיסוי הפונקציונליות החדשה


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves code styling to better separate inline and block code and avoid clobbering syntax highlighting.
> 
> - Refactors default inline `code` styles and adds explicit `pre code` rules so block code doesn’t inherit inline backgrounds/padding and uses full font size
> - Ensures highlighted blocks (`.highlight pre code`) inherit colors from the Pygments CSS instead of being overridden
> - Updates print styles to set unified code color (`code`, `pre code`, and `.highlight` spans) for legibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b78d4359348b300e5d4e6fca3d4ac7bd6706fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->