### PR TITLE
fix: הוספת בדיקה והסבר לשגיאת delete_repo בטוקן GitHub

### DIFF
--- a/GUIDES/BOT_USER_GUIDE.md
+++ b/GUIDES/BOT_USER_GUIDE.md
@@ -653,7 +653,8 @@ class DataHandler:
 3. עבור ל-[GitHub Settings > Tokens](https://github.com/settings/tokens)
 4. צור Personal Access Token חדש:
    - בחר **Classic Token**
-   - הרשאות: `repo`, `gist`, `delete_repo` (אופציונלי)
+   - הרשאות: `repo`, `gist`
+   - `delete_repo` – **חובה רק אם רוצים למחוק ריפו שלם דרך הבוט** (בלעדיה GitHub יחזיר שגיאת 403 "Must have admin rights" גם לבעלים)
    - תוקף: 90 יום (או יותר)
 5. העתק את הטוקן
 6. שלח לבוט

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -2390,8 +2390,10 @@ class GitHubMenuHandler:
                 "🔑 שלח לי את הטוקן של GitHub:\n\n"
                 "הטוקן יישמר בצורה מאובטחת לחשבון שלך לצורך שימוש עתידי.\n"
                 "תוכל להסיר אותו בכל עת עם הפקודה /github_logout.\n\n"
-                "💡 טיפ: צור טוקן ב:\n"
-                "https://github.com/settings/tokens"
+                "💡 טיפ: צור טוקן (classic) ב:\n"
+                "https://github.com/settings/tokens\n\n"
+                "הרשאות מומלצות: repo, gist.\n"
+                "אם תרצה גם למחוק ריפו דרך הבוט – סמן בנוסף את delete_repo."
             )
             return REPO_SELECT
 
@@ -5552,6 +5554,20 @@ class GitHubMenuHandler:
             parse_mode="HTML",
         )
 
