### PR TITLE
Cursor/ bc 73932aac bd8b 445b a910 bba4dafda93b d773

### DIFF
--- a/webapp/static/js/repo-browser.js
+++ b/webapp/static/js/repo-browser.js
@@ -486,12 +486,7 @@ async function initCodeViewer(content, language) {
 }
 
 async function ensureCodeMirrorRuntime() {
-    // CodeMirror 5 from CDN (guide)
-    if (window.CodeMirror && typeof window.CodeMirror.fromTextArea === 'function') {
-        return 'cm5';
-    }
-
-    // Fallback: use existing in-app CodeMirror 6 loader (local bundle)
+    // Prefer CodeMirror 6 (consistent with rest of webapp)
     if (window.editorManager && typeof window.editorManager.loadCodeMirror === 'function') {
         try {
             await window.editorManager.loadCodeMirror();
@@ -502,6 +497,11 @@ async function ensureCodeMirrorRuntime() {
 
     if (window.CodeMirror6 && window.CodeMirror6.EditorView && window.CodeMirror6.EditorState) {
         return 'cm6';
+    }
+
+    // Fallback to CodeMirror 5 from CDN (if CM6 not available)
+    if (window.CodeMirror && typeof window.CodeMirror.fromTextArea === 'function') {
+        return 'cm5';
     }
 
     return null;


### PR DESCRIPTION
מצאתי את השורש! חסרה טעינת theme ל-CodeMirror 6.

הוספתי קריאה ל-editorManager.getEditorTheme() כמו שעושים ב-view_file.html. עכשיו:

הרקע יגיע מה-theme
הדגשת תחביר תעבוד
יהיה עקבי עם שאר תצוגות הקוד ב-WebApp
תבדוק עכשיו אם הרקע והדגשת התחביר עובדים



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CodeMirror 6 theme support to the repo browser viewer for consistent theming and syntax highlighting.
> 
> - In `repo-browser.js`, when using CM6, fetches theme via `editorManager.getEditorTheme()` using the document `data-theme` (defaulting to `dark`) and applies it as an extension
> - Wrapped in try/catch with a console warning on failure; no other behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34cbacf1daa1f4d6de2256c7b8b2d60b06b63d52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->