### PR TITLE
Event loop already running

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4117,7 +4117,7 @@ def _run_awaitable_blocking(awaitable, *, thread_label: str) -> Any:
                     loop.close()
                 finally:
                     try:
-                        if prev_loop is None or (prev_loop.is_closed() if prev_loop else True):
+                        if prev_loop is None or prev_loop.is_closed():
                             asyncio.set_event_loop(None)
                         else:
                             asyncio.set_event_loop(prev_loop)


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקון שגיאת `RuntimeError: This event loop is already running` שהתרחשה בעת הרצת קורוטינות בסביבת WSGI (כמו Flask עם gevent).
- הוספנו פונקציית עזר (`_run_awaitable_blocking`) שמריצה awaitable בצורה בטוחה, תוך יצירת event loop חדש ב-thread נקי במידת הצורך.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- יצירת פונקציית עזר חדשה `_run_awaitable_blocking` ב-`webapp/app.py`.
- הפונקציה מטפלת בהרצת קורוטינות בסביבה סינכרונית:
    - מנסה להריץ ב-event loop חדש ב-thread הנוכחי.
    - אם קיים event loop פעיל, מנסה להריץ ב-`_OBSERVABILITY_THREADPOOL`.
    - במקרה קיצון (כמו עם gevent), אם גם ה-threadpool מעלה שגיאת "event loop already running", היא מריצה את הקורוטינה ב-thread חדש לחלוטין.
- הפונקציות `_run_profiler` ו-`_run_db_health` עודכנו להשתמש ב-`_run_awaitable_blocking` כדי למנוע את השגיאה.

## 🧪 בדיקות
- הבדיקה העיקרית היא לוודא שהשגיאה `RuntimeError: This event loop is already running` אינה מופיעה יותר בפונקציות המושפעות.
- [ ] Unit
- [ ] Integration
- [x] Manual (נדרש לבדוק בסביבת ריצה עם WSGI/gevent)

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [ ] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה חיובית: פותר שגיאת ריצה קריטית.
- סיכון נמוך: השינוי ממוקד לטיפול בבעיית event loop.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לגרסה קודמת של `webapp/app.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-11cbe4d8-aad6-4de7-a5de-9386cec6c607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11cbe4d8-aad6-4de7-a5de-9386cec6c607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves async execution reliability under Flask/WSGI (e.g., gevent) and eliminates "event loop already running" failures.
> 
> - Add `_run_awaitable_blocking` that runs awaitables with a new event loop, using threadpool and fresh-thread fallbacks when a loop is already running
> - Refactor `_run_profiler` and `_run_db_health` to delegate to the new helper
> - Minor import update to include `Future` and centralized error-handling/fallback logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad33ba3a889f21940968e3c7acc4b14fa2abb9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->