### PR TITLE
Cursor/ai 5712

### DIFF
--- a/services/embedding_service.py
+++ b/services/embedding_service.py
@@ -430,9 +430,10 @@ class EmbeddingService:
                     return embedding2
         except Exception:
             pass
-        # Self-heal: if still 404, try to pick a working model from ListModels automatically.
+        # Self-heal: if current model is 404 (and v1 fallback didn't return an embedding),
+        # try to pick a working model from ListModels automatically.
         try:
-            if embedding is None and int(status1 or 0) == 404 and (status2 is None or int(status2 or 0) == 404):
+            if embedding is None and int(status1 or 0) == 404:
                 healed = await self._self_heal_on_404(
                     text=text,
                     preferred_dimensions=int(dimensions),


### PR DESCRIPTION
מה זה אומר בלוגים שלך
זה אומר שכרגע הקונפיג עדיין מצביע על text-embedding-004, והמודל הזה לא קיים/לא תומך embedContent אצלך – לא ב־v1beta ולא ב־v1. לכן כל ניסיון embedding נכשל עם 404.

הנקודה הקריטית: עד עכשיו “העדכון האוטומטי” התבסס בעיקר על תהליך ה־startup/health. אם הוא לא הספיק לרוץ לפני שנשלחה בקשת embedding (או לא הצליח לשמור קונפיג), אז עדיין היית רואה נסיונות ל־004.

מה שיניתי כדי שזה יתעדכן באמת, ולא רק “ירשום בלוג”
הוספתי self-heal בתוך services/embedding_service.py:

אם יש 404 על המודל הנוכחי (כולל ניסיון fallback ל־v1) → השירות קורא ListModels, מסנן רק מודלים שתומכים embedContent, בוחר מודל embedding סביר, מנסה אותו מיד, וב־best‑effort גם מנסה לשמור אותו ב־DB כדי שכל המערכת תעבור אליו.
יש throttle (ברירת מחדל 60 שניות) כדי שלא יהיו “סופות” של ListModels תחת עומס.
בנוסף, הורדתי את לוגי httpx ל־WARNING כדי שלא יודפס URL עם key=.
דחפתי את זה ל־cursor/ai-5712 בקומיט: fix: self-heal מודל embedding לפי ListModels כשיש 404.

חשוב (אבטחה)
בלוגים קודמים שלך חשפו את GEMINI_API_KEY בתוך URL. גם אם עכשיו זה יפסיק להופיע בלוגים, מומלץ מאוד לסובב/לבטל את המפתח הזה בגוגל ולהחליף, כי הוא כבר הודלף.


