### PR TITLE
Predictive system error filtering

### DIFF
--- a/alert_manager.py
+++ b/alert_manager.py
@@ -341,8 +341,10 @@ def _recompute_thresholds(now_ts: float) -> None:
 
     # Update Prometheus gauges (best-effort, lazy import to avoid cycles)
     try:
-        cur_err = get_current_error_rate_percent(window_sec=5 * 60)
-        cur_lat = get_current_avg_latency_seconds(window_sec=5 * 60)
+        # שמור עקביות: ספים מחושבים רק על דגימות פנימיות, ולכן גם ה-"current" gauges
+        # צריכים לשקף את אותו מקור (ולא לכלול תקלות חיצוניות/Circuit Breaker).
+        cur_err = get_current_error_rate_percent(window_sec=5 * 60, source="internal")
+        cur_lat = get_current_avg_latency_seconds(window_sec=5 * 60, source="internal")
         _update_gauges(err_thr, lat_thr, cur_err, cur_lat)
     except Exception:
         _update_gauges(err_thr, lat_thr, None, None)

--- a/predictive_engine.py
+++ b/predictive_engine.py
@@ -222,8 +222,11 @@ def _get_current_values() -> Tuple[float, float, float]:
             get_current_error_rate_percent,
             get_current_avg_latency_seconds,
         )
-        err = float(get_current_error_rate_percent(window_sec=5 * 60))
-        lat = float(get_current_avg_latency_seconds(window_sec=5 * 60))
+        # חשוב: פעולות Predictive (כולל ריסטארט וורקר) צריכות להתבסס על בריאות פנימית בלבד.
+        # שגיאות שמקורן בשירותים חיצוניים / Circuit Breaker יכולות להקפיץ את שיעור השגיאות,
+        # אבל לא מעידות שהוורקר עצמו "תקול".
+        err = float(get_current_error_rate_percent(window_sec=5 * 60, source="internal"))
+        lat = float(get_current_avg_latency_seconds(window_sec=5 * 60, source="internal"))
     except Exception:
         err, lat = 0.0, 0.0
     try:


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו את ה־Predictive Engine כדי שלא יפעיל ריסטארטים על בסיס כשלים חיצוניים או צפויים (כמו Circuit Breaker). כעת, חישוב שיעור השגיאות והלייטנסי שמפעילים ריסטארט מתבסס רק על דגימות "פנימיות" של הוורקר.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות (רשימת תבליטים):
- עודכן `predictive_engine.py` לדגום `error_rate_percent` ו־`avg_latency_seconds` עם `source="internal"` בלבד.
- עודכן `alert_manager.py` ליישר קו עם הספים ולעדכן את ה־Prometheus gauges (לשיעור שגיאות ולייטנסי) גם כן עם `source="internal"`.
- נוסף טסט יחידה ב־`tests/test_predictive_engine.py` שמוודא שה־Predictive Engine מבקש במפורש `source="internal"` בעת דגימת המדדים.

## 🧪 בדיקות
- נוסף טסט יחידה חדש (`test_predictive_engine_samples_internal_only`) שעבר בהצלחה ומוודא שהמערכת דוגמת רק שגיאות פנימיות.
- [x] Unit

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- **השפעה חיובית**: מונע ריסטארטים מיותרים של וורקרים עקב כשלים חיצוניים, משפר את יציבות המערכת.
- **סיכון**: נמוך. השינוי הוא סינון בלבד ואינו משנה את לוגיקת הריסטארט עצמה, אלא את מקור הנתונים.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל־PR. הסיכון נמוך.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d376713-9743-4186-ba75-c1ada1380e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d376713-9743-4186-ba75-c1ada1380e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns predictive health metrics to use internal-only samples, preventing external/circuit-breaker noise from influencing predictions and thresholds.
> 
> - Update `predictive_engine._get_current_values` to fetch `error_rate_percent` and `avg_latency_seconds` with `source="internal"`
> - Update `alert_manager._recompute_thresholds` to set current Prometheus gauges using `source="internal"` for consistency with internally-derived thresholds
> - Add unit test `test_predictive_engine_samples_internal_only` verifying internal-only sampling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a5392e6652c58731fb3b7b583c87bd699ba51f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->