### PR TITLE
feat: add admin unmirror functionality with confirmation modal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
           mypy services/code_service.py services/__init__.py code_preview.py autocomplete_manager.py --config-file mypy.ini --show-error-codes
           # Run broad, permissive pass for the rest (non-blocking for now)
           mypy . --ignore-missing-imports --show-error-codes | tee mypy-output.txt || true
-          if grep -E '\[(attr-defined|return-value)\]' mypy-output.txt; then
+          # תופסים רק שורות "error:" אמיתיות. ב-mypy חדש יש שורות "note:" כמו
+          # 'Error code ... not covered by "type: ignore[attr-defined]" comment'
+          # שמכילות את הסוגריים אבל אינן שגיאה.
+          if grep -E ': error:.*\[(attr-defined|return-value)\]' mypy-output.txt; then
             echo "Found mypy attr-defined/return-value errors above"
             exit 1
           fi

--- a/services/git_mirror_service.py
+++ b/services/git_mirror_service.py
@@ -494,6 +494,46 @@ class GitMirrorService:
         """בדיקה אם mirror קיים"""
         return self._get_repo_path(repo_name).exists()
 
+    def delete_mirror(self, repo_name: str) -> Dict[str, Any]:
+        """
+        מחיקת ה-mirror מהדיסק (תיקיית bare repo).
+
+        Args:
+            repo_name: שם הריפו
+
+        Returns:
+            dict עם success, existed, path, message
+        """
+        repo_name = str(repo_name or "").strip()
+        if not self._validate_repo_name(repo_name):
+            return {"success": False, "existed": False, "path": None, "message": "Invalid repo name"}
+
+        repo_path = self._get_repo_path(repo_name)
+        if not repo_path.exists():
+            return {
+                "success": True,
+                "existed": False,
+                "path": str(repo_path),
+                "message": "Mirror does not exist",
+            }
+
+        if not self._safe_rmtree(repo_path):
+            logger.error(f"Failed to delete mirror: {repo_path}")
+            return {
+                "success": False,
+                "existed": True,
+                "path": str(repo_path),
+                "message": "Failed to delete mirror directory",
+            }
+
+        logger.info(f"Mirror deleted: {repo_path}")
+        return {
+            "success": True,
+            "existed": True,
+            "path": str(repo_path),
+            "message": "Mirror deleted",
+        }
+
     def get_mirror_info(self, repo_name: str) -> Optional[Dict[str, Any]]:
         """קבלת מידע על mirror"""
         repo_path = self._get_repo_path(repo_name)

--- a/services/git_mirror_service.py
+++ b/services/git_mirror_service.py
@@ -1402,10 +1402,10 @@ class GitMirrorService:
         Returns:
             Dict עם מבנה ה-diff המפורסר
         """
-        files = []
-        current_file = None
-        current_hunks = []
-        current_hunk = None
+        files: List[Dict[str, Any]] = []
+        current_file: Optional[Dict[str, Any]] = None
+        current_hunks: List[Dict[str, Any]] = []
+        current_hunk: Optional[Dict[str, Any]] = None
 
         lines = diff_output.split('\n')
         i = 0

--- a/services/repo_sync_service.py
+++ b/services/repo_sync_service.py
@@ -419,17 +419,8 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
         "blocked_due_to_running_job": False,
     }
 
-    # 1) ניקוי jobs ממתינים *לפני* שאר השלבים, כדי שלא ייתפס job חדש
-    #    בזמן שאנחנו מוחקים. אחרי המחיקה לא קיים job בסטטוס pending עבור
-    #    הריפו, ולכן ה-worker לא יוכל לטעון אותו ולכתוב מחדש לאינדקס.
-    try:
-        result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
-        stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
-    except Exception:
-        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}", exc_info=True)
-
-    # 2) חסימה אם קיים sync job פעיל בפועל. ה-find_one רץ אחרי delete_many של
-    #    pending, כך שאם יש running, הוא נטען לפני הניקוי שלנו ועדיין כותב.
+    # 1) חסימה אם קיים sync job פעיל בפועל - בלי תופעות לוואי.
+    #    אם נחזיר sync_in_progress, שום דבר לא נמחק.
     try:
         running_job = db.sync_jobs.find_one({"repo_name": repo_name, "status": "running"})
     except Exception:
@@ -452,8 +443,18 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
             "stats": stats,
         }
 
+    # 2) ניקוי jobs ממתינים אחרי שאישרנו שאין running. מצמצם את חלון ה-race:
+    #    worker שיתפוס job אחרי השלב הזה לא ימצא את הריפו ב-pending.
+    try:
+        result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
+        stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
+    except Exception:
+        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}", exc_info=True)
+
     # 3) מחיקת ה-mirror מהדיסק *לפני* שנוגעים ביתר ה-DB. אם הדיסק נכשל - DB
     #    נשאר ברובו שלם (למעט pending שכבר נוקו - מקובל כי בלאו הכי לא רץ סנכרון).
+    #    אם worker תפס job בחלון בין שלב 1 ל-3, ה-`mirror_exists` שלו יחזיר
+    #    False ב-`_run_sync_logic` והוא יחזור עם error בלי לכתוב לאינדקס.
     delete_result = git_service.delete_mirror(repo_name)
     stats["mirror_existed"] = bool(delete_result.get("existed"))
     stats["mirror_deleted"] = bool(delete_result.get("success") and delete_result.get("existed"))

--- a/services/repo_sync_service.py
+++ b/services/repo_sync_service.py
@@ -389,12 +389,12 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
     """
     הסרה מלאה של ריפו מה-mirror: גם מה-DB וגם מהדיסק.
 
