### PR TITLE
fix: persist sticky notes cache from memory on state changes

### DIFF
--- a/webapp/static/js/sticky-notes.js
+++ b/webapp/static/js/sticky-notes.js
@@ -722,11 +722,15 @@
         const nextSeq = (this._pendingSeq.get(id) || 0) + 1;
         this._pendingSeq.set(id, nextSeq);
       } catch(_) {}
+      this._persistCacheFromMemory();
       this._saveDebounced();
       this._ensureBackgroundAutoFlush();
     }
 
     _flushPendingKeepalive(){
+      try {
+        this._persistCacheFromMemory();
+      } catch(_) {}
       try {
         const combined = new Map();
         try {
@@ -982,6 +986,7 @@
           }
         }
       }
+      this._persistCacheFromMemory();
       if ((!this._pending || this._pending.size === 0) && (!this._inFlight || this._inFlight.size === 0)) {
         this._stopBackgroundAutoFlush();
       }
@@ -999,6 +1004,7 @@
       }
       this._pending.delete(id);
       await this._sendUpdate(id, data);
+      this._persistCacheFromMemory();
       if ((!this._pending || this._pending.size === 0) && (!this._inFlight || this._inFlight.size === 0)) {
         this._stopBackgroundAutoFlush();
       }
@@ -1349,6 +1355,16 @@
       try {
         const payload = { ts: Date.now(), notes: Array.isArray(notesArray) ? notesArray : [] };
         localStorage.setItem(this._cacheKey, JSON.stringify(payload));
+      } catch(_) {}
+    }
+
+    _persistCacheFromMemory(){
+      try {
+        const all = [];
+        for (const [, entry] of this.notes.entries()) {
+          if (entry && entry.data) all.push(entry.data);
+        }
+        this._saveCache(all);
       } catch(_) {}
     }
   }


### PR DESCRIPTION
## ✨ תיאור קצר
הוספת קריאות ל-`_persistCacheFromMemory()` בנקודות קריטיות בזרימת הסנכרון כדי להבטיח שהמטמון המקומי (localStorage) יישמר עם המצב הנוכחי של ההערות בזיכרון.

## 📦 שינויים עיקריים
- [x] קוד (Frontend - JavaScript)

### פירוט:
- הוספת `_persistCacheFromMemory()` - מתודה חדשה שמאחסנת את כל ההערות מהזיכרון ל-localStorage
- קריאה למתודה זו ב-4 מקומות קריטיים:
  1. בסוף `_addPending()` - לאחר הוספת הערה חדשה
  2. בתחילת `_flushPendingKeepalive()` - לפני שליחת keepalive
  3. בסוף `_processPendingUpdates()` - לאחר עיבוד עדכונים
  4. בסוף `_sendUpdate()` - לאחר שליחת עדכון

## 🧪 בדיקות
- CI Required Checks: 🔍 Code Quality & Security; Unit Tests (3.11); Unit Tests (3.12)
- השינוי הוא defensive - הוספת קריאות persist בנקודות בטוחות שכבר מטפלות בשגיאות
- כל הקריאות החדשות עטופות ב-try/catch כדי למנוע השפעה על זרימת הקוד הקיימת

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון הקיים
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות

## 🧩 השפעות/סיכונים
- **השפעה חיובית**: שיפור אמינות המטמון המקומי - הערות לא יאבדו במקרה של קריסה או סגירת דפדפן בזמן סנכרון
- **סיכון**: זניח - קריאות persist נוספות עלולות להוסיף עומס קל על localStorage, אך כל קריאה עטופה ב-try/catch

## 🔗 קישורים
- CI Required Checks: 🔍 Code Quality & Security; Unit Tests (3.11); Unit Tests (3.12)

https://claude.ai/code/session_01UCWnSj4UYXMzYYi4UFWHBa