### PR TITLE
Cursor/worker push delivery url ba24

### DIFF
--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -2895,11 +2895,9 @@
           return;
         }
 
-        // Mark as bound so the ES5 fallback binder won't double-bind on modern browsers.
+        // If another binder already attached handlers, do nothing.
         try {
-          pushEnableBtn.setAttribute('data-bound', '1');
-          pushDisableBtn.setAttribute('data-bound', '1');
-          pushTestBtn.setAttribute('data-bound', '1');
+          if (pushEnableBtn.getAttribute('data-bound') === '1') return;
         } catch (_) {}
 
         function setPushStatus(text){ pushStatus.textContent = text; }
@@ -3034,6 +3032,11 @@
       if (pushEnableBtn) pushEnableBtn.addEventListener('click', enablePush);
       if (pushDisableBtn) pushDisableBtn.addEventListener('click', disablePush);
       if (pushTestBtn) pushTestBtn.addEventListener('click', testPush);
+      try {
+        pushEnableBtn.setAttribute('data-bound', '1');
+        pushDisableBtn.setAttribute('data-bound', '1');
+        pushTestBtn.setAttribute('data-bound', '1');
+      } catch (_) {}
       refreshPushUi();
       }
       {% endif %}
@@ -3204,12 +3207,14 @@
             var testBtn = byId('pushTestBtn');
             if (!enableBtn || !disableBtn || !testBtn) return;
             if (enableBtn.getAttribute('data-bound') === '1') return;
-            enableBtn.setAttribute('data-bound', '1');
-            disableBtn.setAttribute('data-bound', '1');
-            testBtn.setAttribute('data-bound', '1');
             enableBtn.addEventListener('click', function (e) { try { e.preventDefault(); } catch (_) {} enablePush(); });
             disableBtn.addEventListener('click', function (e) { try { e.preventDefault(); } catch (_) {} disablePush(); });
             testBtn.addEventListener('click', function (e) { try { e.preventDefault(); } catch (_) {} testPush(); });
+            try {
+              enableBtn.setAttribute('data-bound', '1');
+              disableBtn.setAttribute('data-bound', '1');
+              testBtn.setAttribute('data-bound', '1');
+            } catch (_) {}
             refreshPushUi();
           }
 


### PR DESCRIPTION

הבנתי למה זה “לא עזר”: בדף ההגדרות יש הרבה תחביר JS מודרני (?. ו־??). בוובוויו/דפדפן ישן זה יכול להפיל את כל הסקריפט של הדף עם שגיאת syntax — ואז הכפתורים של Web Push לא יקבלו מאזיני click, ולכן גם לא תראה שום בקשות/לוגים.

כדי לעקוף את זה הוספתי סקריפט קטן ונפרד (ES5) שמחבר את שלושת הכפתורים ומעדכן את pushStatus, גם אם הסקריפט הגדול נפל. זה כבר commit+push לענף cursor/worker-push-delivery-url-ba24 (קומיט: 87030d8b).

אחרי הדיפלוי, אמור להיות לפחות שינוי מיידי בטקסט “מצב לא ידוע” כשאתה לוחץ (למשל “בודק תמיכה בדפדפן…” / “שולח פוש בדיקה…”).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens Web Push settings to work in older browsers/WebViews and avoids duplicate handlers.
> 
> - Adds a small ES5-compatible binder that registers Service Worker, handles subscribe/unsubscribe/test, and updates `pushStatus` so buttons function even if the main settings script fails
> - In the primary Web Push init, prevents double-binding by checking `data-bound` and marking `pushEnableBtn`/`pushDisableBtn`/`pushTestBtn` as bound
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00565d88878fef2b84fc42c352fa419033c0ad00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->