### PR TITLE
Cursor/markdown html code highlighting cf9f

### DIFF
--- a/services/styled_export_service.py
+++ b/services/styled_export_service.py
@@ -509,13 +509,15 @@ def get_export_theme(
                 continue
             if theme.get("id") == theme_id:
                 # 🔧 תיקון: אם ה-syntax_css שמור עם selector ישן (.source),
-                # נייצר מחדש עם ה-selector הנכון (.highlight)
+                # נתקן את ה-Pygments selectors בלבד (לא לפגוע ב-CodeMirror)
                 stored_css = theme.get("syntax_css", "")
                 if stored_css and ".source " in stored_css:
-                    # CSS ישן - צריך לתקן
-                    stored_css = stored_css.replace(".source ", ".highlight ")
-                    # גם להסיר את ה-attribute selector הישן
-                    stored_css = stored_css.replace('[data-theme-type="custom"] ', '')
+                    # תיקון Pygments CSS: [data-theme-type="custom"] .source .X → .highlight .X
+                    # ⚠️ לא לגעת ב-CodeMirror שמתחיל ב-:root[data-theme-type="custom"]
+                    stored_css = stored_css.replace(
+                        '[data-theme-type="custom"] .source ',
+                        '.highlight '
+                    )
                 
                 return {
                     "id": theme_id,


### PR DESCRIPTION
עכשיו יש לנו שני תיקונים:

קובץ	תיקון
theme_parser_service.py	ערכות חדשות מיוצרות עם .highlight
styled_export_service.py	ערכות ישנות מה-DB מתוקנות אוטומטית
אחרי deploy, כל הערכות יעבדו - גם הישנות וגם החדשות! 🎉

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures legacy user themes render correctly by normalizing old Pygments selectors.
> 
> - In `get_export_theme`, detect `.source ` in stored `syntax_css` and replace `[data-theme-type="custom"] .source ` with `.highlight ` (skips CodeMirror rules starting with `:root[data-theme-type="custom"]`)
> - Return the corrected `stored_css` for user themes instead of the raw `syntax_css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1739f109c02b2dd75684eac5f3b676b76fbbda3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->