### PR TITLE
Cursor/ai 5712

### DIFF
--- a/services/embedding_worker.py
+++ b/services/embedding_worker.py
@@ -112,7 +112,6 @@ class EmbeddingWorker:
             includes self-heal (ListModels pick) and persistence. After it returns an embedding,
             we refresh `settings` so metadata matches the actual model going forward.
             """
-            nonlocal settings
             nonlocal effective_model, effective_api_version, effective_dim, effective_key
             model = str(getattr(settings, "model", "") or "")
             api_version = str(getattr(settings, "api_version", "") or "v1beta")


### PR DESCRIPTION
הלוגים האלה קרו בדיוק בגלל מה שחשדתי: ה־EmbeddingWorker עבד “עם קונפיג קבוע” ולכן לא הפעיל self-heal כשהמודל החזיר 404 — ואז הוא יצר 0 chunks.

תיקנתי את זה עכשיו:

ב־services/embedding_worker.py הוספתי: אם generate_embedding_with_status() מחזיר 404, ה־worker קורא ל־EmbeddingService.generate_embedding() שמפעיל self‑heal (בחירה מתוך ListModels), ואז מרענן את settings כך שה־metadata (embeddingModelKey וכו’) יתאימו למודל שבאמת עבד.
הוספתי גם best‑effort retry ל־dimension mismatch (422) עם dimensions=0.