### PR TITLE
Increase max_days limit in _load_whats_new function

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9527,7 +9527,7 @@ def _load_whats_new_cached() -> List[Dict[str, Any]]:
         return []
 
 
-def _load_whats_new(limit: int = 5, offset: int = 0, max_days: int = 30) -> Dict[str, Any]:
+def _load_whats_new(limit: int = 5, offset: int = 0, max_days: int = 180) -> Dict[str, Any]:
     """טוען פיצ'רים חדשים עם תמיכה ב-pagination והגבלת ימים"""
     all_features = _load_whats_new_cached()
     


### PR DESCRIPTION
Updated the max_days parameter in _load_whats_new function from 30 to 180.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the "What's New" timeframe.
> 
> - In `app.py`, updates default `max_days` in `_load_whats_new` from `30` to `180`, allowing items from the last 6 months to be included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52542368e05a92fb3817b56449a98a428afbe922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->