### PR TITLE
מגבלת ערכות נושא אדמין

### DIFF
--- a/webapp/templates/settings/theme_builder.html
+++ b/webapp/templates/settings/theme_builder.html
@@ -1335,6 +1335,13 @@
     }
 
     // ========== API Functions ==========
+    function _formatMaxAllowed(maxAllowed) {
+        // Admin יכול להיות ללא מגבלה => null מהשרת
+        if (maxAllowed === null || maxAllowed === undefined) return '∞';
+        const n = parseInt(String(maxAllowed), 10);
+        return Number.isFinite(n) ? String(n) : '∞';
+    }
+
     async function fetchThemes() {
         if (!themesList) return;
         try {
@@ -1346,7 +1353,7 @@
             }
 
             currentThemes = data.themes || [];
-            if (themesMax) themesMax.textContent = data.max_allowed;
+            if (themesMax) themesMax.textContent = _formatMaxAllowed(data.max_allowed);
 
             renderThemesList();
 


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו חריגה למגבלת 10 ערכות נושא מיובאות אישיות: כעת אדמינים יכולים לשמור מספר בלתי מוגבל של ערכות נושא, בעוד משתמשים רגילים נשארים מוגבלים ל-10. ה-UI עודכן להציג '∞' לאדמינים.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/) - (הכוונה לשינוי ב-`theme_builder.html` שמשפיע על ה-UI)
- [ ] DevOps/CI/CD

פירוט נקודות:
- שינוי הלוגיקה ב-`webapp/themes_api.py` כך שהפונקציות `_get_user_max_themes_allowed` ו-`_is_over_theme_limit` יחריגו אדמינים (באמצעות `_is_admin`).
- ה-API מחזיר `max_allowed: null` עבור אדמינים כדי לסמן מגבלה בלתי מוגבלת.
- עדכון קובץ ה-HTML `webapp/templates/settings/theme_builder.html` כדי לפרמט את `max_allowed` ולהציג '∞' כאשר הערך הוא `null`.
- הוספת בדיקות יחידה חדשות לוודא שאדמינים יכולים ליצור, לייבא וליישם ערכות נושא גם לאחר חציית מגבלת 10 ערכות.

## 🧪 בדיקות
- הוספו בדיקות יחידה ב-`tests/test_theme_builder_api.py` וב-`tests/test_themes_import_and_presets_api.py` המאמתות את עקיפת המגבלה עבור משתמשי אדמין.
- [x] Unit
- [ ] Integration
- [ ] Manual (מומלץ לבדוק ידנית את תצוגת ה-UI לאדמין ולמשתמש רגיל)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [x] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי (רלוונטי, אך לא צורף)

## 🧩 השפעות/סיכונים
- אין השפעה שלילית על משתמשים רגילים.
- אדמינים יכולים לשמור מספר בלתי מוגבל של ערכות נושא, מה שעשוי להגדיל את נפח הנתונים ב-DB עבור משתמשי אדמין ספציפיים, אך זהו השינוי המבוקש.

## 🔗 קישורים
- Issues קשורים: #

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לחזור לגרסה הקודמת של הקוד. אין שינויים מבניים במסד הנתונים.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb4a1ca2-228b-49f2-a688-67428ee2ae2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb4a1ca2-228b-49f2-a688-67428ee2ae2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables unlimited custom themes for admins and surfaces this in the API/UI.
> 
> - Backend: Add `_get_user_max_themes_allowed` and `_is_over_theme_limit`; update `GET /api/themes` to return `max_allowed` (regular users: number, admins: `null`).
> - Enforce limit via `_is_over_theme_limit` in `create_theme`, `presets/<id>/apply`, and `import` so admins bypass the cap.
> - UI: Add `_formatMaxAllowed` to render `∞` when `max_allowed` is `null` and show formatted value in `theme_builder.html`.
> - Tests: New cases verifying admin unlimited behavior for listing, creating, applying presets, and importing themes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1b360dad1d12df3691083f56e9f6090d1845578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->