### PR TITLE
Claude/auto heal embedding model o r lpu

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -469,7 +469,11 @@ def _maybe_start_embedding_health_check() -> None:
                 # non-None even in a fresh daemon thread.  Bypass the
                 # check only — run_forever() will still call
                 # _set_running_loop(self) so httpx/sniffio detect asyncio.
-                loop._check_running = lambda: None
+                # Guard: uvloop uses __slots__ and rejects new attributes.
+                try:
+                    loop._check_running = lambda: None
+                except (AttributeError, TypeError):
+                    pass
                 asyncio.set_event_loop(loop)
                 try:
                     loop.run_until_complete(coro)


### PR DESCRIPTION
נדחף. ההבדל מהגישה הקודמת:

_set_running_loop(None)
_check_running = lambda: None
"another loop is running"
פותר (מנקה state)
פותר (מדלג על הבדיקה)
run_forever() → _set_running_loop(self)
נקרא, אבל loop כבר "נוקה"
נקרא כרגיל
httpx/sniffio detect asyncio
נכשל (state נוקה)
עובד (loop רשום כרגיל)
אחרי deploy חפש:
# הצלחה (ה-self-heal רץ!):
grep "Self-heal triggered\|Self-heal SUCCESS" app.log

# עדיין נכשל:
grep "Embedding health-check thread failed" app.log