### PR TITLE
Admonitions modal overflow

### DIFF
--- a/webapp/static/css/markdown-toolbar.css
+++ b/webapp/static/css/markdown-toolbar.css
@@ -73,6 +73,11 @@
   transform: translateY(0);
 }
 
+/* מאפשר לתפריטים לחרוג מגבולות ה-Split View בדסקטופ */
+.split-view.md-toolbar-open {
+  overflow: visible;
+}
+
 /* פריטי תפריט */
 .md-toolbar-item {
   display: flex;

--- a/webapp/static/js/markdown-toolbar.js
+++ b/webapp/static/js/markdown-toolbar.js
@@ -138,6 +138,17 @@ const MarkdownToolbar = {
 
     const isMarkdown = this.isMarkdownContext();
     toolbar.classList.toggle('is-visible', isMarkdown);
+    if (!isMarkdown && this._dropdownOpen) {
+      this.closeDropdown();
+    }
+  },
+
+  updateOverflowState(isOpen) {
+    const toolbar = document.querySelector('.md-toolbar-group');
+    if (!toolbar) return;
+    const host = toolbar.closest('.split-view');
+    if (!host) return;
+    host.classList.toggle('md-toolbar-open', !!isOpen);
   },
 
   // ---------- העברת הסרגל לשורת העורך ----------
@@ -286,6 +297,7 @@ const MarkdownToolbar = {
 
     this._dropdownOpen = !this._dropdownOpen;
     dropdown.classList.toggle('is-open', this._dropdownOpen);
+    this.updateOverflowState(this._dropdownOpen);
 
     // עדכון נגישות
     if (trigger) {
@@ -306,6 +318,7 @@ const MarkdownToolbar = {
       dropdown.classList.remove('is-open');
       this._dropdownOpen = false;
     }
+    this.updateOverflowState(false);
 
     // עדכון נגישות (גם אם כבר סגור)
     if (trigger) {


### PR DESCRIPTION
## ✨ תיאור קצר
- הוספתי מצב `md-toolbar-open` שמאפשר לתפריטי ה-Markdown לחרוג מגבולות ה-Split View.
- עדכנתי את קוד ה-JS להפעיל ולכבות את המצב הזה בזמן פתיחה וסגירה של תפריטי המשנה, ולנקות אותו כשהמסמך אינו Markdown, כדי למנוע חיתוך של תפריטי ההתראות.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת כלל CSS ל-`.split-view.md-toolbar-open` עם `overflow: visible;` כדי לאפשר לתפריטים לחרוג.
- עדכון `MarkdownToolbar.js` עם פונקציה `updateOverflowState` לניהול הקלאס `md-toolbar-open` על אלמנט ה-Split View.
- קריאה ל-`updateOverflowState(true)` בפתיחת תפריט ו-`updateOverflowState(false)` בסגירת תפריט.
- ניקוי מצב ה-overflow כאשר הקונטקסט אינו Markdown.

## 🧪 בדיקות
- לא הרצתי בדיקות מקומיות.
- [ ] Unit
- [ ] Integration
- [x] Manual (בדיקה ויזואלית של פתיחת תפריטים ב-Split View)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינוי קוסמטי בלבד, סיכון נמוך מאוד.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-commit זה.

---
<a href="https://cursor.com/background-agent?bcId=bc-df61fdff-940e-46ff-816e-6b2839a3a231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df61fdff-940e-46ff-816e-6b2839a3a231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Markdown toolbar dropdowns to render outside the Split View and cleans up state when not in Markdown.
> 
> - Adds CSS rule ` .split-view.md-toolbar-open { overflow: visible; }` to allow dropdown overflow
> - Introduces `updateOverflowState()` in `markdown-toolbar.js` to toggle `md-toolbar-open` on the nearest `split-view`
> - Hooks overflow toggling into `toggleDropdown()` and `closeDropdown()`; auto-closes dropdown when context isn’t Markdown
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2218f9819c2c513574b26147be50aedf532fc67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->