### PR TITLE
Cursor/admin impersonation feature 42e6

### DIFF
--- a/tests/test_admin_impersonation.py
+++ b/tests/test_admin_impersonation.py
@@ -139,12 +139,20 @@ class TestAdminImpersonation:
     
     def test_impersonation_hides_admin_ui(self, client, admin_user_session):
         """במצב Impersonation, אלמנטי אדמין נעלמים."""
+        admin_badge = "משתמש אדמין".encode("utf-8")
+        regular_badge = "משתמש רגיל".encode("utf-8")
+
+        # לפני Impersonation - אמור להופיע תג אדמין
+        response = client.get('/settings')
+        assert admin_badge in response.data
+
         # הפעלת Impersonation
         client.post('/admin/impersonate/start')
         
-        # בדיקת עמוד הבית
-        response = client.get('/dashboard')
-        assert b'admin-menu' not in response.data
+        # אחרי Impersonation - תג אדמין נעלם
+        response = client.get('/settings')
+        assert admin_badge not in response.data
+        assert regular_badge in response.data
     
     def test_impersonation_blocks_admin_pages(self, client, admin_user_session):
         """במצב Impersonation, עמודי אדמין חסומים."""
@@ -188,12 +196,12 @@ class TestAdminImpersonation:
     def test_context_processor_calculates_effective_status(self, client, admin_user_session):
         """בדיקה שה-Context Processor מחשב נכון את הסטטוס האפקטיבי."""
         # לפני Impersonation
-        response = client.get('/dashboard')
-        # בדוק שיש אלמנטי אדמין ב-HTML
-        assert b'actual_is_admin' in response.data or b'admin-menu' in response.data
+        response = client.get('/settings')
+        # בדוק שכפתור ההפעלה מופיע לאדמין
+        assert b'btn-start-impersonation' in response.data
         
         # אחרי הפעלת Impersonation
         client.post('/admin/impersonate/start')
         response = client.get('/dashboard')
-        # בדוק שאין אלמנטי אדמין ב-HTML (למעט כפתור היציאה)
-        assert b'impersonation-banner' in response.data
+        # בדוק שכפתור היציאה קיים ב-UI
+        assert b'btn-stop-impersonation' in response.data

--- a/webapp/static/css/impersonation.css
+++ b/webapp/static/css/impersonation.css
@@ -1,52 +1,28 @@
-/* Admin Impersonation Banner & Controls */
+/* Admin Impersonation Controls (compact) */
 
 .impersonation-control {
-    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     z-index: 1050;
 }
 
-/* באנר צף כשמצב פעיל */
-.impersonation-banner {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    background: linear-gradient(90deg, #f59e0b 0%, #d97706 100%);
-    color: #1a1a1a;
-    padding: 8px 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
+.impersonation-status {
+    font-size: 12px;
     font-weight: 600;
-    font-size: 14px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-    z-index: 9999;
-    animation: slideDown 0.3s ease-out;
-}
-
-@keyframes slideDown {
-    from {
-        transform: translateY(-100%);
-    }
-    to {
-        transform: translateY(0);
-    }
-}
-
-.impersonation-banner .impersonation-icon {
-    font-size: 18px;
-}
-
-.impersonation-banner .btn {
-    margin-right: 8px;
+    color: #92400e;
+    background: rgba(245, 158, 11, 0.15);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    padding: 4px 8px;
+    border-radius: 999px;
+    white-space: nowrap;
 }
 
 /* כפתור הפעלה (כשלא פעיל) */
 #btn-start-impersonation {
     font-size: 12px;
     padding: 4px 8px;
-    opacity: 0.8;
+    opacity: 0.9;
     transition: opacity 0.2s;
 }
 
@@ -54,20 +30,21 @@
     opacity: 1;
 }
 
+/* כפתור יציאה (כשפעיל) */
+#btn-stop-impersonation {
+    font-size: 12px;
+    padding: 4px 8px;
+}
+
 /* 🆘 Fail-Safe Link */
 .impersonation-failsafe {
-    color: rgba(0, 0, 0, 0.4);
+    color: rgba(0, 0, 0, 0.45);
     font-size: 14px;
-    padding: 4px 8px;
+    padding: 4px 6px;
     text-decoration: none;
     transition: color 0.2s;
 }
 
 .impersonation-failsafe:hover {
-    color: rgba(0, 0, 0, 0.8);
-}
-
-/* התאמה כשיש באנר - הזז את ה-body למטה */
-body.impersonation-active {
-    padding-top: 48px;
+    color: rgba(0, 0, 0, 0.85);
 }

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1592,7 +1592,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/impersonation.css') }}?v={{ static_version }}">
     {% endif %}
 </head>
-<body class="{% if user_is_impersonating %}impersonation-active{% endif %}">
+<body>
     <div id="theme-mask" aria-hidden="true"></div>
     <script>
         // 🆕 מניעת מסך לבן: הצגת מסכה בזמן מעבר ערכה (עד שה-CSS נטען)
@@ -1715,27 +1715,16 @@
                 </div>
                 {% endif %}
 