+    # הודעת עזרה כשחסרה הרשאת delete_repo בטוקן.
+    # GitHub מחזיר במקרה כזה 403 "Must have admin rights to Repository" גם כשאתה הבעלים,
+    # וזו דרך מבלבלת לומר שלטוקן עצמו חסרה ההרשאה למחיקה.
+    _DELETE_REPO_SCOPE_HELP = (
+        "❌ לא הצלחתי למחוק את הריפו כי לטוקן שלך חסרה ההרשאה <b>delete_repo</b>.\n\n"
+        "זה לא קשור לבעלות — אתה הבעלים של הריפו. GitHub פשוט מחזיר שגיאת 403 "
+        '("Must have admin rights") כשלטוקן אין הרשאת מחיקה.\n\n'
+        "כך מתקנים:\n"
+        "1. היכנס ל-GitHub → Settings → Developer settings → Personal access tokens (classic)\n"
+        "2. צור טוקן חדש (או ערוך קיים) וסמן גם את <b>delete_repo</b> (בנוסף ל-<b>repo</b>)\n"
+        "3. שלח לי כאן את הטוקן החדש ואז נסה למחוק שוב\n\n"
+        "🔗 https://github.com/settings/tokens"
+    )
+
     async def confirm_delete_repo(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מבצע מחיקת ריפו שלם לאחר אישור"""
         query = update.callback_query
@@ -5570,6 +5586,15 @@ class GitHubMenuHandler:
             if repo.owner.login != owner.login:
                 await query.edit_message_text("❌ ניתן למחוק רק ריפו שאתה בעליו")
                 return
+            # בדיקה מקדימה: עבור טוקני classic, GitHub מחזיר את רשימת ההרשאות בכותרת
+            # X-OAuth-Scopes (נחשף ב-PyGithub כ-oauth_scopes לאחר הבקשות שלמעלה).
+            # אם ידוע לנו בוודאות שחסרה delete_repo – נעצור עם הסבר ברור במקום
+            # להריץ את המחיקה ולקבל 403 מבלבל. אם הרשימה לא ידועה (למשל טוקן
+            # fine-grained שלא מחזיר את הכותרת) – נמשיך ונסתמך על טיפול החריגות.
+            scopes = getattr(g, "oauth_scopes", None)
+            if isinstance(scopes, (list, tuple)) and scopes and "delete_repo" not in scopes:
+                await query.edit_message_text(self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML")
+                return
             repo.delete()
             # נקה קאש ריפוזיטוריז כדי שהרשימה תרוענן ולא תציג פריטים שנמחקו
             context.user_data.pop("repos", None)
@@ -5579,9 +5604,22 @@ class GitHubMenuHandler:
             )
             # נקה בחירה לאחר מחיקה
             session["selected_repo"] = None
+        except GithubException as ge:
+            status = getattr(ge, "status", None)
+            data = getattr(ge, "data", {}) or {}
+            err_msg = data.get("message", "") if isinstance(data, dict) else str(ge)
+            logger.error(f"Error deleting repository (GithubException {status}): {err_msg}")
+            # 403 עם "admin rights"/"delete_repo" כמעט תמיד אומר שלטוקן חסרה הרשאת delete_repo
+            err_text = str(err_msg).lower()
+            if status == 403 and ("admin rights" in err_text or "delete_repo" in err_text):
+                await query.edit_message_text(self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML")
+            else:
+                await query.edit_message_text(
+                    f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(err_msg))}", parse_mode="HTML"
+                )
         except Exception as e:
             logger.error(f"Error deleting repository: {e}")
-            await query.edit_message_text(f"❌ שגיאה במחיקת ריפו: {e}")
+            await query.edit_message_text(f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(e))}", parse_mode="HTML")
         finally:
             # לאחר מחיקה, ודא שקאש הרשימות אינו משאיר את הריפו הישן
             context.user_data.pop("repos", None)

--- a/github_menu_handler.py
+++ b/github_menu_handler.py
@@ -5578,13 +5578,23 @@ class GitHubMenuHandler:
         if not (token and repo_name):
             await query.edit_message_text("❌ נתונים חסרים למחיקה")
             return
+        # רענון התפריט הראשי מתבצע רק במסלול ההצלחה. במסלולי שגיאה/עזרה נשאיר
+        # את ההודעה על המסך עם כפתור חזרה, אחרת github_menu_command היה דורס
+        # את ההסבר (שניהם עורכים את אותה הודעת ה-callback).
+        refresh_menu = True
+        back_kb = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("🔙 חזור לתפריט", callback_data="github_menu")]]
+        )
         try:
             g = Github(token)
             repo = g.get_repo(repo_name)
             owner = g.get_user()
             # ודא שלמשתמש יש הרשאה למחוק
             if repo.owner.login != owner.login:
-                await query.edit_message_text("❌ ניתן למחוק רק ריפו שאתה בעליו")
+                refresh_menu = False
+                await query.edit_message_text(
+                    "❌ ניתן למחוק רק ריפו שאתה בעליו", reply_markup=back_kb
+                )
                 return
             # בדיקה מקדימה: עבור טוקני classic, GitHub מחזיר את רשימת ההרשאות בכותרת
             # X-OAuth-Scopes (נחשף ב-PyGithub כ-oauth_scopes לאחר הבקשות שלמעלה).
@@ -5593,7 +5603,10 @@ class GitHubMenuHandler:
             # fine-grained שלא מחזיר את הכותרת) – נמשיך ונסתמך על טיפול החריגות.
             scopes = getattr(g, "oauth_scopes", None)
             if isinstance(scopes, (list, tuple)) and scopes and "delete_repo" not in scopes:
-                await query.edit_message_text(self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML")
+                refresh_menu = False
+                await query.edit_message_text(
+                    self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML", reply_markup=back_kb
+                )
                 return
             repo.delete()
             # נקה קאש ריפוזיטוריז כדי שהרשימה תרוענן ולא תציג פריטים שנמחקו
@@ -5605,6 +5618,7 @@ class GitHubMenuHandler:
             # נקה בחירה לאחר מחיקה
             session["selected_repo"] = None
         except GithubException as ge:
+            refresh_menu = False
             status = getattr(ge, "status", None)
             data = getattr(ge, "data", {}) or {}
             err_msg = data.get("message", "") if isinstance(data, dict) else str(ge)
@@ -5612,19 +5626,30 @@ class GitHubMenuHandler:
             # 403 עם "admin rights"/"delete_repo" כמעט תמיד אומר שלטוקן חסרה הרשאת delete_repo
             err_text = str(err_msg).lower()
             if status == 403 and ("admin rights" in err_text or "delete_repo" in err_text):
-                await query.edit_message_text(self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML")
+                await query.edit_message_text(
+                    self._DELETE_REPO_SCOPE_HELP, parse_mode="HTML", reply_markup=back_kb
+                )
             else:
                 await query.edit_message_text(
-                    f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(err_msg))}", parse_mode="HTML"
+                    f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(err_msg))}",
+                    parse_mode="HTML",
+                    reply_markup=back_kb,
                 )
         except Exception as e:
+            refresh_menu = False
             logger.error(f"Error deleting repository: {e}")
-            await query.edit_message_text(f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(e))}", parse_mode="HTML")
+            await query.edit_message_text(
+                f"❌ שגיאה במחיקת ריפו: {safe_html_escape(str(e))}",
+                parse_mode="HTML",
+                reply_markup=back_kb,
+            )
         finally:
             # לאחר מחיקה, ודא שקאש הרשימות אינו משאיר את הריפו הישן
             context.user_data.pop("repos", None)
             context.user_data.pop("repos_cache_time", None)
-            await self.github_menu_command(update, context)
+            # רענן את התפריט רק במסלול ההצלחה, כדי לא לדרוס הודעת שגיאה/עזרה
+            if refresh_menu:
+                await self.github_menu_command(update, context)
 
     async def show_danger_delete_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מציג תפריט מחיקות מסוכן"""

--- a/tests/test_github_delete_repo_scope.py
+++ b/tests/test_github_delete_repo_scope.py
@@ -46,6 +46,23 @@ class _Context:
         self.bot_data = {}
 
 
+class _FakeGithubException(gmh.GithubException):
+    """חריגה תואמת GithubException עם status/data ניתנים להגדרה.
+
+    ב-PyGithub האמיתי (כפי שמותקן ב-CI) השדות ``status`` ו-``data`` הם
+    properties לקריאה בלבד, ולכן השמה ישירה אליהם זורקת AttributeError.
+    כאן אנחנו מצלילים אותם כתכונות מחלקה רגילות (הן קודמות ב-MRO לפרופרטי
+    של מחלקת האב), כך שאפשר להגדיר אותם בטסט בלי תלות בגרסת PyGithub.
+    """
+
+    status = None
+    data = None
+
+    def __init__(self, status, data):
+        self.status = status
+        self.data = data
+
+
 class _FakeRepoOwner:
     def __init__(self, login):
         self.login = login
@@ -93,7 +110,11 @@ def _build_handler(monkeypatch, fake_github):
     handler.user_sessions[5] = {"selected_repo": "octocat/demo", "github_token": "ghp_x"}
     monkeypatch.setattr(handler, "get_user_token", lambda uid: "ghp_x")
 
+    # נעקוב אחרי קריאות לרענון התפריט כדי לוודא שלא דורסים הודעות שגיאה/עזרה.
+    handler.menu_calls = []
+
     async def _noop_menu(update, context):
+        handler.menu_calls.append(True)
         return None
 
     monkeypatch.setattr(handler, "github_menu_command", _noop_menu)
@@ -114,6 +135,8 @@ async def test_delete_repo_blocked_when_scope_missing(monkeypatch):
     assert "delete_repo" in last
     # לא בוצעה מחיקה בפועל
     assert repo_holder["repo"].deleted is False
+    # לא דורסים את ההסבר ברענון התפריט
+    assert handler.menu_calls == []
 
 
 @pytest.mark.asyncio
@@ -127,15 +150,15 @@ async def test_delete_repo_success_when_scope_present(monkeypatch):
 
     assert repo_holder["repo"].deleted is True
     assert any("נמחק בהצלחה" in t for t in update.callback_query.message.texts)
+    # במסלול ההצלחה כן מרעננים את התפריט
+    assert handler.menu_calls == [True]
 
 
 @pytest.mark.asyncio
 async def test_delete_repo_403_admin_rights_shows_scope_help(monkeypatch):
     """אם ה-scopes לא ידועים (טוקן fine-grained) ו-GitHub מחזיר 403 admin rights –
     מציגים את הסבר ה-delete_repo במקום השגיאה הגולמית."""
-    exc = gmh.GithubException("403")
-    exc.status = 403
-    exc.data = {"message": "Must have admin rights to Repository."}
+    exc = _FakeGithubException(403, {"message": "Must have admin rights to Repository."})
     fake_github, _ = _make_fake_github(oauth_scopes=None, delete_exc=exc)
     handler = _build_handler(monkeypatch, fake_github)
     update, context = _Update(), _Context()
@@ -144,3 +167,5 @@ async def test_delete_repo_403_admin_rights_shows_scope_help(monkeypatch):
 
     last = update.callback_query.message.texts[-1]
     assert "delete_repo" in last
+    # גם כאן ההסבר נשאר על המסך ולא מרעננים את התפריט
+    assert handler.menu_calls == []

--- a/tests/test_github_delete_repo_scope.py
+++ b/tests/test_github_delete_repo_scope.py
@@ -1,0 +1,146 @@
+"""בדיקות למחיקת ריפו ב-GitHub כשלטוקן חסרה הרשאת delete_repo.
+
+הרקע: כשמוחקים ריפו דרך ה-API עם טוקן שאין לו את ההרשאה ``delete_repo``,
+GitHub מחזיר 403 "Must have admin rights to Repository" – גם כשהמשתמש הוא
+הבעלים. הבוט אמור לזהות את המקרה ולהציג הסבר ברור במקום שגיאה מבלבלת.
+"""
+import types
+
+import pytest
+
+import github_menu_handler as gmh
+
+
+class _Msg:
+    def __init__(self):
+        self.texts = []
+
+    async def edit_text(self, text, **kwargs):
+        self.texts.append(text)
+        return self
+
+
+class _Query:
+    def __init__(self, user_id=5):
+        self.message = _Msg()
+        self.data = ""
+        self.from_user = types.SimpleNamespace(id=user_id)
+
+    async def edit_message_text(self, text, **kwargs):
+        self.message.texts.append(text)
+        return self.message
+
+    async def answer(self, *args, **kwargs):
+        return None
+
+
+class _Update:
+    def __init__(self, user_id=5):
+        self.callback_query = _Query(user_id)
+        self.effective_user = types.SimpleNamespace(id=user_id)
+
+
+class _Context:
+    def __init__(self):
+        self.user_data = {}
+        self.bot_data = {}
+
+
+class _FakeRepoOwner:
+    def __init__(self, login):
+        self.login = login
+
+
+class _FakeRepo:
+    def __init__(self, owner_login, delete_exc=None):
+        self.owner = _FakeRepoOwner(owner_login)
+        self._delete_exc = delete_exc
+        self.deleted = False
+
+    def delete(self):
+        if self._delete_exc is not None:
+            raise self._delete_exc
+        self.deleted = True
+
+
+class _FakeUser:
+    def __init__(self, login):
+        self.login = login
+
+
+def _make_fake_github(owner_login="octocat", oauth_scopes=None, delete_exc=None):
+    """מחזיר מחלקה שמחקה את PyGithub.Github עם scopes/בעלים נשלטים."""
+    repo_holder = {}
+
+    class _FakeGithub:
+        def __init__(self, token):
+            self.token = token
+            self.oauth_scopes = oauth_scopes
+
+        def get_repo(self, name):
+            repo = _FakeRepo(owner_login, delete_exc=delete_exc)
+            repo_holder["repo"] = repo
+            return repo
+
+        def get_user(self):
+            return _FakeUser("octocat")
+
+    return _FakeGithub, repo_holder
+
+
+def _build_handler(monkeypatch, fake_github):
+    handler = gmh.GitHubMenuHandler()
+    handler.user_sessions[5] = {"selected_repo": "octocat/demo", "github_token": "ghp_x"}
+    monkeypatch.setattr(handler, "get_user_token", lambda uid: "ghp_x")
+
+    async def _noop_menu(update, context):
+        return None
+
+    monkeypatch.setattr(handler, "github_menu_command", _noop_menu)
+    monkeypatch.setattr(gmh, "Github", fake_github)
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_delete_repo_blocked_when_scope_missing(monkeypatch):
+    """כשידוע ש-delete_repo חסרה בכותרת ה-scopes – חוסמים מראש ולא קוראים ל-delete()."""
+    fake_github, repo_holder = _make_fake_github(oauth_scopes=["repo", "gist"])
+    handler = _build_handler(monkeypatch, fake_github)
+    update, context = _Update(), _Context()
+
+    await handler.confirm_delete_repo(update, context)
+
+    last = update.callback_query.message.texts[-1]
+    assert "delete_repo" in last
+    # לא בוצעה מחיקה בפועל
+    assert repo_holder["repo"].deleted is False
+
+
+@pytest.mark.asyncio
+async def test_delete_repo_success_when_scope_present(monkeypatch):
+    """כש-delete_repo קיימת – המחיקה מתבצעת ומוצגת הודעת הצלחה."""
+    fake_github, repo_holder = _make_fake_github(oauth_scopes=["repo", "delete_repo"])
+    handler = _build_handler(monkeypatch, fake_github)
+    update, context = _Update(), _Context()
+
+    await handler.confirm_delete_repo(update, context)
+
+    assert repo_holder["repo"].deleted is True
+    assert any("נמחק בהצלחה" in t for t in update.callback_query.message.texts)
+
+
+@pytest.mark.asyncio
+async def test_delete_repo_403_admin_rights_shows_scope_help(monkeypatch):
+    """אם ה-scopes לא ידועים (טוקן fine-grained) ו-GitHub מחזיר 403 admin rights –
+    מציגים את הסבר ה-delete_repo במקום השגיאה הגולמית."""
+    exc = gmh.GithubException("403")
+    exc.status = 403
+    exc.data = {"message": "Must have admin rights to Repository."}
+    fake_github, _ = _make_fake_github(oauth_scopes=None, delete_exc=exc)
+    handler = _build_handler(monkeypatch, fake_github)
+    update, context = _Update(), _Context()
+
+    await handler.confirm_delete_repo(update, context)
+
+    last = update.callback_query.message.texts[-1]
+    assert "delete_repo" in last


### PR DESCRIPTION
## ✨ תיאור קצר
תוקנה בעיה שבה משתמשים קיבלו הודעת שגיאה מבלבלת ("Must have admin rights to Repository") כשניסו למחוק ריפו דרך הבוט, גם כשהם בעלים. הבעיה היא שלטוקן שלהם חסרה הרשאת `delete_repo`. הוספנו בדיקה מקדימה וטיפול חריגות שמציג הסבר ברור עם הוראות לתיקון.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [x] בוט טלגרם
- [x] תיעוד (docs/)

### פירוט:
- **בדיקה מקדימה בטוקנים Classic:** לפני ניסיון מחיקה, בודקים את רשימת ה-scopes שחוזרת מ-GitHub. אם `delete_repo` חסרה – מציגים הסבר ברור במקום להריץ את המחיקה ולקבל 403.
- **טיפול חריגות ל-403 "admin rights":** אם GitHub מחזיר 403 עם הודעה על admin rights או delete_repo, מציגים את אותו הסבר עזרה (למקרה של טוקנים fine-grained שלא מחזירים את ה-scopes).
- **הודעת עזרה מפורטת:** הוספנו `_DELETE_REPO_SCOPE_HELP` שמסביר בדיוק מה הבעיה וכיצד לתקן (צור טוקן חדש עם `delete_repo`).
- **עדכון הנחיות הטוקן:** בהודעת ה-login וב-GUIDES, הבהרנו שהרשאות מומלצות הן `repo` ו-`gist`, ו-`delete_repo` נדרשת רק אם רוצים למחוק ריפו.
- **בדיקות יחידה:** הוספנו 3 בדיקות שמכסות את כל המקרים: חסימה כשחסרה ה-scope, הצלחה כשקיימת, וטיפול 403 כשה-scopes לא ידועים.

## 🧪 בדיקות
- [x] Unit: הוספנו `tests/test_github_delete_repo_scope.py` עם 3 בדיקות שמכסות את כל הסיטואציות
  - `test_delete_repo_blocked_when_scope_missing`: בדיקה שהמחיקה חסומה כשידוע שחסרה `delete_repo`
  - `test_delete_repo_success_when_scope_present`: בדיקה שהמחיקה מתבצעת כשה-scope קיימת
  - `test_delete_repo_403_admin_rights_shows_scope_help`: בדיקה שטיפול החריגות מציג את ההסבר הנכון
- [x] Integration: הבדיקות משתמשות ב-mock של PyGithub ובודקות את הזרימה המלאה

## 📝 סוג שינוי
- [x] fix: תיקון באג – הודעות ש

https://claude.ai/code/session_01Sz2Di3c2tfCyCbsSSdXHn4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * נוספו הנחיות ברורות יותר ליצירת טוקן GitHub עבור פעולות מחיקה, כולל הסבר מתי נדרשת הרשאת `delete_repo`.
  * שופרה חוויית המחיקה כך שמוצגת הודעת עזרה מסודרת כאשר חסרה הרשאה מתאימה.

* **Bug Fixes**
  * נמנעת כעת מחיקה כאשר לטוקן חסרה ההרשאה הדרושה.
  * שגיאות 403 מוצגות עם הסבר ידידותי יותר במקום הודעה כללית.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->