### PR TITLE
כפתור העתקה לפלט קוד

### DIFF
--- a/webapp/static/css/code-tools.css
+++ b/webapp/static/css/code-tools.css
@@ -505,6 +505,54 @@
 .code-tools-container .view-toggle {
   display: inline-flex;
   gap: 0.25rem;
+  align-items: center;
+}
+
+.code-tools-container .view-toggle .value-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.code-tools-container .view-toggle .copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  opacity: 0.45;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  flex-shrink: 0;
+}
+
+.code-tools-container .view-toggle .value-wrapper:hover .copy-btn,
+.code-tools-container .view-toggle .copy-btn:focus-visible,
+.code-tools-container .view-toggle .copy-btn.is-active {
+  opacity: 1;
+}
+
+.code-tools-container .view-toggle .copy-btn:hover {
+  background: rgba(100, 255, 218, 0.15);
+  color: #64ffda;
+}
+
+.code-tools-container .view-toggle .copy-btn:active {
+  transform: scale(0.92);
+}
+
+.code-tools-container .view-toggle .copy-btn.copied {
+  background: rgba(100, 255, 218, 0.2);
+  color: #64ffda;
+}
+
+.code-tools-container .view-toggle .copy-btn .copy-icon,
+.code-tools-container .view-toggle .copy-btn i {
+  font-size: 0.85rem;
 }
 
 .code-tools-container .view-btn {

--- a/webapp/static/js/code-tools-page.js
+++ b/webapp/static/js/code-tools-page.js
@@ -145,7 +145,7 @@
     const copyOutputBtn = document.getElementById('btn-copy-output');
     const copyRunOutputBtn = document.getElementById('btn-copy-run-output');
     if (copyOutputBtn) copyOutputBtn.hidden = mode === 'output';
-    if (copyRunOutputBtn) copyRunOutputBtn.hidden = mode !== 'output';
+    if (copyRunOutputBtn) copyRunOutputBtn.classList.toggle('is-active', mode === 'output');
   }
 
   function setViewMode(mode) {

--- a/webapp/templates/code_tools.html
+++ b/webapp/templates/code_tools.html
@@ -61,20 +61,22 @@
       <div class="panel-header">
         <span class="panel-title">תוצאה</span>
         <div class="panel-header-actions">
-          <button id="btn-copy-output" class="btn btn-sm btn-outline" title="העתק קוד תוצאה">
+          <button id="btn-copy-output" class="btn btn-sm btn-outline" title="העתק קוד">
             <span class="copy-icon">📋</span>
-            <span class="copy-text">העתק קוד</span>
-          </button>
-          <button id="btn-copy-run-output" class="btn btn-sm btn-outline" title="העתק פלט" hidden>
-            <span class="copy-icon">📋</span>
-            <span class="copy-text">העתק פלט</span>
+            <span class="copy-text">העתק</span>
           </button>
         </div>
         <div class="view-toggle">
           <button class="view-btn active" data-view="code">קוד</button>
           <button class="view-btn" data-view="diff">Diff</button>
           <button class="view-btn" data-view="issues">בעיות</button>
-          <button class="view-btn" data-view="output">פלט</button>
+          <div class="value-wrapper output-toggle">
+            <button class="view-btn" data-view="output">פלט</button>
+            <button id="btn-copy-run-output" class="copy-btn" type="button" title="העתק פלט" aria-label="העתק פלט">
+              <span class="copy-icon">📋</span>
+              <span class="sr-only">העתק פלט</span>
+            </button>
+          </div>
         </div>
       </div>
       <div class="panel-body">


### PR DESCRIPTION
## ✨ תיאור קצר
הוספנו כפתור "העתק פלט" חדש לפלט הרצת הקוד בעמוד הכלים, לצד כפתור העתקת הקוד הקיים. השינוי נדרש כדי לאפשר למשתמשים להעתיק בקלות את תוצאות ההרצה.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הוספת כפתור "העתק פלט" חדש ל-`webapp/templates/code_tools.html` בפאנל התוצאה.
- עדכון `webapp/static/js/code-tools-page.js` ל:
    - החלפת נראות כפתורי ההעתקה ("העתק קוד" ו"העתק פלט") בהתאם לטאב הפעיל (קוד או פלט).
    - הטמעת לוגיקת העתקה כללית עם משוב ויזואלי (✓ הועתק!) וטיפול במקרים של פלט ריק.
    - שמירת טקסט הפלט להעתקה ב-`dataset` של אלמנט הפלט.

## 🧪 בדיקות
לא בוצעו בדיקות או בדיקה ידנית בסביבת Webapp רצה.
- [ ] Unit
- [ ] Integration
- [ ] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות (לא בוצעו בדיקות ידניות או אוטומטיות)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי (לא צורף)

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינוי UI/UX קטן, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ניתן לבצע Rollback לקומיט הקודם. השינויים הם בקבצי HTML ו-JS בלבד.

---
<a href="https://cursor.com/background-agent?bcId=bc-700f7a9a-e609-4bfd-8a05-9d6c58f7f850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-700f7a9a-e609-4bfd-8a05-9d6c58f7f850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces copy support for execution output and refines clipboard UX in the code tools page.
> 
> - Adds `"העתק פלט"` button in `code_tools.html` and renames existing button to `"העתק קוד"`
> - Toggles visibility of `btn-copy-output` vs `btn-copy-run-output` based on active view via `syncCopyButtons`
> - Implements shared copy helpers (`cacheCopyDefaults`, `markCopySuccess`, `copyTextWithFeedback`) with success state and empty-content handling
> - Builds and stores run output text in `runOutput.dataset.copyText` (`buildRunOutputCopyText`) during execution and errors for one-click copying
> - Updates run UI to reset and populate `runOutput` and its `dataset.copyText` on start/success/error
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01b6c8084806db7b6615a201a0539dd59feefc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->