### PR TITLE
Cursor/worker push delivery url ba24

### DIFF
--- a/webapp/templates/settings_push_debug.html
+++ b/webapp/templates/settings_push_debug.html
@@ -406,8 +406,12 @@ function unregisterServiceWorkerNow() {
         return;
       }
       return reg.unregister().then(function (ok) {
-        _setBrowserActionsStatus(ok ? 'Service Worker בוטל. מרענן...' : 'לא הצלחתי לבטל Service Worker');
-        try { location.reload(); } catch (_) {}
+        if (ok) {
+          _setBrowserActionsStatus('Service Worker בוטל. מרענן...');
+          try { location.reload(); } catch (_) {}
+          return;
+        }
+        _setBrowserActionsStatus('לא הצלחתי לבטל Service Worker');
       });
     }).catch(function (e) {
       _setBrowserActionsStatus('שגיאה בביטול Service Worker: ' + String((e && e.message) || e || 'unknown'));


### PR DESCRIPTION

זה דווקא כן אמין—פשוט מדובר על שני דברים שונים:

“מחק את כל המנויים” מוחק את המנויים בשרת (MongoDB).
אבל הדפדפן עדיין יכול להחזיק מנוי מקומי (PushSubscription) ו‑Service Worker רשום. זה לא נמחק אוטומטית ע״י מחיקה בשרת.
כדי שתוכל “לאפס באמת” בלי DevTools, הוספתי בעמוד הדיבוג כפתורים:

“בטל מנוי בדפדפן (Unsubscribe)”
“בטל רישום Service Worker”
זה כבר commit+push לענף cursor/worker-push-delivery-url-ba24 (קומיט: b129ea13).

מה לעשות עכשיו:

בעמוד הדיבוג לחץ “מחק את כל המנויים” (שרת)
ואז לחץ “בטל מנוי בדפדפן”
ואם עדיין כתוב SW רשום, לחץ “בטל רישום Service Worker”
אחרי הרענון, הסטטוס אמור להפוך ל־🟡/🔴 בהתאם, ואז תוכל לבצע Subscribe נקי מחדש.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces browser-side reset controls to fully clear Web Push state without DevTools.
> 
> - Adds `בטל מנוי בדפדפן (Unsubscribe)` and `בטל רישום Service Worker` buttons to `settings_push_debug.html`
> - Implements `unsubscribeFromBrowserNow()` to cancel the active `PushSubscription`, invoke `DELETE /api/push/subscribe` by `endpoint` (best-effort), and refresh UI
> - Implements `unregisterServiceWorkerNow()` to unregister the current Service Worker and refresh UI
> - Updates debug note clarifying that deleting subscriptions in the server DB does not remove local browser subscriptions/SW
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77c84dd6dc5ede4d58d02c6ee984100c3ea057b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->