### PR TITLE
feat: dynamic repo selection in upload-from-repo & z-index fixes

### DIFF
--- a/webapp/static/css/repo-browser.css
+++ b/webapp/static/css/repo-browser.css
@@ -1079,7 +1079,7 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 99;
+    z-index: 1099;
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -1104,7 +1104,7 @@
         display: none;
     }
     
-    /* Sidebar as overlay from the right (RTL support) */
+    /* סיידבר כשכבת-על מימין (תמיכה ב-RTL) – z-index גבוה מסרגל חיפוש (1001) */
     .repo-sidebar {
         position: fixed;
         right: 0;
@@ -1114,7 +1114,7 @@
         width: 85vw !important;
         max-width: 320px;
         min-width: auto;
-        z-index: 200;
+        z-index: 1100;
         transform: translateX(100%);
         transition: transform 0.3s ease;
         box-shadow: -4px 0 20px rgba(0, 0, 0, 0.3);
@@ -1338,7 +1338,9 @@
     right: 0;
     width: 400px;
     max-width: 90vw;
+    /* dvh מתחשב בסרגל ניווט של אנדרואיד; 100vh כ-fallback לדפדפנים ישנים */
     height: 100vh;
+    height: 100dvh;
     background: var(--bg-secondary, #181825);
     border-left: 1px solid var(--border-color, #45475a);  /* גבול בצד התוכן */
     z-index: 1000;
@@ -1346,6 +1348,8 @@
     transition: transform 0.3s ease;
     display: flex;
     flex-direction: column;
+    /* ריווח תחתון ל-safe area של מכשירים ניידים (אנדרואיד / iOS) */
+    padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 html[dir="rtl"] .history-panel {

--- a/webapp/static/js/repo-browser.js
+++ b/webapp/static/js/repo-browser.js
@@ -1677,7 +1677,7 @@ function updateFileHeader(filePath) {
             </span>
         </div>
         <div class="file-actions file-header-actions">
-            <a class="btn-icon file-edit-btn" href="/upload/from-repo?path=${encodeURIComponent(filePath)}" target="_blank" title="ערוך / העתק קטעים" aria-label="ערוך קובץ">
+            <a class="btn-icon file-edit-btn" href="/upload/from-repo?path=${encodeURIComponent(filePath)}&repo=${encodeURIComponent(currentRepo)}" target="_blank" title="ערוך / העתק קטעים" aria-label="ערוך קובץ">
                 <i class="bi bi-pencil-square"></i>
             </a>
             <button class="file-history-btn" data-path="${escapeHtml(filePath)}" title="היסטוריית קובץ" aria-label="היסטוריית קובץ">
@@ -2259,6 +2259,29 @@ window.RepoState = {
     },
     get editorView6() {
         return state.editorView6;
+    },
+    /**
+     * עדכון תוכן הקובץ המוצג – מעדכן את ה-state, ה-editor, ותצוגת Markdown אם פעילה.
+     * משמש את viewFileAtCommit כדי להבטיח שהתוכן מתעדכן בכל מצב תצוגה.
+     */
+    async setFileContent(content) {
+        state.currentFileContent = content;
+
+        // עדכון ה-editor אם קיים
+        if (state.editor && typeof state.editor.setValue === 'function') {
+            state.editor.setValue(content);
+        } else if (state.editorView6) {
+            const view = state.editorView6;
+            const docLength = view.state.doc.length;
+            view.dispatch({
+                changes: { from: 0, to: docLength, insert: String(content || '') }
+            });
+        }
+
+        // אם תצוגת Markdown פעילה – עדכון הרינדור
+        if (state.markdownPreviewEnabled) {
+            await renderMarkdownPreview(content);
+        }
     }
 };
 

--- a/webapp/static/js/repo-history.js
+++ b/webapp/static/js/repo-history.js
@@ -855,8 +855,11 @@ const RepoHistory = (function() {
                 return;
             }
 
-            // Update editor content
-            if (window.RepoState && window.RepoState.editor) {
+            // עדכון תוכן הקובץ – דרך setFileContent שמעדכן state, editor, ו-Markdown preview
+            if (window.RepoState && typeof window.RepoState.setFileContent === 'function') {
+                await window.RepoState.setFileContent(data.content);
+            } else if (window.RepoState && window.RepoState.editor) {
+                // fallback ישן למקרה ש-setFileContent לא זמין
                 window.RepoState.editor.setValue(data.content);
             }
 


### PR DESCRIPTION
## ✨ תיאור קצר
הוספת תמיכה בבחירת ריפו דינמית בעמוד העלאה מהריפו (במקום hard-coded CodeBot), תיקון z-index של overlay ו-sidebar בדפדפן הריפו, ושיפור עדכון תוכן הקובץ בעת צפייה בהיסטוריה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] Frontend (JavaScript/CSS)

### פירוט:
- **Backend (`webapp/app.py`)**:
  - הוספת קבלת `repo` parameter מ-query string בנתיב `/upload/from-repo`
  - validation של שם הריפו (regex: `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$`)
  - שליפת metadata של הריפו מ-DB (URL, default branch) במקום hard-coded GitHub URL
  - בניית `source_url` דינמית על בסיס metadata
  - הסרת `.git` מסוף ה-URL אם קיים

- **Frontend (`webapp/static/js/repo-browser.js`)**:
  - העברת `currentRepo` כ-parameter בקישור "ערוך קובץ"
  - הוספת method `setFileContent()` ב-`RepoState` לעדכון תוכן בכל מצבי התצוגה (editor, CodeMirror6, Markdown preview)

- **Frontend (`webapp/static/js/repo-history.js`)**:
  - שימוש ב-`setFileContent()` החדש בעת צפייה בקובץ בהיסטוריה
  - fallback ישן למקרה שה-method לא זמין

- **CSS (`webapp/static/css/repo-browser.css`)**:
  - תיקון z-index של modal overlay: `99` → `1099`
  - תיקון z-index של sidebar: `200` → `1100`
  - הוספת תמיכה ב-`100dvh` (dynamic viewport height) לטלפונים עם סרגל ניווט
  - הוספת `padding-bottom: env(safe-area-inset-bottom)` לטלפונים עם notch/home indicator

## 🧪 בדיקות
- [ ] Unit
- [ ] Integration
- [ ] Manual – בדיקת העלאה מריפו שונה, בדיקת z-index בדפדפן הריפו, בדיקת עדכון תוכן בהיסטוריה

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש (בחירת ריפו דינמית)
- [x] fix: תיקון z-index ו-viewport height
- [x] refactor: חילוץ `setFileContent()` לשימוש משותף

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון
- [ ] בדיקות רצות ועוברות (יש להריץ)
- [x] אין סודות/PII בקוד
- [x] אין מחיקות מסוכנות
- [x] הודעת הקומיט תואמת Conventional Commits

## 🧩 השפעות/סיכונים
- **השפעה חיובית**: תמיכה בריפו

https://claude.ai/code/session_01KYUB6twimzAkqQTmDdnkfd