### PR TITLE
Observability dashboard issues

### DIFF
--- a/monitoring/alerts_storage.py
+++ b/monitoring/alerts_storage.py
@@ -51,15 +51,16 @@ def _read_enabled() -> bool:
     קריאה מה-DB נשארת פעילה תמיד (אלא אם מושבתת מפורשות),
     כדי שדשבורד ה-Observability יציג נתונים היסטוריים גם כשהכתיבה מושבתת.
     """
-    if _is_true(os.getenv("DISABLE_DB")):
-        return False
     if _is_true(os.getenv("DISABLE_ALERTS_READS")):
         return False
-    # אם ALERTS_DB_ENABLED=true או METRICS_DB_ENABLED=true - אפשר לקרוא
+    # Explicit opt-in wins over global disable (tests often set DISABLE_DB=1 by default).
+    # אם ALERTS_DB_ENABLED=true או METRICS_DB_ENABLED=true - אפשר לקרוא (גם אם DISABLE_DB=true)
     if _is_true(os.getenv("ALERTS_DB_ENABLED")):
         return True
     if _is_true(os.getenv("METRICS_DB_ENABLED")):
         return True
+    if _is_true(os.getenv("DISABLE_DB")):
+        return False
     # Fallback: אפשר קריאה אם יש MongoDB URL מוגדר (גם בלי הדגלים)
     return bool(os.getenv("MONGODB_URL"))
 


### PR DESCRIPTION
## ✨ תיאור קצר
תיקון באג ב-`alerts_storage.py` שגרם לדשבורד ה-Observability לא להציג נתונים (כמו אירועי דיפלוימנט וגרפי התראות). הבעיה נבעה מהשבתה שגויה של קריאה מה-DB כאשר כתיבה מושבתת, גם אם קיים חיבור ל-MongoDB.

## 📦 שינויים עיקריים
- [X] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הפרדת לוגיקת הפעלת קריאה (`_read_enabled()`) מכתיבה (`_write_enabled()`) ב-`monitoring/alerts_storage.py`.
- עדכון הפונקציה `_get_collection` לקבל פרמטר `for_read` המאפשר אתחול חיבור לקריאה גם כשהכתיבה מושבתת.
- הוספת דגל `_write_disabled` להבחנה בין השבתה מכוונת של כתיבה לכשל באתחול.
- עדכון קריאות לפונקציות ה-DB (כמו `record_alert`, `count_alerts_since`) להשתמש בפרמטר `for_read` המתאים.

## 🧪 בדיקות
- הפעלתי את בדיקות היחידה הקיימות (unit tests) והן עברו בהצלחה.
- [X] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [X] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [X] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [X] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [X] אין סודות/מפתחות בקוד
- [X] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [X] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית: דשבורד ה-Observability יציג כעת נתונים מלאים ונכונים עבור אירועי דיפלוימנט, גרפי התראות ו-Context drill-down.
- סיכון נמוך: השינויים ממוקדים בלוגיקת הפעלת ה-DB.

## 🔗 קישורים
- Issues קשורים: # (תיקון המשך ל-`03c1a3d5`)
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לחזור לגרסה הקודמת של `monitoring/alerts_storage.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-79bd2935-d02c-4040-bfb7-6cb44519b50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79bd2935-d02c-4040-bfb7-6cb44519b50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores Observability dashboard data by separating read vs write enablement in `alerts_storage.py`.
> 
> - Introduces `_read_enabled()` (with `DISABLE_ALERTS_READS` and `MONGODB_URL` fallback) and refines `_write_enabled()`; `_enabled()` now delegates to write for compatibility
> - Updates `_get_collection` and `_get_catalog_collection` to accept `for_read` and to distinguish `_write_disabled` from `_init_failed`, enabling read-only connections when writes are off
> - Adjusts call sites: write paths (`record_alert`, `is_new_error`) use `for_read=False`; read paths (`count_alerts_since`, `list_recent_alert_ids`, other fetch/aggregate helpers) use read mode
> - Maintains fail-open behavior and best-effort indexing; no schema changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d000ab8b6fd72938aa60075ff6e458c516df9fe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->