-    מה נמחק:
-    - תיקיית ה-bare mirror בדיסק
-    - מסמכי `repo_files` של הריפו (אינדקס תוכן)
-    - המסמך ב-`repo_metadata`
-    - jobs בסטטוס pending ב-`sync_jobs` (כדי שלא יעיר worker מאוחר יותר)
-    - השדה `selected_repo` ממשתמשים שבחרו דווקא בריפו הזה
+    סדר הפעולות חשוב כדי להימנע מחוסר עקביות:
+    1. בדיקה שאין sync job ב-running (אחרת ה-worker יחזור לכתוב אינדקס).
+    2. מחיקת ה-bare mirror מהדיסק — הפעולה הכי שברירית, חייבת להצליח לפני
+       שנוגעים ב-DB.
+    3. ניקוי DB: `repo_files`, `repo_metadata`, `sync_jobs` ממתינים,
+       ו-`selected_repo` ממשתמשים שבחרו דווקא בריפו הזה.
 
     Args:
         repo_name: שם הריפו
@@ -416,54 +416,93 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
         "users_unset": 0,
         "mirror_existed": False,
         "mirror_deleted": False,
+        "blocked_due_to_running_job": False,
     }
 
-    # 1) מחיקת אינדקס הקבצים
+    # 1) חסימה אם יש sync job פעיל - אחרת worker רץ ימשיך לכתוב לאינדקס
+    #    ויחיה מחדש את ה-metadata אחרי המחיקה.
+    try:
+        running_job = db.sync_jobs.find_one({"repo_name": repo_name, "status": "running"})
+    except Exception:
+        logger.exception(f"Failed to query sync_jobs for {repo_name}")
+        return {
+            "success": False,
+            "error": "database_error",
+            "message": "Failed to query sync state",
+            "stats": stats,
+        }
+    if running_job:
+        stats["blocked_due_to_running_job"] = True
+        logger.warning(
+            f"Refusing to unmirror {repo_name}: sync job is currently running"
+        )
+        return {
+            "success": False,
+            "error": "sync_in_progress",
+            "message": "Sync job is currently running for this repo; try again shortly",
+            "stats": stats,
+        }
+
+    # 2) מחיקת ה-mirror מהדיסק *לפני* שנוגעים ב-DB. אם הדיסק נכשל - DB נשאר שלם.
+    delete_result = git_service.delete_mirror(repo_name)
+    stats["mirror_existed"] = bool(delete_result.get("existed"))
+    stats["mirror_deleted"] = bool(delete_result.get("success") and delete_result.get("existed"))
+
+    if not delete_result.get("success"):
+        logger.error(
+            f"Failed to delete mirror directory for {repo_name}: "
+            f"{delete_result.get('message')}"
+        )
+        return {
+            "success": False,
+            "error": "mirror_delete_failed",
+            "message": "Failed to delete mirror directory",
+            "stats": stats,
+        }
+
+    # 3) מחיקת אינדקס הקבצים
     try:
         result = db.repo_files.delete_many({"repo_name": repo_name})
         stats["files_removed"] = int(getattr(result, "deleted_count", 0) or 0)
