### PR TITLE
Potential fix for code scanning alert no. 371: Uncontrolled command line

### DIFF
--- a/services/git_mirror_service.py
+++ b/services/git_mirror_service.py
@@ -692,17 +692,21 @@ class GitMirrorService:
         if not ref:
             ref = "HEAD"
 
-        # ולידציה של נתיבים לפני הרצת git (מניעת uncontrolled command line)
-        if not self._validate_repo_file_path(file_path):
+        # ולידציה חזקה של נתיב הקובץ לפני שילוב בפקודת git
+        safe_file_path = self._get_safe_file_path(file_path)
+        if not safe_file_path:
             logger.warning("Rejected invalid repo file path: %r", file_path)
             return None
+
+        # ולידציה של ref לפני שילוב בפקודת git (מניעת uncontrolled command line)
         if not self._validate_repo_ref(ref):
             logger.warning("Rejected invalid repo ref: %r", ref)
             return None
 
         repo_path = self._get_repo_path(repo_name)
 
-        result = self._run_git_command(["git", "show", f"{ref}:{file_path}"], cwd=repo_path, timeout=30)
+        # שימוש רק בערכים שעברו ולידציה בקומנד עצמו
+        result = self._run_git_command(["git", "show", f"{ref}:{safe_file_path}"], cwd=repo_path, timeout=30)
 
         if result.success:
             return result.stdout


### PR DESCRIPTION
Potential fix for [https://github.com/amirbiron/CodeBot/security/code-scanning/371](https://github.com/amirbiron/CodeBot/security/code-scanning/371)

General approach: Ensure any user-controlled strings incorporated into git command arguments are strictly validated and normalized before use, using allowlists and strict patterns. Avoid passing raw user input into `"ref:path"` expressions.

Best specific fix here:

* In `GitMirrorService.get_file_content`:
  * Normalize and validate `file_path` using the stricter `_get_safe_file_path` helper, which both validates and returns a canonical safe path, instead of only calling `_validate_repo_file_path`.
  * Continue to validate `ref` with `_validate_repo_ref`, but ensure the value passed into the f-string is the trimmed/validated version.
  * If either `file_path` or `ref` fails validation, return `None` early and log a warning.
* Leave `_run_git_command` as-is; it already enforces command shape and does not use `shell=True`, so once inputs are validated the subprocess call is safe.

Concretely:

* Edit `services/git_mirror_service.py` around lines 689–705:
  * After stripping `file_path`, call `safe_file_path = self._get_safe_file_path(file_path)` and reject if `None`.
  * Validate `ref` via `_validate_repo_ref(ref)` after stripping, and reject if invalid.
  * Use `safe_file_path` instead of `file_path` when constructing `["git", "show", f"{ref}:{safe_file_path}"]`.

No changes are required in `webapp/app.py` or `webapp/routes/repo_browser.py`; they will automatically benefit from the stricter validation in `get_file_content`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
