### PR TITLE
Mobile collection long names

### DIFF
--- a/webapp/static/css/collections.css
+++ b/webapp/static/css/collections.css
@@ -498,6 +498,15 @@
 .workspace-card__drag:active{cursor:grabbing}
 .workspace-card__body{flex:1;min-width:0;display:flex;flex-direction:column;gap:.15rem}
 .workspace-card__name{font-weight:600;color:var(--collections-dark-text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.workspace-card__name.is-wrapped{
+  white-space:normal;
+  text-overflow:clip;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+  word-break:break-word;
+}
 .workspace-card__link{text-decoration:none;color:inherit}
 .workspace-card__meta{font-size:.82rem;color:var(--collections-secondary-text);display:flex;align-items:center;gap:.35rem;flex-wrap:wrap}
 .workspace-card__actions{display:flex;gap:.35rem;flex-wrap:wrap}

--- a/webapp/static/js/collections.js
+++ b/webapp/static/js/collections.js
@@ -1073,7 +1073,7 @@
       let itemsContainer = null;
       if (isWorkspace) {
         hydrateWorkspaceBoard(container, collectionId, baseItems);
-        autoFitText('.workspace-card__name', { minPx: 12, maxPx: 16 });
+        autoFitText('.workspace-card__name', { minPx: 12, maxPx: 16, allowWrap: true });
       } else {
         itemsContainer = container.querySelector('#collectionItems');
         wireDnd(itemsContainer, collectionId);
@@ -1993,11 +1993,19 @@
   // --- התאמת טקסט דינמית לאורכים משתנים ---
   function autoFitText(selector, opts){
     try {
-      const { minPx = 12, maxPx = 16 } = opts || {};
+      const {
+        minPx = 12,
+        maxPx = 16,
+        allowWrap = false,
+        wrapClass = 'is-wrapped',
+      } = opts || {};
       const els = document.querySelectorAll(selector);
       if (!els || !els.length) return;
       els.forEach(el => {
         if (!(el instanceof HTMLElement)) return;
+        if (allowWrap && wrapClass) {
+          el.classList.remove(wrapClass);
+        }
         // שחזור גודל בסיסי אם נשמר, אחרת קבע ושמור
         let base = Number(el.dataset.baseFontPx || '');
         if (!base || Number.isNaN(base)) {
@@ -2020,6 +2028,11 @@
         const ratio = Math.max(minPx / base, Math.min(1, available / Math.max(1, needed)));
         const next = Math.max(minPx, Math.min(maxPx, Math.floor(base * ratio)));
         el.style.fontSize = next + 'px';
+        if (allowWrap && wrapClass && next <= minPx) {
+          if (el.scrollWidth > el.clientWidth + 1) {
+            el.classList.add(wrapClass);
+          }
+        }
       });
     } catch(_e){ /* ignore */ }
   }
@@ -2037,6 +2050,7 @@
   const onResize = throttle(() => {
     autoFitText('#collectionItems .file', { minPx: 12, maxPx: 16 });
     autoFitText('#collectionsSidebar .sidebar-item .name', { minPx: 12, maxPx: 16 });
+    autoFitText('.workspace-card__name', { minPx: 12, maxPx: 16, allowWrap: true });
   }, 150);
   window.addEventListener('resize', onResize);
 


### PR DESCRIPTION
## ✨ תיאור קצר
הרחבנו את מנגנון `autoFitText` עבור כרטיסי שולחן עבודה (Workspace Cards). כעת, במקרה של גלישת טקסט, הפונט יוקטן עד סף קריא, ואם עדיין יש גלישה, הטקסט יעבור לשבירת שורה לשתי שורות כדי למנוע חיתוך.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- שינוי בפונקציה `autoFitText` ב-`collections.js` כדי לתמוך באפשרות `allowWrap` וב-`wrapClass`.
- הוספת לוגיקה ב-`autoFitText` להוספת הקלאס `is-wrapped` כאשר הטקסט קטן לגודל המינימלי ועדיין גולש.
- הוספת סטייל `is-wrapped` ב-`collections.css` המאפשר הצגת שתי שורות טקסט עם `webkit-line-clamp`.
- הפעלת `autoFitText` עם `allowWrap: true` עבור `.workspace-card__name` גם בטעינה וגם ב-`resize`.

## 🧪 בדיקות
- נבדק ידנית על ידי שינוי אורכי טקסט שונים בכרטיסי שולחן עבודה ובשינוי גודל חלון הדפדפן כדי לוודא התנהגות נכונה.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות עברו)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [ ] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינוי ויזואלי בלבד, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: חזרה לגרסה קודמת של הקבצים `collections.js` ו-`collections.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-461fc7b2-5b57-4306-b4a2-7d1b2ba82032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-461fc7b2-5b57-4306-b4a2-7d1b2ba82032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of long names in workspace cards by extending `autoFitText` to optionally wrap text and applying it to workspace items.
> 
> - Extends `autoFitText` in `collections.js` with `allowWrap` and `wrapClass` options; when min size is reached and overflow persists, adds `is-wrapped`
> - Adds CSS for ``.workspace-card__name.is-wrapped`` (two-line clamp with `-webkit-line-clamp`)
> - Applies `autoFitText('.workspace-card__name', { minPx: 12, maxPx: 16, allowWrap: true })` on board hydrate and window resize
> - Keeps existing auto-fit behavior for sidebar and collection list names
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32146393d0c81450d7836881ca9c70fc2d972849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->