-    except Exception as e:
-        logger.exception(f"Failed to delete repo_files for {repo_name}: {e}")
-        return {"success": False, "error": "db_files_failed", "message": str(e), "stats": stats}
+    except Exception:
+        logger.exception(f"Failed to delete repo_files for {repo_name}")
+        return {
+            "success": False,
+            "error": "database_error",
+            "message": "Failed to delete repo files index",
+            "stats": stats,
+        }
 
-    # 2) מחיקת מטא-דאטה של הריפו
+    # 4) מחיקת מטא-דאטה של הריפו
     try:
         result = db.repo_metadata.delete_many({"repo_name": repo_name})
         stats["metadata_removed"] = int(getattr(result, "deleted_count", 0) or 0)
-    except Exception as e:
-        logger.exception(f"Failed to delete repo_metadata for {repo_name}: {e}")
-        return {"success": False, "error": "db_metadata_failed", "message": str(e), "stats": stats}
+    except Exception:
+        logger.exception(f"Failed to delete repo_metadata for {repo_name}")
+        return {
+            "success": False,
+            "error": "database_error",
+            "message": "Failed to delete repo metadata",
+            "stats": stats,
+        }
 
-    # 3) ניקוי jobs ממתינים (לא נוגעים ב-running/completed כדי לא להפיל worker שכרגע מעבד)
+    # 5) ניקוי jobs ממתינים
     try:
         result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
         stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
-    except Exception as e:
+    except Exception:
         # לא קריטי - רק לוג
-        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}: {e}")
+        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}", exc_info=True)
 
-    # 4) ניקוי בחירת ריפו מהמשתמשים
+    # 6) ניקוי בחירת ריפו מהמשתמשים
     try:
         result = db.users.update_many(
             {"selected_repo": repo_name},
             {"$unset": {"selected_repo": ""}},
         )
         stats["users_unset"] = int(getattr(result, "modified_count", 0) or 0)
-    except Exception as e:
-        logger.warning(f"Failed to unset selected_repo for {repo_name}: {e}")
-
-    # 5) מחיקת ה-mirror מהדיסק
-    delete_result = git_service.delete_mirror(repo_name)
-    stats["mirror_existed"] = bool(delete_result.get("existed"))
-    stats["mirror_deleted"] = bool(delete_result.get("success") and delete_result.get("existed"))
-
-    if not delete_result.get("success"):
-        return {
-            "success": False,
-            "error": "mirror_delete_failed",
-            "message": delete_result.get("message", "Failed to delete mirror directory"),
-            "stats": stats,
-        }
+    except Exception:
+        logger.warning(f"Failed to unset selected_repo for {repo_name}", exc_info=True)
 
     logger.info(f"Unmirrored {repo_name}: {stats}")
     return {"success": True, "repo_name": repo_name, "stats": stats}

--- a/services/repo_sync_service.py
+++ b/services/repo_sync_service.py
@@ -419,8 +419,17 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
         "blocked_due_to_running_job": False,
     }
 
-    # 1) חסימה אם יש sync job פעיל - אחרת worker רץ ימשיך לכתוב לאינדקס
-    #    ויחיה מחדש את ה-metadata אחרי המחיקה.
+    # 1) ניקוי jobs ממתינים *לפני* שאר השלבים, כדי שלא ייתפס job חדש
+    #    בזמן שאנחנו מוחקים. אחרי המחיקה לא קיים job בסטטוס pending עבור
+    #    הריפו, ולכן ה-worker לא יוכל לטעון אותו ולכתוב מחדש לאינדקס.
+    try:
+        result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
+        stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
+    except Exception:
+        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}", exc_info=True)
+
+    # 2) חסימה אם קיים sync job פעיל בפועל. ה-find_one רץ אחרי delete_many של
+    #    pending, כך שאם יש running, הוא נטען לפני הניקוי שלנו ועדיין כותב.
     try:
         running_job = db.sync_jobs.find_one({"repo_name": repo_name, "status": "running"})
     except Exception:
