### PR TITLE
Cursor/worker push delivery url ba24

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -84,11 +84,22 @@ export default {
       // IMPORTANT: In some runtimes, non-2xx responses may not throw.
       // Treat non-2xx as failure and propagate back to server for cleanup/diagnosis.
       try {
-        const st = resp && typeof resp.status === "number" ? resp.status : 0;
+        const st =
+          (resp && typeof resp.statusCode === "number" ? resp.statusCode : 0) ||
+          (resp && typeof resp.status === "number" ? resp.status : 0) ||
+          0;
         if (st && (st < 200 || st >= 300)) {
           let details = "";
           try {
-            details = (await resp.text()) || "";
+            // web-push (Node) returns { statusCode, body, headers }.
+            // In some runtimes it may return a fetch Response-like object.
+            if (resp && typeof resp.body === "string") {
+              details = resp.body || "";
+            } else if (resp && typeof resp.text === "function") {
+              details = (await resp.text()) || "";
+            } else {
+              details = "";
+            }
           } catch (_) {
             details = "";
           }
@@ -112,7 +123,10 @@ export default {
       console.log(JSON.stringify({ 
         event: "push_sent", 
         endpoint_hash: endpointHash,
-        status: (resp && typeof resp.status === "number" ? resp.status : 201)
+        status:
+          (resp && typeof resp.statusCode === "number" ? resp.statusCode : 0) ||
+          (resp && typeof resp.status === "number" ? resp.status : 0) ||
+          201
       }));
 
       return json({ ok: true });


### PR DESCRIPTION
הבנתי. הלוג שאתה רואה ב‑Cloudflare (“POST /send … status 200”) עדיין יכול לקרות גם כשה‑FCM דוחה את ה‑push, כי fetch עצמו לא זורק חריגה על 4xx/5xx. לכן תיקנתי את ה‑Worker כך שהוא בודק את ה‑HTTP status שחוזר מ‑sendNotification:

אם הסטטוס לא 2xx → ה‑Worker יחזיר ok:false עם status/details, ואז אצלך ב־/api/push/test תראה errors/codes במקום sent.
אם הסטטוס 2xx → ok:true כמו קודם.
זה כבר commit+push לענף cursor/worker-push-delivery-url-ba24 (קומיט: 984e3723).

אחרי הדיפלוי של ה‑Worker, תריץ שוב “שלח פוש בדיקה (שרת)” בעמוד הדיבוג ותשלח לי את ה‑JSON. אם יש דחייה, עכשיו נקבל סטטוס ברור (401/403=VAPID mismatch, 404/410=מנוי מת, וכו׳) ונוכל לסגור את זה סופית.







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves push delivery error handling and observability in `worker/src/index.js`.
> 
> - Capture response from `webpush.sendNotification` and treat non-2xx statuses as failures, returning `{ ok:false, status, error:"upstream_error", details }` to the caller
> - Enhance logging: report `push_sent` with the actual upstream status (preferring `statusCode`/`status`), and log non-2xx errors with truncated body/details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a91580266dbe9f110785ccc3879c89ea5b8d00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->