### PR TITLE
docs: עדכון מדריך "העתק כמארקדאון" — Source Mapping

### DIFF
--- a/webapp/FEATURE_SUGGESTIONS/COPY_SELECTION_AS_MARKDOWN_GUIDE.md
+++ b/webapp/FEATURE_SUGGESTIONS/COPY_SELECTION_AS_MARKDOWN_GUIDE.md
@@ -450,10 +450,17 @@ HTML מרונדר (חלקי):
                        || endNode.getAttribute('data-source-line'));
     }
 
-    // אם חסר אחד מהם — השתמש בשני
-    if (startLine == null && endLine != null) startLine = endLine;
-    if (endLine == null && startLine != null) endLine = startLine;
-    if (startLine == null) return null;
+    // אם חסר אחד מהם — קרא את שני ה-attributes מה-node שנמצא.
+    // חשוב: לא מעתיקים startLine ל-endLine (או להיפך) כי זה ייתן
+    // slice(n, n) = מערך ריק. במקום זה, קוראים גם start וגם end מאותו node.
+    if (!startNode && endNode) {
+      startLine = Number(endNode.getAttribute('data-source-line'));
+    }
+    if (!endNode && startNode) {
+      endLine = Number(startNode.getAttribute('data-source-line-end')
+                       || startNode.getAttribute('data-source-line'));
+    }
+    if (startLine == null || endLine == null) return null;
 
     // ודא שהטווח הגיוני
     if (endLine < startLine) {
@@ -639,6 +646,8 @@ token.map[1] → data-source-line-end="3" (שורת סיום, exclusive)
 - את ה-`data-source-line-end` של ה-end container (= שורת הסיום)
 
 אם הסלקציה כולה בתוך אלמנט אחד — שני הערכים מגיעים מאותו אלמנט. אם היא חוצה כמה אלמנטים — כל אחד נותן את הצד שלו.
+
+**טיפול ב-node חסר:** כשרק צד אחד של הסלקציה נמצא (למשל כשגוררים לסוף `#md-content` והדפדפן שם את `endContainer` על הקונטיינר עצמו), הקוד קורא **את שני ה-attributes** (`data-source-line` + `data-source-line-end`) מה-node שכן נמצא. ככה נמנעים ממצב של `slice(n, n)` שמחזיר מערך ריק.
 
 ### חלק 5: חיתוך מקור
 


### PR DESCRIPTION
## ✨ תיאור קצר
עדכון מסמך המדריך `COPY_SELECTION_AS_MARKDOWN_GUIDE.md` להחלפת גישת המימוש מ-Fuzzy Matching (השוואת מחרוזות) ל-Source Mapping (מיפוי ישיר דרך data attributes). הגישה החדשה אמינה יותר, מדויקת 100%, וחוסכת regex מסובך.

## 📦 שינויים עיקריים
- [ ] תיעוד (docs/)

### פירוט:
- **הסרת הסבר Fuzzy Matching** — הסרת הגישה הישנה שהסתמכה על השוואת טקסט ו-regex
- **הוספת סקשן "למה Source Mapping"** — הסבר מפורש מדוע הגישה הישנה שבירה (נרמול רווחים, מקרי קצה, fallback)
- **עדכון עקרון המימוש** — שינוי מ-4 שלבים (פיצול, חילוץ, מציאה, החזרה) ל-4 שלבים חדשים (Plugin, קריאה מ-DOM, חישוב טווח, חיתוך)
- **הוספת Plugin ל-Source Mapping** — קוד חדש שמוסיף `data-source-line` ו-`data-source-line-end` לכל אלמנט בלוק
- **שכתוב לוגיקת ההעתקה** — החלפת `mapSelectionToSource` (מבוסס טקסט) ב-`mapRangeToMarkdown` (מבוסס DOM attributes)
- **הסרת פונקציות עזר** — `normalize`, `stripMarkdownSyntax`, `findLineIndex` כבר לא נדרשות
- **טבלת השוואה** — הוספת טבלה המשווה בין שתי הגישות (דיוק, מקרי קצה, תחזוקה, ביצועים)
- **טבלת tokens** — הוספת טבלה המפרטת אילו token types יש להם `map` ב-markdown-it
- **עדכון צ'קליסט** — הוספת בדיקה לאימות `data-source-line` ב-DevTools

## 🧪 בדיקות
תיעוד בלבד — אין קוד להריץ. השינויים הם הנחיות למימוש עתידי.

## 📝 סוג שינוי
- [x] docs: שינוי תיעוד בלבד

## ✅ צ'קליסט
- [x] תיעוד עודכן (FEATURE_SUGGESTIONS/COPY_SELECTION_AS_MARKDOWN_GUIDE.md)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות

## 🧩 השפעות/סיכונים
- **אין השפעה על קוד פעיל** — זהו מסמך מדריך בלבד
- **השפעה עתידית** — כשהמימוש יתבצע, הוא יהיה מדויק יותר ותחזוקה קלה יותר

## 🔗

https://claude.ai/code/session_01F5YD5d7MdGPvmvsUFwVLqf