@@ -443,7 +452,8 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
             "stats": stats,
         }
 
-    # 2) מחיקת ה-mirror מהדיסק *לפני* שנוגעים ב-DB. אם הדיסק נכשל - DB נשאר שלם.
+    # 3) מחיקת ה-mirror מהדיסק *לפני* שנוגעים ביתר ה-DB. אם הדיסק נכשל - DB
+    #    נשאר ברובו שלם (למעט pending שכבר נוקו - מקובל כי בלאו הכי לא רץ סנכרון).
     delete_result = git_service.delete_mirror(repo_name)
     stats["mirror_existed"] = bool(delete_result.get("existed"))
     stats["mirror_deleted"] = bool(delete_result.get("success") and delete_result.get("existed"))
@@ -460,7 +470,7 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
             "stats": stats,
         }
 
-    # 3) מחיקת אינדקס הקבצים
+    # 4) מחיקת אינדקס הקבצים
     try:
         result = db.repo_files.delete_many({"repo_name": repo_name})
         stats["files_removed"] = int(getattr(result, "deleted_count", 0) or 0)
@@ -473,7 +483,7 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
             "stats": stats,
         }
 
-    # 4) מחיקת מטא-דאטה של הריפו
+    # 5) מחיקת מטא-דאטה של הריפו
     try:
         result = db.repo_metadata.delete_many({"repo_name": repo_name})
         stats["metadata_removed"] = int(getattr(result, "deleted_count", 0) or 0)
@@ -485,14 +495,6 @@ def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
             "message": "Failed to delete repo metadata",
             "stats": stats,
         }
-
-    # 5) ניקוי jobs ממתינים
-    try:
-        result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
-        stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
-    except Exception:
-        # לא קריטי - רק לוג
-        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}", exc_info=True)
 
     # 6) ניקוי בחירת ריפו מהמשתמשים
     try:

