### PR TITLE
שגיאת מגבלת zip

### DIFF
--- a/tests/test_github_import_repo_zip_limit.py
+++ b/tests/test_github_import_repo_zip_limit.py
@@ -1,0 +1,95 @@
+import io
+import types
+import zipfile
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_import_repo_allows_zip_over_content_limit(monkeypatch):
+    import github_menu_handler as gh
+
+    handler = gh.GitHubMenuHandler()
+    monkeypatch.setattr(handler, "get_user_token", lambda _uid: "token")
+
+    class _Repo:
+        def get_archive_link(self, *_a, **_k):
+            return "https://example.com/archive.zip"
+
+    class _Gh:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, _full):
+            return _Repo()
+
+    monkeypatch.setattr(gh, "Github", _Gh)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("repo-123/file.txt", "hello")
+    payload = buf.getvalue()
+
+    class _Resp:
+        def __init__(self, content):
+            self._content = content
+            self.headers = {"Content-Length": str(gh.IMPORT_MAX_TOTAL_BYTES + 1024)}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size=131072):
+            for i in range(0, len(self._content), chunk_size):
+                yield self._content[i:i + chunk_size]
+
+    monkeypatch.setattr(gh, "http_request", lambda *a, **k: _Resp(payload))
+
+    saved = {"n": 0}
+
+    class _Facade:
+        def get_latest_version(self, user_id, file_name):
+            return None
+
+        def save_file(self, **kwargs):
+            saved["n"] += 1
+            return True
+
+    monkeypatch.setattr(gh, "_get_files_facade", lambda: _Facade())
+
+    class _Msg:
+        def __init__(self):
+            self.texts = []
+
+        async def edit_text(self, text, **kwargs):
+            self.texts.append(text)
+            return self
+
+    class _Query:
+        def __init__(self):
+            self.from_user = types.SimpleNamespace(id=1)
+            self.message = _Msg()
+
+        async def edit_message_text(self, text, **kwargs):
+            self.message.texts.append(text)
+            return self.message
+
+        async def answer(self, *args, **kwargs):
+            return None
+
+    class _Update:
+        def __init__(self):
+            self.callback_query = _Query()
+
+    class _Context:
+        def __init__(self):
+            self.user_data = {}
+            self.bot_data = {}
+
+    upd, ctx = _Update(), _Context()
+
+    await handler.import_repo_from_zip(upd, ctx, "o/r", "main")
+
+    assert saved["n"] == 1
+    combined = "\n".join(upd.callback_query.message.texts)
+    assert "repo:o/r" in combined
+    assert "20MB" not in combined


### PR DESCRIPTION
## ✨ תיאור קצר
- הפרדתי בין מגבלת גודל קובץ ה-ZIP המורד (100MB) לבין מגבלת גודל התוכן המיובא בפועל (20MB).
- תיקנתי באג שבו ריפו קטן נחסם בטעות עקב בדיקה שגויה של Content-Length, ועדכנתי את הודעות השגיאה ואת כפתור הבוט להבהרת ההבדל בין הורדת ZIP לייבוא תוכן.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- הגדרת קבוע חדש `IMPORT_MAX_ZIP_BYTES` (100MB) למגבלת גודל ה-ZIP להורדה.
- עדכון לוגיקת בדיקת גודל ה-ZIP ב-`github_menu_handler.py` כדי להשתמש במגבלה החדשה.
- שינוי הודעות השגיאה למשתמש כך שיציגו את המגבלה הנכונה (ZIP או תוכן).
- שינוי טקסט הכפתור "הורד ריפו" ל"ייבוא ריפו" בתפריט הגיטהאב.
- הוספת בדיקת יחידה חדשה שמוודאת שייבוא ריפו מצליח גם כאשר כותרת `Content-Length` של ה-ZIP חורגת ממגבלת התוכן, אך התוכן בפועל קטן.

## 🧪 בדיקות
- איך בדקתם? מה עבר? מה נשאר?
- [x] Unit
- [ ] Integration
- [ ] Manual
  - בדיקת יחידה חדשה (`test_github_import_repo_zip_limit.py`) נוספה ומוודאת שהמגבלות מטופלות נכון.
  - נדרשת בדיקה ידנית של התרחיש המקורי (ייבוא ריפו קטן עם Content-Length גדול) לוודא שהתיקון עובד בפועל.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [x] תיעוד עודכן (README/Docs) - (הודעות שגיאה וכפתורים מעודכנים)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה:
  - שינוי זה משפר את חווית המשתמש ומונע חסימות שגויות של ייבוא ריפו. אין סיכון ביצועים או אבטחה ידוע.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr_rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה:
  - ביצוע Rollback לגרסה הקודמת של הקוד.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f9b55b5-5cfb-4e0e-9227-4fced8b57a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f9b55b5-5cfb-4e0e-9227-4fced8b57a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates ZIP download limit from imported content limit and updates UX and tests accordingly.
> 
> - Adds `IMPORT_MAX_ZIP_BYTES` (100MB) and switches ZIP `Content-Length` and streamed-size checks to this limit in `github_menu_handler.py`
> - Retains `IMPORT_MAX_TOTAL_BYTES` (20MB) for actual imported content; updates error messages to reference the correct limit via `format_bytes`
> - Renames GitHub menu button label from "⬇️ הורד ריפו" to "⬇️ ייבוא ריפו"
> - Adds `tests/test_github_import_repo_zip_limit.py` validating imports succeed when ZIP header exceeds content limit but payload is small, and that messages don’t mention "20MB" incorrectly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b229a2486b4d0ea9427da35e279566b861fe26a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->