### PR TITLE
אינדוקס קובץ app.py

### DIFF
--- a/services/code_indexer.py
+++ b/services/code_indexer.py
@@ -162,6 +162,10 @@ class CodeIndexer:
     # גודל מקסימלי לאינדוקס (500KB)
     MAX_FILE_SIZE = 500_000
 
+    # allowlist נקודתי לקבצים "גדולים" שחייבים להיות באינדקס
+    # חשוב: משתמשים בנתיב רלטיבי בפורמט POSIX (למשל webapp/app.py)
+    LARGE_FILE_ALLOWLIST = {"webapp/app.py"}
+
     def __init__(self, db: Any = None):
         """
         Args:
@@ -235,7 +239,8 @@ class CodeIndexer:
             return False
 
         # בדיקת גודל
-        if len(content) > self.MAX_FILE_SIZE:
+        normalized_path = file_path.replace("\\", "/").lstrip("/")
+        if len(content) > self.MAX_FILE_SIZE and normalized_path not in self.LARGE_FILE_ALLOWLIST:
             logger.info(f"Skipping large file ({len(content)} bytes): {file_path}")
             return False
 


### PR DESCRIPTION
## ✨ תיאור קצר
אפשרנו אינדוקס של הקובץ `webapp/app.py` גם אם גודלו עולה על המגבלה של 500KB, מכיוון שהוא קובץ קריטי. קבצים גדולים אחרים ימשיכו להידלג כרגיל.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הוספת `LARGE_FILE_ALLOWLIST` למחלקת `CodeIndexer` ב־`services/code_indexer.py`.
- עדכון הלוגיקה ב־`index_file` כדי לבדוק אם הנתיב נמצא ב־allowlist לפני דילוג על קבצים גדולים.
- הוספת טסט חדש ב־`tests/test_code_indexer.py` שמוודא ש־`webapp/app.py` מאונדקס וקבצים גדולים אחרים עדיין מדולגים.

## 🧪 בדיקות
- [x] Unit
- [ ] Integration
- [ ] Manual
הוספנו טסט יחידה חדש (`test_index_file_allows_webapp_app_py_even_if_large`) שמוודא את ההתנהגות הרצויה: קובץ גדול "רגיל" נדחה, אך `webapp/app.py` (כולל וריאציות נתיב) עובר אינדוקס. הטסטים רצו ועברו בהצלחה מקומית.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה מינימלית. הקובץ `webapp/app.py` יאונדקס, מה שעשוי להגדיל במעט את צריכת הזיכרון/זמן האינדוקס הראשוני, אך זהו קובץ חשוב לאינדוקס. אין סיכוני אבטחה או ביצועים משמעותיים.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
ניתן לבצע rollback על ידי היפוך הקומיט הנוכחי.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c24a71b-2687-4864-8c29-8258967907c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c24a71b-2687-4864-8c29-8258967907c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables indexing of a critical file while preserving existing large-file skips.
> 
> - Adds `LARGE_FILE_ALLOWLIST` to `CodeIndexer` and normalizes paths in `index_file` so `webapp/app.py` bypasses the `MAX_FILE_SIZE` (500KB) check
> - Keeps other oversized files skipped as before
> - Adds unit test `test_index_file_allows_webapp_app_py_even_if_large` (including path variants like `/webapp/app.py` and `webapp\app.py`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 741973ccfadba45f8cb5fe1c1f52e29cb95ef497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->