-                {% if can_impersonate %}
-                <div id="impersonation-toggle" class="impersonation-control" data-actual_is_admin="{{ '1' if actual_is_admin else '0' }}">
-                    {% if user_is_impersonating %}
-                        <!-- מצב פעיל - באנר צף -->
-                        <div class="impersonation-banner">
-                            <span class="impersonation-icon">👁️</span>
-                            <span class="impersonation-text">מצב צפייה כמשתמש פעיל</span>
-                            <button id="btn-stop-impersonation" class="btn btn-sm btn-warning">
-                                <i class="fas fa-user-shield"></i> חזור למצב אדמין
-                            </button>
-                            <!-- 🆘 Fail-Safe Link: תמיד גלוי למקרה שה-JS לא עובד -->
-                            <a href="?force_admin=1" class="impersonation-failsafe" title="לחץ כאן אם הכפתור לא עובד">
-                                <i class="fas fa-life-ring"></i>
-                            </a>
-                        </div>
-                    {% else %}
-                        <!-- כפתור הפעלה (רק לאדמינים) -->
-                        <button id="btn-start-impersonation" class="btn btn-sm btn-outline-secondary" title="צפה במערכת כמשתמש רגיל">
-                            <i class="fas fa-eye"></i> צפה כמשתמש
-                        </button>
-                    {% endif %}
+                {% if user_is_impersonating %}
+                <div id="impersonation-toggle" class="impersonation-control">
+                    <span class="impersonation-status" title="מצב צפייה כמשתמש פעיל">👁️ צפייה כמשתמש</span>
+                    <button id="btn-stop-impersonation" class="btn btn-sm btn-warning">
+                        <i class="fas fa-user-shield"></i> חזור לאדמין
+                    </button>
+                    <!-- 🆘 Fail-Safe Link: תמיד גלוי למקרה שה-JS לא עובד -->
+                    <a href="?force_admin=1" class="impersonation-failsafe" title="לחץ כאן אם הכפתור לא עובד">
+                        <i class="fas fa-life-ring"></i>
+                    </a>
                 </div>
                 {% endif %}
                 

--- a/webapp/templates/settings.html
+++ b/webapp/templates/settings.html
@@ -298,6 +298,23 @@
         border-radius: 10px;
       "
     >
+      <h4>👁️ מצב צפייה כמשתמש</h4>
+      <p style="opacity: 0.8; margin-bottom: 0.75rem;">
+        מאפשר לבדוק את ה‑UI כמשתמש רגיל בלי הרשאות אדמין. ליציאה חירום אפשר תמיד להוסיף ?force_admin=1 ל‑URL.
+      </p>
+      <div style="display: flex; gap: 0.5rem; flex-wrap: wrap">
+        <button id="btn-start-impersonation" class="btn btn-secondary" title="צפה במערכת כמשתמש רגיל">
+          <i class="fas fa-eye"></i> צפה כמשתמש
+        </button>
+      </div>
+    </div>
+    <div
+      style="
+        padding: 1rem;
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 10px;
+      "
+    >
       <h4>📃 ניהול ספריית סניפטים</h4>
       <div style="display: flex; gap: 0.5rem; flex-wrap: wrap">
         <a class="btn btn-primary" href="/admin/snippets/pending"


### PR DESCRIPTION

סיכום קצר:

העברתי את כפתור “צפה כמשתמש” לאזור כלי אדמין במסך ההגדרות, כך שהוא לא מופיע בנאב־בר.
החלפתי את הבאנר הכתום בבקרת מצב קומפקטית בנאב־בר (סטטוס קטן + כפתור “חזור לאדמין” + קישור חירום), כדי שלא יסתיר את הניווט.
עדכנתי את הטסטים בהתאם ל‑UI החדש.
Delta מהמדריך (מקס׳ 5):

כפתור ההפעלה הועבר מהנאב־בר למסך ההגדרות (כלי אדמין).
הבאנר הכתום הוחלף לבקרת מצב קומפקטית בנאב־בר במקום פס מלא רוחב.
הוסר הצורך ב־padding-top ל‑body (אין פס צף שחוסם).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a full admin impersonation flow with backend enforcement, metrics, and streamlined UI.
> 
> - Backend: new session flags and helpers (`is_impersonating_safe`, `start_impersonation`, `stop_impersonation`, `can_impersonate`), routes `POST /admin/impersonate/start|stop` and `GET /admin/impersonate/status`, and `admin_required` updated to block while impersonating unless `?force_admin=1`
> - Metrics/events: counters/histograms for sessions and duration, and after-request hook emitting `action_performed_while_impersonating`
> - Context/UI: context processor now computes effective `user_is_admin`/`user_is_premium` and exposes `user_is_impersonating`, `can_impersonate`; views (`dashboard`, `view_file`, `md_preview`, `settings`, theme pages) now respect effective roles
> - Frontend: new compact navbar control (status + "stop" button + fail-safe link) when active, start button moved to `settings` under Admin tools; added `webapp/static/js/impersonation.js` (CSRF-aware, no-cache reload) and `css/impersonation.css`; `base.html` wired meta CSRF and assets
> - Tests: added `tests/test_admin_impersonation.py` covering access control, UI visibility, fail-safe override, and session integrity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9a3ce30cc55c90b89757ff2bf2cf2b6afdd2e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->