### PR TITLE
Disable profiler overhead

### DIFF
--- a/handlers/profiler_handler.py
+++ b/handlers/profiler_handler.py
@@ -62,6 +62,18 @@ def require_profiler_auth(handler):
 
 def setup_profiler_routes(app: web.Application, profiler_service: QueryProfilerService):
     """הגדרת routes לפרופיילר"""
+    # נטרול מוחלט של פרופיילר: routes חייבים להיות מיידיים וללא DB/חישובים/איסוף בזיכרון.
+    # (שומרים את הקוד הקיים למקרה שיחזור בעתיד, אבל כרגע לא משתמשים בו)
+    async def _disabled(_request: web.Request) -> web.Response:
+        return web.json_response({"status": "disabled"})
+
+    app.router.add_get("/api/profiler/slow-queries", _disabled)
+    app.router.add_post("/api/profiler/explain", _disabled)
+    app.router.add_post("/api/profiler/recommendations", _disabled)
+    app.router.add_post("/api/profiler/analyze", _disabled)
+    app.router.add_get("/api/profiler/summary", _disabled)
+    app.router.add_get("/api/profiler/collection/{name}/stats", _disabled)
+    return
 
     @require_profiler_auth
     async def get_slow_queries(request: web.Request) -> web.Response:


### PR DESCRIPTION
## ✨ תיאור קצר
השבתה מוחלטת של הפרופיילר כדי לצמצם עומס (overhead) על המערכת ולפתור עיכובים משמעותיים ב-`/api/profiler/summary`. ה-endpoint יחזיר כעת תגובה מיידית ללא לוגיקה כבדה, DB או חישובים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- נטרול כל ה-endpoints של `/api/profiler/*` ב-Flask (`webapp/app.py`) וב-aiohttp (`handlers/profiler_handler.py`) כך שיחזירו `{"status": "disabled"}` מיידית, ללא ביצוע שאילתות DB או חישובים.
- מניעת רישום `CommandListener` של PyMongo ב-`database/manager.py` כאשר גם ה-profiler וגם לוגי ה-slow_mongo כבויים. זה מונע איסוף נתונים וצבירת זיכרון (context) מיותרים.
- הוספת פקודת `db.command("profile", 0)` ל-MongoDB בעת החיבור ב-`database/manager.py`, להשבתת איסוף שאילתות איטיות ברמת ה-DB (best-effort).
- ניקוי זיכרון: מאחר שה-listener לא נרשם ו/או לא שומר context כשהפרופיילר כבוי, אין צבירה של נתוני profiler בזיכרון.

## 🧪 בדיקות
- הרצתי בדיקות יחידה ממוקדות (כולל `test_db_manager_profiler_runs_when_slow_mongo_disabled`) שעברו בהצלחה.
- בדיקות ידניות לוודא שה-endpoints של `/api/profiler/*` מחזירים `{"status": "disabled"}` באופן מיידי.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [x] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית על ביצועי המערכת עקב הסרת עומס מהפרופיילר. אין סיכון לפונקציונליות קיימת מכיוון שהפרופיילר מושבת לחלוטין.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- ביטול ה-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9d3464e-ebec-4a39-913e-7bba622d20d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9d3464e-ebec-4a39-913e-7bba622d20d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

