### PR TITLE
נראות פקודות מנהל

### DIFF
--- a/tests/test_help_listing.py
+++ b/tests/test_help_listing.py
@@ -69,6 +69,14 @@ def test_build_help_message_shows_admin_section_for_admin():
     assert "<code>/status</code>" in text
 
 
+def test_admin_help_does_not_duplicate_cache_commands():
+    # cache_stats/clear_cache מוגדרים גם בקטלוג ChatOps וגם בסקשן "מטמון".
+    # בעזרת אדמין לא אמורים לראות אותם כפעמיים.
+    text = mod._build_help_message({"cache_stats", "clear_cache", "status"}, is_admin=True)
+    assert text.count("<code>/cache_stats</code>") == 1
+    assert text.count("<code>/clear_cache</code>") == 1
+
+
 @pytest.mark.asyncio
 async def test_codekeeperbot_help_command_uses_registered_commands(monkeypatch):
     bot = object.__new__(mod.CodeKeeperBot)


### PR DESCRIPTION
Make the "Admin (Limited)" section in `/help` visible only to admins and dynamically populate its commands from the ChatOps catalog.

Previously, the admin section in `/help` was displayed to all users if the commands were registered, regardless of their admin status. This change ensures that the section is correctly restricted to administrators and keeps the command list synchronized with the official documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-78c1eddc-17ce-47ba-8e24-80c92f516f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78c1eddc-17ce-47ba-8e24-80c92f516f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts and streamlines the admin help section while sourcing it from a single catalog.
> 
> - Add `admin_only` and `entries_source` to `HelpSection`; compute `NON_ADMIN_SECTION_COMMANDS` to avoid duplicates
> - Load ChatOps commands via `_load_chatops_commands_catalog()` from `webapp/static/data/commands.json`; map to `HelpEntry` in `_build_chatops_help_entries_from_catalog()`
> - Resolve section entries dynamically with `_resolve_section_entries()`; remove static admin lines from `STATIC_HELP_MESSAGE`
> - Update `_build_help_message(…, is_admin=...)` and call sites to check `chatops.permissions.is_admin`
> - Tests: visibility for admins vs non-admins and deduplication of `cache_stats`/`clear_cache`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebb5cdb0f28dc564fac44921d14a916e8a6eef1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->