### PR TITLE
Document and file navigation

### DIFF
--- a/webapp/static/js/collections.js
+++ b/webapp/static/js/collections.js
@@ -2058,10 +2058,6 @@
           await openFileByName(fname);
           return;
         }
-        if (!ev.target.closest('.collection-card__drag') && !ev.target.closest('.drag') && !ev.target.closest('button')) {
-          const fname = name;
-          await openFileByName(fname);
-        }
       });
     }
 
@@ -2259,11 +2255,8 @@
     const url = (mode === 'md')
       ? `/md/${encodeURIComponent(fileId)}`
       : `/html/${encodeURIComponent(fileId)}`;
-    try {
-      window.open(url, '_blank', 'noopener');
-    } catch (_err) {
-      window.location.href = url;
-    }
+    // דרישת UX: לפתוח באותו טאב (לא בכרטיסייה חדשה)
+    window.location.href = url;
   }
 
   // פתיחת קובץ לפי שם הקובץ (שימושי גם ללחיצה על כל השורה)
@@ -2552,9 +2545,6 @@
         const fname = link.getAttribute('data-open') || '';
         await openFileByName(fname);
         return;
-      }
-      if (!ev.target.closest('button')) {
-        await openFileByName(name);
       }
     });
   }

--- a/webapp/templates/dashboard.html
+++ b/webapp/templates/dashboard.html
@@ -56,12 +56,12 @@
         
         <div class="pinned-grid" data-pinned-grid>
             {% for file in pinned_files %}
-            <a href="/file/{{ file.id }}" class="pinned-card" data-pinned-card data-file-id="{{ file.id }}">
+            <div class="pinned-card" data-pinned-card data-file-id="{{ file.id }}">
                 <div class="pinned-card__icon">{{ file.icon }}</div>
                 <div class="pinned-card__content">
-                    <div class="pinned-card__name" title="{{ file.file_name }}">
+                    <a class="pinned-card__name" href="/file/{{ file.id }}" title="{{ file.file_name }}">
                         {{ file.file_name }}
-                    </div>
+                    </a>
                     <div class="pinned-card__meta">
                         <span class="lang-badge" data-lang="{{ file.language|lower }}">{{ file.language }}</span>
                         {% if file.lines %}
@@ -77,10 +77,10 @@
                         data-unpin-file="{{ file.id }}"
                         title="הסר מנעוצים"
                         aria-label="הסר מנעוצים"
-                        onclick="event.preventDefault(); event.stopPropagation(); unpinFile('{{ file.id }}');">
+                        onclick="event.stopPropagation(); unpinFile('{{ file.id }}');">
                     ✕
                 </button>
-            </a>
+            </div>
             {% endfor %}
         </div>
         
@@ -794,6 +794,13 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
+.pinned-card__name:hover {
+    text-decoration: underline;
 }
 
 .pinned-card__meta {


### PR DESCRIPTION
## ✨ תיאור קצר
שיניתי את התנהגות הלחיצה על כרטיסים וקישורים ב״אוספים שלי״ וב״קבצים נעוצים״ כדי לשפר את חווית המשתמש. כעת, לחיצה על 🌐 במסמכי Markdown/HTML נפתחת באותו טאב, ורק שם המסמך/קובץ הוא קישור לפרטיו, במקום כל הכרטיס.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- **״האוספים שלי״**: לחיצה על אייקון 🌐 (לצפייה ב־Markdown/HTML) פותחת את התצוגה **באותו טאב** (במקום טאב חדש).
- **״האוספים שלי״**: ביטלתי את פתיחת הקובץ בלחיצה על כל הכרטיס. כעת, **רק לחיצה על שם המסמך** פותחת אותו. כפתורים כמו 🧾/🌐/✕ נשארו עם התנהגותם הרגילה.
- **דשבורד / ״קבצים נעוצים״**: הכרטיס כבר לא עטוף כולו בקישור. כעת, **רק שם הקובץ** הוא קישור לעמוד הקובץ.

## 🧪 בדיקות
- בדקתי ידנית את ההתנהגות החדשה ב״אוספים שלי״ וב״קבצים נעוצים״.
- הרצתי `python3 -m pytest -q tests/test_pin_to_dashboard.py tests/test_collections_api.py` והבדיקות עברו בהצלחה.
- [x] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [ ] feat: פיצ'ר חדש
- [x] fix: תיקון באג (תיקון התנהגות UX לא עקבית)
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
- [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
- [ ] CHANGELOG עודכן אם נדרש
- [x] כל ה‑Required Checks לעיל ירוקים
- [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- שיפור חווית המשתמש על ידי הפיכת הלחיצות למדויקות וצפויות יותר. אין סיכון מהותי.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- במקרה תקלה, ניתן לבצע Rollback על ידי החזרת הקוד לגרסה הקודמת.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-73efb4f8-5503-46f9-a878-fa71ba45542a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73efb4f8-5503-46f9-a878-fa71ba45542a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

