### PR TITLE
Cursor/collection documents viewer 0a57

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,6 +49,7 @@ import secrets
 import yaml
 import threading
 import base64
+import contextvars
 import traceback
 import asyncio
 
@@ -4204,39 +4205,44 @@ def _run_awaitable_blocking(awaitable, *, thread_label: str) -> Any:
             running_loop = asyncio.get_running_loop()
         except RuntimeError:
             running_loop = None
+        run_in_clean_context = False
         if running_loop is not None:
             loop_thread_id = getattr(running_loop, "_thread_id", None)
-            if loop_thread_id is not None and loop_thread_id != threading.get_ident():
-                try:
-                    asyncio.events._set_running_loop(None)
-                except Exception:
-                    pass
+            if loop_thread_id is None or loop_thread_id != threading.get_ident():
+                # Loop context leaked from a different thread (gevent/contextvars).
+                # Run in a clean context to avoid false "loop already running".
+                run_in_clean_context = True
                 running_loop = None
             elif running_loop.is_running():
                 raise RuntimeError("event loop is already running")
 
-        prev_loop = None
-        loop = None
-        try:
+        def _run_in_new_loop_inner():
+            prev_loop = None
+            loop = None
             try:
-                prev_loop = asyncio.get_event_loop()
-            except RuntimeError:
-                prev_loop = None
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            return loop.run_until_complete(_runner())
-        finally:
-            if loop is not None:
                 try:
-                    loop.close()
-                finally:
+                    prev_loop = asyncio.get_event_loop()
+                except RuntimeError:
+                    prev_loop = None
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                return loop.run_until_complete(_runner())
+            finally:
+                if loop is not None:
                     try:
-                        if prev_loop is None or prev_loop.is_closed():
-                            asyncio.set_event_loop(None)
-                        else:
-                            asyncio.set_event_loop(prev_loop)
-                    except Exception:
-                        pass
+                        loop.close()
+                    finally:
+                        try:
+                            if prev_loop is None or prev_loop.is_closed():
+                                asyncio.set_event_loop(None)
+                            else:
+                                asyncio.set_event_loop(prev_loop)
+                        except Exception:
+                            pass
+
+        if run_in_clean_context:
+            return contextvars.Context().run(_run_in_new_loop_inner)
+        return _run_in_new_loop_inner()
 
     def _run_in_fresh_thread():
         future: Future = Future()
@@ -4270,7 +4276,7 @@ def _run_awaitable_blocking(awaitable, *, thread_label: str) -> Any:
         running_loop = None
     if running_loop is not None:
         loop_thread_id = getattr(running_loop, "_thread_id", None)
-        if loop_thread_id == threading.get_ident():
+        if loop_thread_id is not None and loop_thread_id == threading.get_ident():
             return _run_in_threadpool_with_fallback()
 
     # אין event loop פעיל ב-thread הנוכחי => מותר להריץ לולאה חדשה כאן.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves asyncio loop handling to avoid false "loop already running" errors under gevent/contextvars.
> 
> - Detects foreign/leaked event loops (`_thread_id` None or different) and runs work in a clean `contextvars.Context()` via `_run_in_new_loop_inner`
> - Refactors loop setup/teardown to reliably restore previous event loop and always close new loops
> - Adjusts thread check to only use threadpool path when `_thread_id` matches current thread
> - Adds `contextvars` import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3681f38d2fbfbfc6b2a6d848a336843cfb6d7c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->