### PR TITLE
Cursor/collection documents viewer 0a57

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4566,7 +4566,7 @@ def _db_health_is_authorized() -> bool:
         # fallback: admin session (webapp)
         try:
             uid = session.get("user_id")
-            if uid is not None and is_admin(int(uid)):
+            if uid is not None and is_admin(int(uid)) and not is_impersonating_safe():
                 return True
         except Exception:
             pass


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an admin web-session fallback for `/api/db/*` authorization.
> 
> - Updates `_db_health_is_authorized` to permit authenticated, non-impersonating admin sessions when `Authorization` lacks `Bearer`, falling back from `DB_HEALTH_TOKEN`
> - Keeps existing Bearer token check via `hmac.compare_digest`; new path wrapped in `try/except`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54a866064d6011e76d6319f97af1d558c51643bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->