### PR TITLE
fix: prevent backup scheduler from running in non-webapp processes

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -699,13 +699,19 @@ def _is_webapp_runtime() -> bool:
     # override מפורש לכל מקרה (סביבות לא סטנדרטיות / טסטים)
     if str(os.getenv("FORCE_BACKUP_SCHEDULER", "")).lower() in {"1", "true", "yes"}:
         return True
-    entry = (sys.argv[0] or "").lower().replace("\\", "/") if sys.argv else ""
+    entry = (sys.argv[0] or "") if sys.argv else ""
     if not entry:
         return False
+    # הרצה ישירה של הקובץ הזה (python app.py / python webapp/app.py / נתיב מלא)
+    try:
+        if os.path.realpath(entry) == os.path.realpath(__file__):
+            return True
+    except Exception:
+        pass
+    # שרת WSGI/ASGI שטוען את webapp.app:app
+    entry_lower = entry.lower().replace("\\", "/")
     webapp_markers = ("gunicorn", "uvicorn", "hypercorn", "waitress", "flask")
-    if any(m in entry for m in webapp_markers):
-        return True
-    if entry.endswith("/webapp/app.py") or entry.endswith("webapp/app.py"):
+    if any(m in entry_lower for m in webapp_markers):
         return True
     return False
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -691,10 +691,34 @@ except Exception:
     pass
 
 # --- Backup Scheduler (auto-backup to Drive & Disk) ---
+# חשוב: ה-scheduler חייב לרוץ רק בתוך תהליך ה-webapp עצמו (gunicorn/flask),
+# ולא כש-module זה מיובא מתהליך אחר (למשל הבוט ב-main.py שעושה
+# `from webapp.app import get_db`). אחרת יקום scheduler נוסף בשירות שאין לו
+# גישה ל-persistent disk ויזרוק PermissionError על /var/data.
+def _is_webapp_runtime() -> bool:
+    # override מפורש לכל מקרה (סביבות לא סטנדרטיות / טסטים)
+    if str(os.getenv("FORCE_BACKUP_SCHEDULER", "")).lower() in {"1", "true", "yes"}:
+        return True
+    entry = (sys.argv[0] or "").lower().replace("\\", "/") if sys.argv else ""
+    if not entry:
+        return False
+    webapp_markers = ("gunicorn", "uvicorn", "hypercorn", "waitress", "flask")
+    if any(m in entry for m in webapp_markers):
+        return True
+    if entry.endswith("/webapp/app.py") or entry.endswith("webapp/app.py"):
+        return True
+    return False
+
 try:
     if str(os.getenv("DISABLE_BACKUP_SCHEDULER", "")).lower() not in {"1", "true", "yes"}:
-        from webapp.backup_scheduler import start_backup_scheduler  # noqa: E402
-        start_backup_scheduler()
+        if _is_webapp_runtime():
+            from webapp.backup_scheduler import start_backup_scheduler  # noqa: E402
+            start_backup_scheduler()
+        else:
+            logger.info(
+                "Skipping backup scheduler: webapp.app imported from non-webapp process (argv0=%s)",
+                (sys.argv[0] if sys.argv else "<empty>"),
+            )
 except Exception:
     pass
 


### PR DESCRIPTION
## ✨ תיאור קצר
הוספת בדיקה לוודא שה-backup scheduler רץ רק בתוך תהליך ה-webapp (gunicorn/flask וכו'), ולא כאשר ה-module מיובא מתהליכים אחרים (כמו הבוט ב-main.py). זה מונע PermissionError כאשר scheduler מנסה לגשת ל-/var/data בתהליך שאין לו גישה persistent disk.

## 📦 שינויים עיקריים
- [x] קוד (Backend)

פירוט נקודות:
- הוספת פונקציה `_is_webapp_runtime()` שמזהה אם הקוד רץ בתוך webapp process
- הפונקציה בודקת:
  - משתנה סביבה `FORCE_BACKUP_SCHEDULER` להחלפה מפורשת
  - `sys.argv[0]` לחיפוש markers של web servers (gunicorn, uvicorn, hypercorn, waitress, flask)
  - נתיב ישיר של `webapp/app.py`
- עטיפת קריאת `start_backup_scheduler()` בתנאי שמוודא שרץ בתוך webapp
- הוספת logging כאשר scheduler מדולג בתהליך שאינו webapp

## 🧪 בדיקות
- הקוד מוגן בתנאי שלא משנה התנהגות קיימת כאשר רץ בתוך webapp
- בדיקה ידנית: ניתן לאמת שה-scheduler לא מתחיל כאשר `from webapp.app import get_db` מתבצע מ-main.py
- משתנה הסביבה `FORCE_BACKUP_SCHEDULER` מאפשר override לצרכי בדיקה/סביבות לא סטנדרטיות

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] fix: תיקון באג

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות

## 🧩 השפעות/סיכונים
- **השפעה חיובית**: מונע PermissionError בתהליכים שאינם webapp (כמו בוט טלגרם)
- **סיכון נמוך**: הקוד מוגן בתנאי שלא משפיע על ריצה רגילה בתוך webapp
- **Rollback**: פשוט – הסרת התנאי תחזיר להתנהגות הקודמת

## 🔗 קישורים
- Issues קשורים: (תיקון באג בעת import מתהליכים אחרים)

https://claude.ai/code/session_01SBBPKtTCAjp71YiRVanQH3