### PR TITLE
Cursor/worker push delivery url ba24

### DIFF
--- a/webapp/push_api.py
+++ b/webapp/push_api.py
@@ -146,9 +146,24 @@ def _coerce_vapid_pair() -> tuple[str, str]:
     Supports either raw base64url strings or a JSON blob pasted into the env
     by mistake (e.g. output of `web-push generate-vapid-keys`).
     """
-    # Prefer worker-scoped env names when present (public is safe to expose; private is used only for local pywebpush path).
-    pub = (os.getenv("WORKER_VAPID_PUBLIC_KEY") or os.getenv("VAPID_PUBLIC_KEY") or "").strip()
-    prv = (os.getenv("WORKER_VAPID_PRIVATE_KEY") or os.getenv("VAPID_PRIVATE_KEY") or "").strip()
+    # IMPORTANT: keep public/private from the same keypair source (avoid mismatches).
+    # - If both WORKER_* keys exist, use them.
+    # - Else use VAPID_* keys.
+    worker_pub = (os.getenv("WORKER_VAPID_PUBLIC_KEY") or "").strip()
+    worker_prv = (os.getenv("WORKER_VAPID_PRIVATE_KEY") or "").strip()
+    server_pub = (os.getenv("VAPID_PUBLIC_KEY") or "").strip()
+    server_prv = (os.getenv("VAPID_PRIVATE_KEY") or "").strip()
+
+    if worker_pub and worker_prv:
+        pub, prv = worker_pub, worker_prv
+    else:
+        # Prefer server pair for local pywebpush; if only public is needed (client),
+        # other parts of the code can still safely use pub even when prv is empty.
+        pub, prv = server_pub, server_prv
+        # In remote-worker mode it's still valid to expose WORKER_VAPID_PUBLIC_KEY
+        # as the subscription key even if server_prv is missing.
+        if worker_pub and not pub:
+            pub = worker_pub
     try:
         import json as _json  # defer import
         blob = None


### PR DESCRIPTION
ה-JSON שאתה מציג מ‑Cloudflare עדיין לא מוכיח שה‑push “נמסר” לדפדפן—הוא רק מוכיח שה‑WebApp הצליח לקרוא ל־Worker וקיבל 200.

הבעיה הכי נפוצה במצב הזה (ובדיוק מתיישבת עם זה ש־VAPID_PRIVATE_KEY חסר בשרת) היא VAPID mismatch:

הדפדפן יוצר subscription לפי ה‑public key שהוא קיבל מ־/api/push/public-key
ה‑Worker שולח לפי ה‑public/private שלו (WORKER_VAPID_PUBLIC_KEY/PRIVATE_KEY)
אם ה‑public key שהשרת מחזיר לדפדפן לא זהה ל‑public key של ה‑Worker → ה‑Push Service (FCM) דוחה את השליחה, ולא תגיע התראה.
לכן תיקנתי את השרת כך ש־/api/push/public-key יעדיף WORKER_VAPID_PUBLIC_KEY (ואם צריך גם WORKER_VAPID_PRIVATE_KEY) לפני VAPID_PUBLIC_KEY. זה כבר commit+push לענף cursor/worker-push-delivery-url-ba24 (קומיט: aa392c71).

מה לעשות אחרי הדיפלוי:

בעמוד הדיבוג לחץ “מחק את כל המנויים” (כדי לנקות מנויים שנוצרו עם key לא נכון)
לחץ “בקש הרשאה + צור מנוי + שמור בשרת” (כדי ליצור subscription חדש עם ה‑public key הנכון)
לחץ “שלח פוש בדיקה (שרת)”
אם עדיין לא מגיע—השלב הבא יהיה להסתכל ב‑Worker logs על push_sent/push_error (זה מה שבאמת אומר אם FCM קיבל או דחה).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent VAPID keypair selection to avoid push delivery failures due to mismatched public/private keys across server and worker.
> 
> - `_coerce_vapid_pair` now prioritizes `WORKER_VAPID_PUBLIC_KEY/PRIVATE_KEY` when both exist; otherwise falls back to `VAPID_PUBLIC_KEY/PRIVATE_KEY`
> - If only the worker public key exists, it is used as the exposed subscription key while allowing empty private on the server
> - Maintains JSON-blob and quote-stripping handling for env-provided keys
> 
> This impacts the public key served by `GET /api/push/public-key` and the local pywebpush path, keeping pub/prv from the same source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a270c79c73c26f23aa364a6cd936fe7b503a0062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->