### PR TITLE
docs: הוספת מדריך מימוש לפיצ'ר גיבוי אישי (Personal Backup)

### DIFF
--- a/GUIDES/PERSONAL_BACKUP_FEATURE_GUIDE.md
+++ b/GUIDES/PERSONAL_BACKUP_FEATURE_GUIDE.md
@@ -867,12 +867,19 @@ class PersonalBackupService:
                     if not new_file_id and not file_name:
                         continue  # לא ניתן לשייך את הפתקית
 
-                    # חישוב scope_id חדש (כמו ב-sticky_notes_api)
+                    # חישוב scope_id חדש — חייב להתאים ל-_make_scope_id בדיוק:
+                    # normalized = re.sub(r"\s+", " ", file_name.strip()).lower()
+                    # digest = sha256(f"{user_id}::{normalized}").hexdigest()[:16]
+                    # scope_id = f"user:{user_id}:file:{digest}"
                     import re
+                    import hashlib
                     scope_id = None
                     if file_name:
                         normalized = re.sub(r"\s+", " ", str(file_name).strip()).lower()
-                        scope_id = f"{user_id}:{normalized}"
+                        digest = hashlib.sha256(
+                            f"{user_id}::{normalized}".encode("utf-8")
+                        ).hexdigest()[:16]
+                        scope_id = f"user:{user_id}:file:{digest}"
 
                     content = note.get("content", "")
 


### PR DESCRIPTION
מדריך מלא למימוש פיצ'ר גיבוי אישי בווב אפ, הכולל:
- שירות גיבוי (services/personal_backup_service.py)
- API endpoints (webapp/backup_api.py)
- ממשק משתמש בדף ההגדרות (settings.html)
- טסטים (tests/test_personal_backup.py)

המדריך מותאם לארכיטקטורה הקיימת: DatabaseManager, CollectionsManager, BookmarksManager, ודפוסי ZIP export מ-collections_api.py.

https://claude.ai/code/session_01Qquudr2z1ZbzZtb53xKdWF

