### PR TITLE
Revert "תיעוד מעבר gevent"

### DIFF
--- a/docs/development/scripts.rst
+++ b/docs/development/scripts.rst
@@ -66,7 +66,6 @@ scripts/migrate_workspace_collections.py
 
 - מעטפת ל-Gunicorn עבור `webapp/` עם הפקת ``ASSET_VERSION`` אוטומטית והפעלת warmup best-effort ל-``/healthz``.
 - מכבד ``PORT`` (ברירת מחדל 5000), ``WEBAPP_WSGI_APP`` ופרמטרי warmup (``WEBAPP_ENABLE_WARMUP`` / ``WEBAPP_WARMUP_URL`` / ``WEBAPP_WARMUP_MAX_ATTEMPTS`` / ``WEBAPP_WARMUP_DELAY_SECONDS``).
-- ברירת המחדל היא worker יחיד עם ``gevent``; ניתן לשלוט ב-``WEB_CONCURRENCY``/``WEBAPP_GUNICORN_WORKERS``, ``WEBAPP_GUNICORN_WORKER_CLASS``, ``WEBAPP_GUNICORN_WORKER_CONNECTIONS`` (ל-``gevent``) ו-``WEBAPP_GUNICORN_THREADS`` (ל-``gthread``).
 - משמש להפעלה מקומית או ב-Render/Heroku כאשר אין Supervisor חיצוני.
 
 ``scripts/start_with_worker.sh``

--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -241,38 +241,32 @@
    * - ``WEB_CONCURRENCY``
      - מספר ה-workers של Gunicorn ב-WebApp. אם מוגדר, גובר על ברירת המחדל של ``scripts/start_webapp.sh`` ומקטין ``queue_delay`` תחת עומס.
      - לא
-     - ``1``
+     - ``2``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKERS``
      - מספר ה-workers של Gunicorn (חלופה ל-``WEB_CONCURRENCY``)
      - לא
-     - ``1``
+     - ``2``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_THREADS``
-     - מספר Threads לכל worker כאשר משתמשים ב-``gthread`` (לא רלוונטי ל-``gevent``)
+     - מספר Threads לכל worker כאשר משתמשים ב-``gthread`` (משפר מקביליות לבקשות I/O)
      - לא
-     - ``4``
+     - ``2``
      - ``8``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKER_CLASS``
-     - Worker class של Gunicorn (ברירת מחדל ``gevent``)
+     - Worker class של Gunicorn (ברירת מחדל ``gthread``)
      - לא
-     - ``gevent``
      - ``gthread``
-     - WebApp
-   * - ``WEBAPP_GUNICORN_WORKER_CONNECTIONS``
-     - מספר חיבורים מקסימלי ל-worker כאשר משתמשים ב-``gevent``
-     - לא
-     - ``100``
-     - ``200``
+     - ``gthread``
      - WebApp
    * - ``WEBAPP_GUNICORN_TIMEOUT``
      - Timeout (שניות) לבקשה ב-Gunicorn
      - לא
-     - ``180``
-     - ``180``
+     - ``60``
+     - ``90``
      - WebApp
    * - ``WEBAPP_GUNICORN_KEEPALIVE``
      - keep-alive (שניות) לחיבורים ב-Gunicorn

--- a/services/config_inspector_service.py
+++ b/services/config_inspector_service.py
@@ -569,32 +569,26 @@ class ConfigService:
         ),
         "WEB_CONCURRENCY": ConfigDefinition(
             key="WEB_CONCURRENCY",
-            default="1",
+            default="2",
             description="מספר ה-workers של Gunicorn ב-WebApp; אם מוגדר, גובר על ברירת המחדל ומקטין queue_delay תחת עומס",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_WORKERS": ConfigDefinition(
             key="WEBAPP_GUNICORN_WORKERS",
-            default="1",
+            default="2",
             description="מספר ה-workers של Gunicorn (חלופה ל-WEB_CONCURRENCY)",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_THREADS": ConfigDefinition(
             key="WEBAPP_GUNICORN_THREADS",
-            default="4",
-            description="מספר Threads לכל worker כאשר משתמשים ב-gthread (לא רלוונטי ל-gevent)",
+            default="2",
+            description="מספר Threads לכל worker כאשר משתמשים ב-gthread (משפר מקביליות לבקשות I/O)",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_WORKER_CLASS": ConfigDefinition(
             key="WEBAPP_GUNICORN_WORKER_CLASS",
-            default="gevent",
+            default="gthread",
             description="Worker class של Gunicorn",
-            category="gunicorn",
-        ),
-        "WEBAPP_GUNICORN_WORKER_CONNECTIONS": ConfigDefinition(
-            key="WEBAPP_GUNICORN_WORKER_CONNECTIONS",
-            default="100",
-            description="מספר חיבורים מקסימלי ל-worker כאשר משתמשים ב-gevent",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_TIMEOUT": ConfigDefinition(


### PR DESCRIPTION
Reverts amirbiron/CodeBot#2961

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior gevent orientation and standardizes Gunicorn defaults to `gthread`.
> 
> - Defaults changed: `WEB_CONCURRENCY` → `2`, `WEBAPP_GUNICORN_WORKERS` → `2`, `WEBAPP_GUNICORN_THREADS` → `2`; `WEBAPP_GUNICORN_WORKER_CLASS` default → `gthread`
> - Removes `WEBAPP_GUNICORN_WORKER_CONNECTIONS` config/Doc entry (gevent-specific)
> - Docs: update `environment-variables.rst` to reflect new defaults and `gthread` as default; tweak `WEBAPP_GUNICORN_THREADS` description; adjust `WEBAPP_GUNICORN_TIMEOUT` examples (60/90)
> - Scripts docs: remove mention of default single `gevent` worker and related tuning vars
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1143a9e3a60e9aae895b5a42d54792f0a2bd7d29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->