### PR TITLE
Add code browser documentation and fix code block styling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,7 @@ Code Keeper Bot - תיעוד API
    :caption: WebApp:
 
    webapp/overview
+   webapp/code-browser
    DEV_WEB_PUSH
    webapp/user-interfaces
    webapp/snippet-library

--- a/docs/webapp/code-browser.rst
+++ b/docs/webapp/code-browser.rst
@@ -1,0 +1,84 @@
+דפדפן קוד (Code Browser)
+=========================
+
+דפדפן הקוד מאפשר צפייה וניווט בריפוזיטורים מ-GitHub ישירות בממשק ה-WebApp.
+
+ייבוא ריפו חדש
+--------------
+
+כדי לייבא ריפוזיטורי חדש לדפדפן הקוד, יש להריץ את הפקודה הבאה (אפשר להריץ ב-Shell של Render):
+
+.. code-block:: python
+
+   python3 - <<'PY'
+   from services.repo_sync_service import initial_import
+   from database.db_manager import get_db
+
+   res = initial_import("<קישור לריפו.git>", "שם הריפו", get_db())
+   print(res)
+   PY
+
+.. note::
+   יש להחליף את ``<קישור לריפו.git>`` בכתובת ה-Git של הריפו (למשל ``https://github.com/user/repo.git``)
+   ואת ``"שם הריפו"`` בשם שיוצג בממשק.
+
+הגדרת סנכרון אוטומטי
+--------------------
+
+לאחר ביצוע ``initial_import``, יש להגדיר Webhook ב-GitHub כדי שהמערכת תסנכרן שינויים אוטומטית.
+
+הגדרת Webhook ב-GitHub
+^^^^^^^^^^^^^^^^^^^^^^
+
+1. כנסו לריפו ב-GitHub
+2. לכו ל-**Settings** → **Webhooks** → **Add webhook**
+3. מלאו את הפרטים הבאים:
+
+   .. list-table::
+      :widths: 30 70
+      :header-rows: 1
+
+      * - שדה
+        - ערך
+      * - **Payload URL**
+        - ``https://<הדומיין של קודבוט>/api/webhooks/github``
+      * - **Content type**
+        - ``application/json``
+      * - **Secret**
+        - אותו ערך שמוגדר ב-``GITHUB_WEBHOOK_SECRET`` בסביבה שלכם
+      * - **Events**
+        - בחרו **Just the push event**
+
+4. לחצו **Add webhook**
+
+.. warning::
+   ודאו שה-Secret תואם בדיוק לערך שמוגדר ב-``GITHUB_WEBHOOK_SECRET`` בשרת.
+   אם הערכים לא תואמים, ה-Webhook ייכשל עם שגיאת אימות.
+
+בדיקת הגדרת ה-Webhook
+^^^^^^^^^^^^^^^^^^^^^
+
+לאחר הגדרת ה-Webhook:
+
+1. בצעו ``git push`` לריפו
+2. כנסו ל-**Settings** → **Webhooks** ב-GitHub ובדקו את סטטוס המשלוח האחרון
+3. סטטוס 200 מעיד על הצלחה
+4. ודאו שהקבצים עודכנו בדפדפן הקוד
+
+משתני סביבה נדרשים
+------------------
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - משתנה
+     - תיאור
+   * - ``GITHUB_WEBHOOK_SECRET``
+     - הסוד המשותף לאימות Webhooks מ-GitHub
+
+ראו גם
+------
+
+- :doc:`/repository-integrations`
+- :doc:`/webapp/overview`

--- a/webapp/static/css/repo-browser.css
+++ b/webapp/static/css/repo-browser.css
@@ -2755,7 +2755,7 @@ html[dir="rtl"] .diff-view-toggle {
 
 .markdown-preview-content .hljs {
     color: #adbac7;
-    background: #22272e;
+    background: transparent;
 }
 
 .markdown-preview-content .hljs-doctag,
@@ -2861,7 +2861,7 @@ html[dir="rtl"] .diff-view-toggle {
 
 [data-theme="light"] .markdown-preview-content .hljs {
     color: #24292f;
-    background: #f6f8fa;
+    background: transparent;
 }
 
 [data-theme="light"] .markdown-preview-content .hljs-doctag,


### PR DESCRIPTION
<h2>מה השתנה (What)</h2>
<ul>
  <li>נוסף עמוד תיעוד חדש ל־Code Browser עם הוראות לייבוא ריפו והגדרת GitHub Webhooks.</li>
  <li>תוקנה בעיית “רקע כפול” בבלוקי קוד ב־Markdown ע״י הגדרת <code>.hljs</code> עם <code>background: transparent</code> (כדי למנוע ריבועים צבעוניים מקוננים).</li>
</ul>

<h2>למה זה חשוב (Why)</h2>
<ul>
  <li>כדי שיהיה מדריך ברור ומהיר לשימוש ב־Code Browser ולהגדרה נכונה של אינטגרציית GitHub.</li>
  <li>כדי לשפר את חוויית הקריאה בתיעוד/Preview ולמנוע ארטיפקטים ויזואליים בקטעי קוד.</li>
</ul>

<h2>בדיקות (Tests)</h2>
<ul>
  <li>בניית הדוקומנטציה עברה בהצלחה (Documentation Preview ירוק).</li>
  <li>כיסוי בדיקות לקוד ששונה נשמר (Codecov ירוק).</li>
</ul>


- Add new documentation page for code browser with instructions
  for importing repositories and setting up GitHub webhooks
- Fix double background issue in markdown code blocks by setting
  .hljs background to transparent (was causing nested colored squares)

https://claude.ai/code/session_01XDcnYGATmpmeKV3YiGL3Hb