### PR TITLE
כפתורי עריכה והעתקה

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -2700,19 +2700,6 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
         setTimeout(() => { try { document.body.removeChild(announcement); } catch(_){} }, 1000);
       } catch(_) {}
     }
-    function fallbackCopy(text) {
-      try {
-        const textarea = document.createElement('textarea');
-        textarea.value = text;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.select();
-        const success = document.execCommand('copy');
-        document.body.removeChild(textarea);
-        return success;
-      } catch(_) { return false; }
-    }
     // כפתור העתקה משופר לכל בלוק קוד + נגישות מלאה
     try {
       const FALLBACK_LANG = (document.documentElement && document.documentElement.dir === 'rtl') ? 'טקסט' : 'Text';
@@ -3699,6 +3686,22 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
   } catch(_) {}
 })();
 
+function fallbackCopy(text) {
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const success = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return success;
+  } catch(_) {
+    return false;
+  }
+}
+
 function copyMarkdownSource(ev){
   try { if (ev) ev.preventDefault(); } catch(_){ }
   const text = (typeof MD_TEXT === 'string') ? MD_TEXT : '';
@@ -3718,28 +3721,13 @@ function copyMarkdownSource(ev){
       labelEl.textContent = value;
     }
   }
-  function fallbackCopyText(value){
-    try {
-      const textarea = document.createElement('textarea');
-      textarea.value = value;
-      textarea.style.position = 'fixed';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      const ok = document.execCommand('copy');
-      document.body.removeChild(textarea);
-      return ok;
-    } catch(_) {
-      return false;
-    }
-  }
   (async function(){
     let success = false;
     try {
       await navigator.clipboard.writeText(text);
       success = true;
     } catch(_) {
-      success = fallbackCopyText(text);
+      success = fallbackCopy(text);
     }
     if (success) {
       setLabel('הועתק!');


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-0c89a15c-1508-4b88-ac49-39a2a098e107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c89a15c-1508-4b88-ac49-39a2a098e107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/template-only changes that affect clipboard interactions; risk is limited to client-side behavior and browser compatibility.
> 
> **Overview**
> Adds two new toolbar actions to the Markdown preview page: a conditional **Edit** link for non-public views and a **Copy Markdown source** button that copies the original `MD_TEXT` to the clipboard with label feedback and a legacy `execCommand` fallback.
> 
> Also tweaks the toolbar layout to wrap on small screens and relocates the `fallbackCopy` helper so it can be reused across copy interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8eeebf6a9c8a49708d5e9e57819c3f98efcffed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->