### PR TITLE
גוון זוהר ערכה קלאסית

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -4073,9 +4073,15 @@
                 themeAttr = normalizedThemeId;
             }
 
-            const shouldReload = resolvedType === 'shared' || resolvedType === 'custom';
-
             previousState = captureThemeState();
+            
+            // בדיקה אם הערכה הקודמת הייתה custom/shared - במקרה כזה צריך reload גם אם עוברים לערכת builtin
+            const prevTheme = (previousState.themeAttr || '').toLowerCase();
+            const wasCustomOrShared = prevTheme === 'custom' || prevTheme.startsWith('shared:') || previousState.themeType === 'custom';
+            
+            // צריך reload אם עוברים ל/מ-ערכות custom/shared
+            const shouldReload = resolvedType === 'shared' || resolvedType === 'custom' || wasCustomOrShared;
+
             applyThemeAttributes(themeAttr, resolvedType);
             persistLocalTheme(themeAttr);
             if (shouldReload) {


### PR DESCRIPTION
## ✨ תיאור קצר
תיקנו בעיית "גוון זוהר" בממשק המשתמש בעת החלפת ערכות נושא. הוספנו רענון דף אוטומטי (reload) כשעוברים מערכת נושא מותאמת אישית (custom/shared) לערכה מובנית (builtin), כדי למנוע שאריות CSS מהערכה הקודמת שגורמות לבעיה.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי בקובץ `webapp/templates/base.html` (JavaScript).
- הוספת לוגיקה שבודקת אם ערכת הנושא הקודמת הייתה custom או shared.
- אם כן, מופעל רענון דף מלא עם `?no_cache=1` גם במעבר לערכה מובנית.

## 🧪 בדיקות
- בדיקה ידנית:
    - עברתי מערכת נושא custom/shared לערכות מובנות (כמו Classic).
    - וודאתי שהדף מתרענן אוטומטית ושה"גוון הזוהר" נעלם.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
    - השפעה מינורית על ביצועים עקב רענון דף נוסף במעבר ספציפי בין ערכות נושא, אך נדרש לתקינות התצוגה.
    - אין השפעה על אבטחה.

## 🔗 קישורים
- Issues קשורים: הבעיה תוארה על ידי המשתמש: "כשמחליפים למשל לערכה הקלאסית בהתחלה יש גוון זוהר מידי כזה לכל הממשק, ואני נאלץ להוסיף ?no_cache=1 כדי לסדר את זה"
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: ביטול הקומיט (revert commit). סיכון נמוך.

---
<a href="https://cursor.com/background-agent?bcId=bc-e29c1638-4edd-49ae-9591-e758e27a1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e29c1638-4edd-49ae-9591-e758e27a1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses UI flicker/leftover styles during theme changes.
> 
> - In `base.html` Theme Picker logic (`selectTheme`), capture previous theme and compute `wasCustomOrShared`
> - Set `shouldReload` true when switching to/from `custom`/`shared` themes (not just when activating them)
> - Retain existing transition tracking (`__ck_theme_transition`) and trigger reload with `?no_cache=1` when needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76a0b3d0953cc941fd010d9673770fe37daca76d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->