### PR TITLE
עיצוב שורת חיפוש

### DIFF
--- a/webapp/templates/md_preview.html
+++ b/webapp/templates/md_preview.html
@@ -730,14 +730,6 @@
   border-color: rgba(255, 255, 255, 0.5);
 }
 
-/* Dark/Dim/Nebula themes - Default dark styling works */
-:root[data-theme="dark"] .md-editor-toolbar,
-:root[data-theme="dim"] .md-editor-toolbar,
-:root[data-theme="nebula"] .md-editor-toolbar {
-  background: var(--glass, rgba(255, 255, 255, 0.08));
-  border-color: var(--glass-border, rgba(255, 255, 255, 0.18));
-}
-
 /* Ocean Theme */
 :root[data-theme="ocean"] .md-editor-toolbar {
   background: rgba(49, 130, 206, 0.2);
@@ -2689,15 +2681,19 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
         if (first) setActiveAndScroll(first);
       }
 
-      function focusNext(){
+      // פונקציה מאוחדת לניווט בין תוצאות - direction: 1 להבא, -1 להקודם
+      function navigateHighlight(direction){
         const all = Array.from(container.querySelectorAll('.md-highlight'));
         if (all.length === 0) return;
         const current = container.querySelector('.md-highlight.is-active');
-        const idx = current ? all.indexOf(current) : -1;
-        const next = all[(idx + 1) % all.length];
-        setActiveAndScroll(next);
+        const idx = current ? all.indexOf(current) : (direction === 1 ? -1 : 0);
+        const target = all[(idx + direction + all.length) % all.length];
+        setActiveAndScroll(target);
         updateCount(all.length, input.value.trim());
       }
+
+      function focusNext(){ navigateHighlight(1); }
+      function focusPrev(){ navigateHighlight(-1); }
 
       input.addEventListener('input', () => {
         const term = (input.value || '').trim();
@@ -2716,16 +2712,6 @@ try { if (typeof window !== 'undefined') { window.attachColorSwatches = attachCo
         updateCount(0, '');
         justAutoFocused = false;
       });
-
-      function focusPrev(){
-        const all = Array.from(container.querySelectorAll('.md-highlight'));
-        if (all.length === 0) return;
-        const current = container.querySelector('.md-highlight.is-active');
-        const idx = current ? all.indexOf(current) : 0;
-        const prev = all[(idx - 1 + all.length) % all.length];
-        setActiveAndScroll(prev);
-        updateCount(all.length, input.value.trim());
-      }
 
       if (nextBtn) {
         nextBtn.addEventListener('click', () => {


### PR DESCRIPTION
## ✨ תיאור קצר
מימשתי עיצוב חדש לסרגל החיפוש והכלים בתצוגת Markdown, בהתאם לבקשה. השינוי כולל העברת כפתורים קיימים, הוספת כפתור ניווט "הקודם" בחיפוש, ותמיכה מלאה בערכות הנושא הקיימות.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- עיצוב מחדש של סרגל החיפוש והכלים בתצוגת Markdown (`md-editor-toolbar`, `md-search-capsule`) עם אפקט "זכוכית" (glassmorphism).
- העברת כפתורי "ערוך" ו"העתק קוד" לשורת הכותרת, ליד כפתורי הניווט.
- העברת כפתור "מסך מלא" לסרגל הכלים החדש של החיפוש.
- הוספת כפתור "הקודם" (▲) לניווט בין תוצאות חיפוש.
- הוספת תמיכה מלאה בעיצוב החדש עבור כל ערכות הנושא (classic, ocean, rose-pine-dawn, dark, dim, nebula, custom/shared).

## 🧪 בדיקות
בדיקה ויזואלית ידנית של העיצוב החדש והפונקציונליות של כפתורי החיפוש ומסך מלא בכל ערכות הנושא.
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות (בדיקות ידניות)
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינויים ויזואליים בלבד, סיכון נמוך.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview: <!-- הוסף כאן קישור ל-RTD Preview של ה-PR, אם קיים -->
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
תוכנית חזרה לאחור במקרה תקלה: ביצוע Rollback ל-PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-bafcde71-c7e4-4ef3-9a5b-09c099c3b147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bafcde71-c7e4-4ef3-9a5b-09c099c3b147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily HTML/CSS refactoring with small, localized JS event changes (search navigation + fullscreen button id). Main risk is minor UI/layout regressions across themes or broken bindings if ids/classes mismatch.
> 
> **Overview**
> **Revamps the Markdown preview search/toolbar UI** by replacing the old `#md-search` bar with a new sticky, glassmorphic `md-editor-toolbar` layout (search capsule + icon buttons), including responsive/mobile styling and per-theme overrides (classic/ocean/rose-pine-dawn/custom/shared).
> 
> Moves the non-reader actions to the page header: adds an explicit `ערוך` link (authenticated only) and a global “העתק קוד” button, and relocates fullscreen control into the new toolbar (new `mdFullscreenBtn2`).
> 
> Extends search navigation with a new “previous result” control (`mdSearchPrev`) and wires it into both the button and `Shift+Enter`, while updating the fullscreen JS to target the new button id and adjust its label/icon on enter/exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1f35c070307490b29816aa563dfc19f6cd99bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->