### PR TITLE
Revert "Revert "תיעוד מעבר gevent (#2961)" (#2962)"

### DIFF
--- a/docs/development/scripts.rst
+++ b/docs/development/scripts.rst
@@ -66,6 +66,7 @@ scripts/migrate_workspace_collections.py
 
 - מעטפת ל-Gunicorn עבור `webapp/` עם הפקת ``ASSET_VERSION`` אוטומטית והפעלת warmup best-effort ל-``/healthz``.
 - מכבד ``PORT`` (ברירת מחדל 5000), ``WEBAPP_WSGI_APP`` ופרמטרי warmup (``WEBAPP_ENABLE_WARMUP`` / ``WEBAPP_WARMUP_URL`` / ``WEBAPP_WARMUP_MAX_ATTEMPTS`` / ``WEBAPP_WARMUP_DELAY_SECONDS``).
+- ברירת המחדל היא worker יחיד עם ``gevent``; ניתן לשלוט ב-``WEB_CONCURRENCY``/``WEBAPP_GUNICORN_WORKERS``, ``WEBAPP_GUNICORN_WORKER_CLASS``, ``WEBAPP_GUNICORN_WORKER_CONNECTIONS`` (ל-``gevent``) ו-``WEBAPP_GUNICORN_THREADS`` (ל-``gthread``).
 - משמש להפעלה מקומית או ב-Render/Heroku כאשר אין Supervisor חיצוני.
 
 ``scripts/start_with_worker.sh``

--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -241,32 +241,38 @@
    * - ``WEB_CONCURRENCY``
      - מספר ה-workers של Gunicorn ב-WebApp. אם מוגדר, גובר על ברירת המחדל של ``scripts/start_webapp.sh`` ומקטין ``queue_delay`` תחת עומס.
      - לא
-     - ``2``
+     - ``1``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKERS``
      - מספר ה-workers של Gunicorn (חלופה ל-``WEB_CONCURRENCY``)
      - לא
-     - ``2``
+     - ``1``
      - ``4``
      - WebApp
    * - ``WEBAPP_GUNICORN_THREADS``
-     - מספר Threads לכל worker כאשר משתמשים ב-``gthread`` (משפר מקביליות לבקשות I/O)
+     - מספר Threads לכל worker כאשר משתמשים ב-``gthread`` (לא רלוונטי ל-``gevent``)
      - לא
-     - ``2``
+     - ``4``
      - ``8``
      - WebApp
    * - ``WEBAPP_GUNICORN_WORKER_CLASS``
-     - Worker class של Gunicorn (ברירת מחדל ``gthread``)
+     - Worker class של Gunicorn (ברירת מחדל ``gevent``)
      - לא
+     - ``gevent``
      - ``gthread``
-     - ``gthread``
+     - WebApp
+   * - ``WEBAPP_GUNICORN_WORKER_CONNECTIONS``
+     - מספר חיבורים מקסימלי ל-worker כאשר משתמשים ב-``gevent``
+     - לא
+     - ``100``
+     - ``200``
      - WebApp
    * - ``WEBAPP_GUNICORN_TIMEOUT``
      - Timeout (שניות) לבקשה ב-Gunicorn
      - לא
-     - ``60``
-     - ``90``
+     - ``180``
+     - ``180``
      - WebApp
    * - ``WEBAPP_GUNICORN_KEEPALIVE``
      - keep-alive (שניות) לחיבורים ב-Gunicorn

--- a/services/config_inspector_service.py
+++ b/services/config_inspector_service.py
@@ -569,26 +569,32 @@ class ConfigService:
         ),
         "WEB_CONCURRENCY": ConfigDefinition(
             key="WEB_CONCURRENCY",
-            default="2",
+            default="1",
             description="מספר ה-workers של Gunicorn ב-WebApp; אם מוגדר, גובר על ברירת המחדל ומקטין queue_delay תחת עומס",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_WORKERS": ConfigDefinition(
             key="WEBAPP_GUNICORN_WORKERS",
-            default="2",
+            default="1",
             description="מספר ה-workers של Gunicorn (חלופה ל-WEB_CONCURRENCY)",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_THREADS": ConfigDefinition(
             key="WEBAPP_GUNICORN_THREADS",
-            default="2",
-            description="מספר Threads לכל worker כאשר משתמשים ב-gthread (משפר מקביליות לבקשות I/O)",
+            default="4",
+            description="מספר Threads לכל worker כאשר משתמשים ב-gthread (לא רלוונטי ל-gevent)",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_WORKER_CLASS": ConfigDefinition(
             key="WEBAPP_GUNICORN_WORKER_CLASS",
-            default="gthread",
+            default="gevent",
             description="Worker class של Gunicorn",
+            category="gunicorn",
+        ),
+        "WEBAPP_GUNICORN_WORKER_CONNECTIONS": ConfigDefinition(
+            key="WEBAPP_GUNICORN_WORKER_CONNECTIONS",
+            default="100",
+            description="מספר חיבורים מקסימלי ל-worker כאשר משתמשים ב-gevent",
             category="gunicorn",
         ),
         "WEBAPP_GUNICORN_TIMEOUT": ConfigDefinition(


### PR DESCRIPTION
This reverts commit 99fd5ad33cea3f3a67df583d01eeecf215de24e0.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns WebApp runtime defaults with the gevent-based setup and updates docs/inspector accordingly.
> 
> - Default Gunicorn config changed to single worker (`WEB_CONCURRENCY`/`WEBAPP_GUNICORN_WORKERS` → `1`), worker class → `gevent`, and `WEBAPP_GUNICORN_THREADS` default → `4` (gthread-only)
> - Adds `WEBAPP_GUNICORN_WORKER_CONNECTIONS` (gevent) with default `100`
> - Confirms/request timeout defaults in docs (`WEBAPP_GUNICORN_TIMEOUT` now `180`), and clarifies keep-alive/warmup descriptions
> - `scripts/start_webapp.sh` docs: notes gevent single-worker default and tunables
> - `services/config_inspector_service.py`: updates defaults/descriptions to match and exposes the new `WEBAPP_GUNICORN_WORKER_CONNECTIONS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f4215dc509da464228e1bb3299ca2bee80f74d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->