### PR TITLE
Cursor/collection documents viewer 0a57

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4620,19 +4620,21 @@ def _get_webapp_db_health_service():
     לכן אנחנו משתמשים בגרסה סינכרונית כדי להימנע מ-asyncio ב-WSGI.
     """
     global _WEBAPP_DB_HEALTH_SERVICE
-    if _WEBAPP_DB_HEALTH_SERVICE is not None:
-        if isinstance(_WEBAPP_DB_HEALTH_SERVICE, SyncDatabaseHealthService):
-            return _WEBAPP_DB_HEALTH_SERVICE
-        old_service = _WEBAPP_DB_HEALTH_SERVICE
-        _WEBAPP_DB_HEALTH_SERVICE = None
-        close_fn = getattr(old_service, "close", None)
-        if callable(close_fn):
-            try:
-                close_result = close_fn()
-                if inspect.isawaitable(close_result):
-                    _run_awaitable_blocking(close_result, thread_label="db_health_close")
-            except Exception:
-                logger.warning("db_health_service_close_failed", exc_info=True)
+    current_service = _WEBAPP_DB_HEALTH_SERVICE
+    if current_service is not None:
+        if isinstance(current_service, SyncDatabaseHealthService):
+            return current_service
+        # Avoid closing a new instance created by another thread.
+        if current_service is _WEBAPP_DB_HEALTH_SERVICE:
+            _WEBAPP_DB_HEALTH_SERVICE = None
+            close_fn = getattr(current_service, "close", None)
+            if callable(close_fn):
+                try:
+                    close_result = close_fn()
+                    if inspect.isawaitable(close_result):
+                        _run_awaitable_blocking(close_result, thread_label="db_health_close")
+                except Exception:
+                    logger.warning("db_health_service_close_failed", exc_info=True)
 
     # ודא שה-client/db של ה-WebApp מאותחל
     _db = get_db()


### PR DESCRIPTION
נראה שהשגיאה עדיין מגיעה כי ה־WebApp כנראה שמר בזיכרון מופע ישן (async) של השירות. הוספתי הגנה שמוודאת שאם מופע השירות אינו סינכרוני, הוא נבנה מחדש.

מה עשיתי:

ב־_get_webapp_db_health_service בדקתי אם המופע הוא SyncDatabaseHealthService.
אם לא – מאפסים ובונים מחדש שירות סינכרוני.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens `'_get_webapp_db_health_service'` to always provide a synchronous `SyncDatabaseHealthService` under WSGI.
> 
> - If the cached service exists but isn’t `SyncDatabaseHealthService`, reset it and attempt a safe close (supports async `close` via `_run_awaitable_blocking`, with error logging) while avoiding races by checking the current reference
> - Leaves creation path intact: rebuilds the service using the current `client`/`db` via a lightweight manager-like wrapper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e20926c36d678e586115aa439838c8cf967255bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->