### PR TITLE
Cursor/event loop already running e7ab

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4106,10 +4106,16 @@ def _run_awaitable_blocking(awaitable, *, thread_label: str) -> Any:
                     self._args = tuple(args or ())
                     self._kwargs = dict(kwargs or {})
                     self.name = name or "native_thread"
+                    # start_new_thread לא תומך ב-daemon; נשמר לשקיפות בלבד.
                     self.daemon = bool(daemon) if daemon is not None else False
 
                 def start(self):
                     def _runner():
+                        # ננסה להצמיד שם לת׳רד (best-effort).
+                        try:
+                            threading.current_thread().name = self.name
+                        except Exception:
+                            pass
                         if self._target is not None:
                             self._target(*self._args, **self._kwargs)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures fresh asyncio loops run on real OS threads rather than gevent-monkeypatched threads to avoid "event loop already running" errors.
> 
> - Adds `_get_native_thread_class` to retrieve the original `threading.Thread` via `gevent.monkey.get_original`, with a fallback `_NativeThread` using `start_new_thread`
> - Updates `_run_in_fresh_thread` in `app.py` to use the native thread class instead of `threading.Thread`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03e75eca7be586acadcb0f40480d44e1caae9706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->