### PR TITLE
Bookmark display and content

### DIFF
--- a/webapp/static/css/bookmarks.css
+++ b/webapp/static/css/bookmarks.css
@@ -369,6 +369,11 @@ iframe .bookmarked {
     .bookmarks-panel-actions button { flex: 0 0 auto; }
     .notification-container { left: 10px; right: 10px; bottom: 10px; }
     .notification { min-width: auto; width: 100%; }
+
+    /* Markdown preview: הסתר כפתור TOC צף כשהפאנל פתוח כדי שלא יצוף מעליו */
+    body.bookmarks-panel-open #mdTocMini {
+        display: none !important;
+    }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## ✨ תיאור קצר
- תיקון סדר סימניות Markdown כך שיוצגו לפי סדר הופעתן במסמך, הסרת התו `¶` משמות הסימניות, והסתרת כפתור תוכן העניינים הצף במובייל כאשר פאנל הסימניות פתוח. השינויים משפרים את חווית המשתמש והתצוגה בממשק.

## 📦 שינויים עיקריים
- [ ] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות (רשימת תבליטים):
- ב-`webapp/static/js/bookmarks.js`:
    - הוספת "מספר שורה" סינתטי (line_number) לסימניות כותרת ב-Markdown כדי לאפשר מיון נכון בפאנל.
    - ניקוי התו `¶` משם הסימניה לפני שמירתה והצגתה.
    - הוספה/הסרה של קלאס `bookmarks-panel-open` לאלמנט ה-`body` בעת פתיחה/סגירה של פאנל הסימניות.
- ב-`webapp/static/css/bookmarks.css`:
    - הוספת כלל CSS להסתרת כפתור תוכן העניינים הצף (`#mdTocMini`) כאשר פאנל הסימניות פתוח (על ידי הקלאס `body.bookmarks-panel-open`).

## 🧪 בדיקות
- בוצעה בדיקה ידנית של סדר הסימניות, ניקוי התו `¶` והתנהגות כפתור ה-TOC במובייל.
- בוצעה בדיקת תקינות תחבירית של קוד ה-JS (`node --check`).
- [ ] Unit
- [ ] Integration
- [x] Manual

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג
- [ ] feat: פיצ'ר חדש
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית/CI
- [ ] breaking change: שינוי שובר תאימות

### דוגמאות Conventional Commits

| סוג | דוגמה להודעה | מתי להשתמש |
| --- | --- | --- |
| feat | feat: הוספת מסך הגדרות | פיצ'ר חדש למשתמש |
| fix | fix: תיקון קריסה בעת התחברות | תיקון באג מול משתמשים/פרודקשן |
| chore | chore: שדרוג Gradle ל-8.9 | תחזוקה, כלי פיתוח, housekeeping |
| docs | docs: עדכון README עם הוראות התקנה | שינויי תיעוד בלבד |
| refactor | refactor: חילוץ Repository ל-UseCases | שינוי מבני ללא שינוי התנהגות |
| test | test: הוספת בדיקות ל-LoginViewModel | הוספת/עדכון בדיקות |
| build | build: הוספת flavor staging ל-CI | שינויים בבילד/תלויות/תצורה |

## ✅ צ'קליסט
- [ ] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן (README/Docs)
- [ ] אם נוספו ג'ובים חדשים (Background Jobs) – וודא שהם רשומים ב-`services/register_jobs.py` (כולל Callback/Trigger להפעלה ידנית — למשל `callback_name`/`trigger_func` לפי המבנה) כדי שיופיעו בדשבורד
- [ ] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [ ] אם נוספו/השתנו טוקנים – עודכן גם `docs/webapp/theming_and_css.rst` + `FEATURE_SUGGESTIONS/theme_matrix.md`
- [ ] אין סודות/מפתחות בקוד
- [ ] אין מחיקות מסוכנות/פעולות על root (ראו .cursorrules)
 - [x] הודעת הקומיט תואמת Conventional Commits (ע"פ הטבלה)
 - [ ] CHANGELOG עודכן אם נדרש
 - [ ] כל ה‑Required Checks לעיל ירוקים
 - [ ] צילום/וידאו UI מצורף אם רלוונטי

## 🧩 השפעות/סיכונים
- השפעה אפשרית על פרודקשן, ביצועים, או אבטחה: שינויים ב-UI/UX של פאנל הסימניות. סיכון נמוך, בעיקר ויזואלי וסדר תצוגה.

## 🔗 קישורים
- Issues קשורים: #
- Docs Preview:
- מסמכים/מפרטים רלוונטיים:
 - [Branch Protection & PR Rules](../docs/branch-protection-and-pr-rules.rst)

## 🧯 סיכון / החזרה לאחור (Rollback)
- תוכנית חזרה לאחור במקרה תקלה: Rollback של ה-PR. השינויים הם בעיקר בצד הלקוח (JS/CSS) ואינם משפיעים על מבנה הנתונים ב-DB באופן שובר תאימות.

---
<p><a href="https://cursor.com/agents?id=bc-ab0f10b4-9867-482a-83f4-422d57e603ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab0f10b4-9867-482a-83f4-422d57e603ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

