### PR TITLE
Increase max_days limit from 90 to 180

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -14225,7 +14225,7 @@ def api_dashboard_whats_new():
     try:
         offset = max(0, int(request.args.get('offset', 0)))
         limit = min(10, max(1, int(request.args.get('limit', 5))))
-        max_days = min(90, max(7, int(request.args.get('max_days', 30))))
+        max_days = min(180, max(7, int(request.args.get('max_days', 30))))
     except (ValueError, TypeError):
         offset = 0
         limit = 5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increases the allowable lookback window for the dashboard "what's new" API.
> 
> - Raises `max_days` cap in `api_dashboard_whats_new` from `90` to `180`, enabling pagination over a longer time range
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02b9c23724c12fa12e05f7be032e8f843498a9dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->