--- a/services/repo_sync_service.py
+++ b/services/repo_sync_service.py
@@ -385,6 +385,90 @@ def _run_sync_logic(
     return {"status": "synced", "old_sha": old_sha[:7], "new_sha": new_sha[:7], "stats": stats}
 
 
+def unmirror_repo(repo_name: str, db: Any) -> Dict[str, Any]:
+    """
+    הסרה מלאה של ריפו מה-mirror: גם מה-DB וגם מהדיסק.
+
+    מה נמחק:
+    - תיקיית ה-bare mirror בדיסק
+    - מסמכי `repo_files` של הריפו (אינדקס תוכן)
+    - המסמך ב-`repo_metadata`
+    - jobs בסטטוס pending ב-`sync_jobs` (כדי שלא יעיר worker מאוחר יותר)
+    - השדה `selected_repo` ממשתמשים שבחרו דווקא בריפו הזה
+
+    Args:
+        repo_name: שם הריפו
+        db: חיבור ל-MongoDB
+
+    Returns:
+        dict עם success, וסטטיסטיקות על מה נמחק (לטובת UI/לוגים)
+    """
+    git_service = get_mirror_service()
+
+    repo_name = str(repo_name or "").strip()
+    if not git_service._validate_repo_name(repo_name):
+        return {"success": False, "error": "invalid_repo_name", "message": "Invalid repo name"}
+
+    stats: Dict[str, Any] = {
+        "files_removed": 0,
+        "metadata_removed": 0,
+        "pending_jobs_removed": 0,
+        "users_unset": 0,
+        "mirror_existed": False,
+        "mirror_deleted": False,
+    }
+
+    # 1) מחיקת אינדקס הקבצים
+    try:
+        result = db.repo_files.delete_many({"repo_name": repo_name})
+        stats["files_removed"] = int(getattr(result, "deleted_count", 0) or 0)
+    except Exception as e:
+        logger.exception(f"Failed to delete repo_files for {repo_name}: {e}")
+        return {"success": False, "error": "db_files_failed", "message": str(e), "stats": stats}
+
+    # 2) מחיקת מטא-דאטה של הריפו
+    try:
+        result = db.repo_metadata.delete_many({"repo_name": repo_name})
+        stats["metadata_removed"] = int(getattr(result, "deleted_count", 0) or 0)
+    except Exception as e:
+        logger.exception(f"Failed to delete repo_metadata for {repo_name}: {e}")
+        return {"success": False, "error": "db_metadata_failed", "message": str(e), "stats": stats}
+
+    # 3) ניקוי jobs ממתינים (לא נוגעים ב-running/completed כדי לא להפיל worker שכרגע מעבד)
+    try:
+        result = db.sync_jobs.delete_many({"repo_name": repo_name, "status": "pending"})
+        stats["pending_jobs_removed"] = int(getattr(result, "deleted_count", 0) or 0)
+    except Exception as e:
+        # לא קריטי - רק לוג
+        logger.warning(f"Failed to clean pending sync_jobs for {repo_name}: {e}")
+
+    # 4) ניקוי בחירת ריפו מהמשתמשים
+    try:
+        result = db.users.update_many(
+            {"selected_repo": repo_name},
+            {"$unset": {"selected_repo": ""}},
+        )
+        stats["users_unset"] = int(getattr(result, "modified_count", 0) or 0)
+    except Exception as e:
+        logger.warning(f"Failed to unset selected_repo for {repo_name}: {e}")
+
+    # 5) מחיקת ה-mirror מהדיסק
+    delete_result = git_service.delete_mirror(repo_name)
+    stats["mirror_existed"] = bool(delete_result.get("existed"))
+    stats["mirror_deleted"] = bool(delete_result.get("success") and delete_result.get("existed"))
+
+    if not delete_result.get("success"):
+        return {
+            "success": False,
+            "error": "mirror_delete_failed",
+            "message": delete_result.get("message", "Failed to delete mirror directory"),
+            "stats": stats,
+        }
+
+    logger.info(f"Unmirrored {repo_name}: {stats}")
+    return {"success": True, "repo_name": repo_name, "stats": stats}
+
+
 def initial_import(repo_url: str, repo_name: str, db: Any) -> Dict[str, Any]:
     """
     ייבוא ראשוני של ריפו

--- a/webapp/routes/repo_browser.py
+++ b/webapp/routes/repo_browser.py
@@ -872,12 +872,12 @@ def api_unmirror_repo(repo_name: str):
 
     try:
         result = unmirror_repo(repo_name, db)
-    except Exception as e:
-        logger.exception(f"Unmirror failed for {repo_name}: {e}")
+    except Exception:
+        logger.exception(f"Unmirror failed for {repo_name}")
         return jsonify({
             "success": False,
             "error": "internal_error",
-            "message": str(e)[:200]
+            "message": "An internal server error occurred"
         }), 500
 
     if not result.get("success"):

--- a/webapp/routes/repo_browser.py
+++ b/webapp/routes/repo_browser.py
@@ -881,6 +881,12 @@ def api_unmirror_repo(repo_name: str):
         }), 500
 
     if not result.get("success"):
-        return jsonify(result), 500
+        status_codes = {
+            "invalid_repo_name": 400,
+            "sync_in_progress": 409,
+            "mirror_delete_failed": 500,
+            "database_error": 500,
+        }
+        return jsonify(result), status_codes.get(result.get("error", ""), 500)
 
     return jsonify(result)

--- a/webapp/routes/repo_browser.py
+++ b/webapp/routes/repo_browser.py
@@ -6,11 +6,12 @@ UI לגלישה בקוד הריפו עם API מתקדם
 
 import logging
 import re
-from flask import Blueprint, render_template, request, jsonify, abort, redirect, url_for, current_app
+from flask import Blueprint, render_template, request, jsonify, abort, redirect, url_for, current_app, session
 from functools import lru_cache
 
 from services.git_mirror_service import get_mirror_service
 from services.repo_search_service import create_search_service
+from services.repo_sync_service import unmirror_repo
 from database.db_manager import get_db
 
 logger = logging.getLogger(__name__)
@@ -819,3 +820,67 @@ def api_select_repo():
             "success": False,
             "error": "Failed to save selection"
         }), 500
+
+
+def _require_admin():
+    """בודק שהמשתמש מחובר וגם אדמין. מחזיר None אם בסדר, אחרת tuple של (response, status)."""
+    if "user_id" not in session:
+        return jsonify({"success": False, "error": "Authentication required"}), 401
+    try:
+        uid = int(session["user_id"])
+    except Exception:
+        return jsonify({"success": False, "error": "Forbidden"}), 403
+
+    # Lazy import כדי למנוע circular import עם webapp.app
+    try:
+        from webapp.app import is_admin as _is_admin
+    except Exception:
+        logger.exception("Failed to import is_admin from webapp.app")
+        return jsonify({"success": False, "error": "Server misconfigured"}), 500
+
+    if not _is_admin(uid):
+        return jsonify({"success": False, "error": "Admin required"}), 403
+    return None
+
+
+@repo_bp.route('/api/repos/<repo_name>/unmirror', methods=['POST'])
+def api_unmirror_repo(repo_name: str):
+    """
+    מסיר ריפו מה-mirroring לחלוטין: מוחק את האינדקס ב-DB ואת ה-bare repo מהדיסק.
+
+    דורש הרשאות אדמין.
+    """
+    auth_error = _require_admin()
+    if auth_error is not None:
+        return auth_error
+
+    repo_name = (repo_name or '').strip()
+    if not repo_name or not re.match(r'^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$', repo_name):
+        return jsonify({"success": False, "error": "Invalid repo name"}), 400
+
+    db = get_db()
+
+    git_service = get_mirror_service()
+    metadata_exists = bool(db.repo_metadata.find_one({"repo_name": repo_name}))
+    mirror_exists = git_service.mirror_exists(repo_name)
+    if not metadata_exists and not mirror_exists:
+        return jsonify({
+            "success": False,
+            "error": "not_found",
+            "message": "Repository not found"
+        }), 404
+
+    try:
+        result = unmirror_repo(repo_name, db)
+    except Exception as e:
+        logger.exception(f"Unmirror failed for {repo_name}: {e}")
+        return jsonify({
+            "success": False,
+            "error": "internal_error",
+            "message": str(e)[:200]
+        }), 500
+
+    if not result.get("success"):
+        return jsonify(result), 500
+
+    return jsonify(result)

--- a/webapp/templates/repo/base_repo.html
+++ b/webapp/templates/repo/base_repo.html
@@ -70,10 +70,189 @@
                 <i class="bi bi-file-code"></i> {{ metadata.total_files | default(0) }} files
             </span>
             {% endif %}
+            {% if user_is_admin %}
+            <button type="button"
+                    class="btn-icon repo-unmirror-btn"
+                    id="repo-unmirror-btn"
+                    title="בטל mirroring למסך הריפו הזה"
+                    aria-label="בטל mirroring">
+                <i class="bi bi-trash"></i>
+            </button>
+            {% endif %}
             <!-- Hidden element to pass repo name to JS -->
             <span id="current-repo-name" data-repo="{{ repo_name }}" data-source="{{ current_source | default('default') }}" style="display: none;"></span>
         </div>
     </div>
+
+    {% if user_is_admin %}
+    <!-- Unmirror Confirmation Modal -->
+    <div class="unmirror-modal-backdrop" id="unmirror-modal" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="unmirror-modal-title">
+        <div class="unmirror-modal">
+            <h3 id="unmirror-modal-title">
+                <i class="bi bi-exclamation-triangle-fill"></i>
+                ביטול mirroring
+            </h3>
+            <p>
+                פעולה זו תמחק לחלוטין את הריפו
+                <strong id="unmirror-modal-repo-name"></strong>
+                ממערכת ה־mirroring:
+            </p>
+            <ul class="unmirror-modal-list">
+                <li>אינדקס הקבצים ב־MongoDB</li>
+                <li>מטא־דאטה של הריפו</li>
+                <li>תיקיית ה־bare mirror מהדיסק</li>
+                <li>jobs ממתינים בתור הסנכרון</li>
+            </ul>
+            <p class="unmirror-modal-warning">
+                לא ניתן לשחזר. אם תרצה לסנכרן שוב בעתיד תצטרך לבצע initial import מחדש.
+            </p>
+            <div class="unmirror-modal-error" id="unmirror-modal-error" style="display: none;"></div>
+            <div class="unmirror-modal-actions">
+                <button type="button" class="btn btn-secondary" id="unmirror-cancel-btn">ביטול</button>
+                <button type="button" class="btn btn-danger" id="unmirror-confirm-btn">
+                    <i class="bi bi-trash"></i>
+                    מחק את הריפו
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        .repo-unmirror-btn {
+            color: #dc3545;
+        }
+        .repo-unmirror-btn:hover {
+            background-color: rgba(220, 53, 69, 0.12);
+        }
+        .unmirror-modal-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.55);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1050;
+        }
+        .unmirror-modal {
+            background: var(--bs-body-bg, #1e1e1e);
+            color: var(--bs-body-color, #eaeaea);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            padding: 24px;
+            width: min(520px, 92vw);
+            max-height: 88vh;
+            overflow-y: auto;
+            box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+        }
+        .unmirror-modal h3 {
+            margin: 0 0 12px;
+            color: #ffb347;
+            font-size: 1.2rem;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .unmirror-modal-list {
+            margin: 8px 0 12px;
+            padding-inline-start: 1.2rem;
+        }
+        .unmirror-modal-warning {
+            color: #f1b0b7;
+            background: rgba(220, 53, 69, 0.12);
+            border: 1px solid rgba(220, 53, 69, 0.35);
+            padding: 8px 12px;
+            border-radius: 6px;
+            font-size: 0.92rem;
+        }
+        .unmirror-modal-error {
+            color: #f5c2c7;
+            background: rgba(220, 53, 69, 0.18);
+            padding: 8px 12px;
+            border-radius: 6px;
+            margin-top: 8px;
+            font-size: 0.92rem;
+        }
+        .unmirror-modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+            margin-top: 16px;
+        }
+    </style>
+
+    <script>
+    (function(){
+        const openBtn = document.getElementById('repo-unmirror-btn');
+        const modal = document.getElementById('unmirror-modal');
+        const cancelBtn = document.getElementById('unmirror-cancel-btn');
+        const confirmBtn = document.getElementById('unmirror-confirm-btn');
+        const repoNameEl = document.getElementById('unmirror-modal-repo-name');
+        const errorEl = document.getElementById('unmirror-modal-error');
+        const currentRepoEl = document.getElementById('current-repo-name');
+        if (!openBtn || !modal || !cancelBtn || !confirmBtn || !repoNameEl) return;
+
+        function getRepoName() {
+            return (currentRepoEl && currentRepoEl.dataset.repo) || '';
+        }
+
+        function openModal() {
+            errorEl.style.display = 'none';
+            errorEl.textContent = '';
+            repoNameEl.textContent = getRepoName();
+            modal.style.display = 'flex';
+            confirmBtn.disabled = false;
+            confirmBtn.innerHTML = '<i class="bi bi-trash"></i> מחק את הריפו';
+        }
+        function closeModal() {
+            modal.style.display = 'none';
+        }
+
+        openBtn.addEventListener('click', openModal);
+        cancelBtn.addEventListener('click', closeModal);
+        modal.addEventListener('click', function(e){
+            if (e.target === modal) closeModal();
+        });
+        document.addEventListener('keydown', function(e){
+            if (e.key === 'Escape' && modal.style.display !== 'none') closeModal();
+        });
+
+        confirmBtn.addEventListener('click', async function(){
+            const repoName = getRepoName();
+            if (!repoName) return;
+            confirmBtn.disabled = true;
+            confirmBtn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> מוחק...';
+            errorEl.style.display = 'none';
+            errorEl.textContent = '';
+            try {
+                const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+                const headers = { 'Accept': 'application/json' };
+                if (csrfMeta && csrfMeta.content) headers['X-CSRFToken'] = csrfMeta.content;
+                const resp = await fetch('/repo/api/repos/' + encodeURIComponent(repoName) + '/unmirror', {
+                    method: 'POST',
+                    headers: headers,
+                    credentials: 'same-origin'
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (!resp.ok || !data.success) {
+                    const msg = (data && (data.message || data.error)) || ('שגיאה: ' + resp.status);
+                    errorEl.textContent = msg;
+                    errorEl.style.display = 'block';
+                    confirmBtn.disabled = false;
+                    confirmBtn.innerHTML = '<i class="bi bi-trash"></i> נסה שוב';
+                    return;
+                }
+                try { localStorage.removeItem('selectedRepo'); } catch (_) {}
+                window.location.href = '/repo/';
+            } catch (err) {
+                errorEl.textContent = 'שגיאת רשת: ' + (err && err.message ? err.message : err);
+                errorEl.style.display = 'block';
+                confirmBtn.disabled = false;
+                confirmBtn.innerHTML = '<i class="bi bi-trash"></i> נסה שוב';
+            }
+        });
+    })();
+    </script>
+    {% endif %}
 
     <!-- Search Results Dropdown -->
     <div id="search-results-dropdown" class="search-results-dropdown hidden">


### PR DESCRIPTION
## ✨ תיאור קצר
הוספת יכולת למחיקת ריפו מה-mirroring לחלוטין (unmirror) עם ממשק משתמש מאובטח. רק אדמינים יכולים להשתמש בפיצ'ר זה, והוא כולל מודל אישור עם אזהרות ברורות לפני ביצוע המחיקה.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] Frontend (UI/Modal)

### פירוט:
- **Backend API**: נוסף endpoint `/api/repos/<repo_name>/unmirror` (POST) שמחק את הריפו מ-MongoDB ומהדיסק
- **Service Layer**: הוספת `unmirror_repo()` ב-`repo_sync_service.py` שמטפל בניקוי:
  - אינדקס קבצים (`repo_files`)
  - מטא-דאטה (`repo_metadata`)
  - jobs ממתינים (`sync_jobs`)
  - בחירת ריפו של משתמשים
  - תיקיית ה-bare mirror מהדיסק
- **Git Service**: הוספת `delete_mirror()` ב-`git_mirror_service.py` למחיקת תיקיית ה-mirror בבטחה
- **Frontend**: 
  - כפתור unmirror אדום בעמוד הריפו (רק לאדמינים)
  - מודל אישור עם אזהרות בעברית
  - טיפול בשגיאות עם הודעות משוב
  - סגירה עם Escape או לחיצה בחוץ למודל
- **Security**: בדיקת הרשאות אדמין בשרת, CSRF token, validation של שם הריפו

## 🧪 בדיקות
- CI Required Checks: 🔍 Code Quality & Security; Unit Tests (3.11); Unit Tests (3.12)
- הקוד עוקב אחרי סגנון Python (Black/isort/flake8)
- אין סודות/PII בקוד
- אין מחיקות מסוכנות – השימוש ב-`_safe_rmtree()` מוודא מחיקה בטוחה

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות (שימוש ב-`_safe_rmtree()`)
- [x] הודעת הקומיט תואמת Conventional Commits

## 🧩 השפעות/סיכונים
- **השפעה**: פיצ'ר חדש לאדמינים בלבד, לא משפיע על משתמשים רגילים
- **סיכון**: מחיקה בלתי הפיכה – לכן יש מודל אישור עם אזהרות ברורות
- **Rollback**: אם נדרש, ניתן להסתיר את הכפתור בתנאי או להסיר את ה-endpoint

## 🔗 קישורים
- Branch Protection &

https://claude.ai/code/session_01Q6VfWztChW6m94kS4mFwu5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can unmirror repositories via a new trash button and confirmation modal; success clears selection and redirects to the repo list.
  * Server exposes a protected unmirror action that validates input, removes on-disk mirrors, and cleans up related repository records with stepwise reporting.

* **Bug Fixes**
  * Unmirror is blocked if a repository sync job is running to avoid conflicts; non‑critical cleanup errors are logged and do not abort the operation.

* **Chores**
  * CI MyPy filtering tightened to reduce false-positive diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amirbiron/CodeBot/pull/3160)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->