### PR TITLE
שגיאת עקומה אליפטית בפוש

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ textstat==0.7.10
 requests==2.32.5
 aiohttp==3.13.1
 httpx==0.28.1
-py_vapid==1.9.2  # pinned: 1.9.3 has broken tar with absolute symlink
+py_vapid==1.9.4  # 1.9.2 breaks with cryptography>=46 ("curve must be an EllipticCurve instance"); 1.9.3 has broken tar (absolute symlink)
 pywebpush==1.14.0
 
 # Google APIs (Drive OAuth + Client)


### PR DESCRIPTION
## ✨ תיאור קצר
עדכון גרסת `py_vapid` מ-`1.9.2` ל-`1.9.4`. גרסה `1.9.2` גרמה לשגיאת `curve must be an EllipticCurve instance` בעת ניסיון שליחת Web Push, עקב חוסר תאימות עם `cryptography>=46`. העדכון פותר את הבעיה ומאפשר שליחת התראות Push מהשרת.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- עדכון התלות של `py_vapid` לגרסה `1.9.4` בקובץ `requirements/base.txt`.

## 🧪 בדיקות
בדיקה ידנית: לאחר פריסה והפעלה מחדש של ה-WebApp, שליחת פוש בדיקה (דרך `/api/push/test`) אמורה לעבוד כעת או להחזיר שגיאות HTTP אמיתיות (ולא את שגיאת ה-`curve`).
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [x] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - השינוי פותר בעיה קריטית בשליחת התראות Push. סיכון נמוך, מכיוון שזו גרסה מתקנת של ספרייה קיימת.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - החזרה לגרסה הקודמת של `py_vapid` (1.9.2) בקובץ `requirements/base.txt` ופריסה מחדש.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e41ddb6-0394-4ba1-b221-2ff86301bea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e41ddb6-0394-4ba1-b221-2ff86301bea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update**
> 
> - Upgrades `py_vapid` from `1.9.2` to `1.9.4` in `requirements/base.txt` to fix the `"curve must be an EllipticCurve instance"` error with `cryptography>=46` and to avoid the broken `1.9.3` tarball.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 609f25805922bfb6c73079d4f26915bd67c8a8fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->