### PR TITLE
feat: אינדוקס ROADMAP.md גם כשהוא עובר את מגבלת הגודל

### DIFF
--- a/services/code_indexer.py
+++ b/services/code_indexer.py
@@ -166,6 +166,11 @@ class CodeIndexer:
     # חשוב: משתמשים בנתיב רלטיבי בפורמט POSIX (למשל webapp/app.py)
     LARGE_FILE_ALLOWLIST = {"webapp/app.py"}
 
+    # allowlist לפי שם-קובץ בלבד (basename), ללא תלות במיקום בתיקיות.
+    # שימושי למסמכים שחשוב לאנדקס גם כשהם עוברים את מגבלת הגודל
+    # (למשל ROADMAP.md שנמצא בשורש הריפו או בתיקיית docs).
+    LARGE_FILE_ALLOWLIST_BASENAMES = {"ROADMAP.md"}
+
     def __init__(self, db: Any = None):
         """
         Args:
@@ -245,7 +250,12 @@ class CodeIndexer:
 
         # בדיקת גודל
         normalized_path = file_path.replace("\\", "/").lstrip("/")
-        if len(content) > self.MAX_FILE_SIZE and normalized_path not in self.LARGE_FILE_ALLOWLIST:
+        basename = normalized_path.rsplit("/", 1)[-1]
+        allowlisted = (
+            normalized_path in self.LARGE_FILE_ALLOWLIST
+            or basename in self.LARGE_FILE_ALLOWLIST_BASENAMES
+        )
+        if len(content) > self.MAX_FILE_SIZE and not allowlisted:
             logger.info(f"Skipping large file ({len(content)} bytes): {file_path}")
             return False
 

--- a/tests/test_code_indexer.py
+++ b/tests/test_code_indexer.py
@@ -110,3 +110,34 @@ def test_index_file_allows_webapp_app_py_even_if_large():
     assert idx.index_file("Repo", "/webapp/app.py", large_content, commit_sha="b" * 40) is True
     assert idx.index_file("Repo", "webapp\\app.py", large_content, commit_sha="c" * 40) is True
 
+
+def test_index_file_allows_roadmap_md_even_if_large():
+    """ROADMAP.md מוחרג לפי שם-קובץ (basename), כך שהוא מאונדקס גם מעל המגבלה
+    וללא תלות במיקומו בתיקיות (שורש/‏docs וכו')."""
+    class _FakeRepoFiles:
+        def __init__(self):
+            self.last_set = None
+
+        def update_one(self, filt, update, upsert=False):
+            self.last_set = update.get("$set", {})
+            return None
+
+    class _FakeDb:
+        def __init__(self):
+            self.repo_files = _FakeRepoFiles()
+
+    db = _FakeDb()
+    idx = CodeIndexer(db=db)
+
+    large_content = "a" * (idx.MAX_FILE_SIZE + 1)
+
+    # ROADMAP.md בשורש הריפו – מאונדקס למרות הגודל
+    assert idx.index_file("Repo", "ROADMAP.md", large_content, commit_sha="a" * 40) is True
+    assert db.repo_files.last_set["path"] == "ROADMAP.md"
+
+    # וגם בתוך תיקייה (basename זהה) – מאונדקס
+    assert idx.index_file("Repo", "docs/ROADMAP.md", large_content, commit_sha="b" * 40) is True
+
+    # קובץ md גדול אחר (שם שונה) עדיין ידולג
+    assert idx.index_file("Repo", "docs/HUGE_NOTES.md", large_content, commit_sha="c" * 40) is False
+


### PR DESCRIPTION
## ✨ תיאור קצר
קבצים מעל `MAX_FILE_SIZE` (500KB) מדולגים באינדוקס, ולכן `ROADMAP.md` של ריפו גדול לא נכלל בחיפוש. הוספתי החרגה לפי שם‑קובץ (basename) כך ש‑`ROADMAP.md` תמיד מאונדקס — ללא תלות במיקומו בתיקיות (שורש או `docs/`).

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [ ] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- הוספת `LARGE_FILE_ALLOWLIST_BASENAMES = {"ROADMAP.md"}` ב‑`services/code_indexer.py`.
- `index_file` בודק כעת גם התאמת basename, בנוסף ל‑allowlist הנתיבי הקיים (`webapp/app.py`).

## 🧪 בדיקות
- הרצתי `pytest tests/test_code_indexer.py` — 8/8 עוברים.
- [x] Unit
- [ ] Integration
- [ ] Manual

בדיקה חדשה `test_index_file_allows_roadmap_md_even_if_large`: ROADMAP.md גדול מאונדקס (גם בשורש וגם ב‑`docs/`), אבל קובץ `.md` גדול אחר (שם שונה) עדיין מדולג.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [ ] תיעוד עודכן — לא נדרש (שינוי לוגי נקודתי)
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root
- [x] הודעת הקומיט תואמת Conventional Commits

עיינתי בתיעוד הפרויקט ([CodeBot Docs](https://amirbiron.github.io/CodeBot/)) בהתאם למדיניות.

## 🔁 Rollback והשפעה על Deploy
- שינוי מבודד; ניתן `git revert` לקומיט בלי תופעות לוואי.
- **חשוב:** אחרי מיזוג ל‑`main` ופריסה ל‑Render, יש להריץ מחדש את ייבוא הריפו (`initial_import`) כדי ש‑`ROADMAP.md` יאונדקס בפועל — האינדקס הקיים לא מתעדכן רטרואקטיבית.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sz2Di3c2tfCyCbsSSdXHn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sz2Di3c2tfCyCbsSSdXHn4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * קבצים גדולים בשם `ROADMAP.md` ייכללו מעתה באינדוקס גם אם הם חורגים ממגבלת הגודל.
  * ההתנהגות חלה גם כשקובץ כזה נמצא בתיקיות שונות, ולא רק במיקום מסוים.
  * קבצים גדולים אחרים שאינם ברשימה ימשיכו להיות מדולגים כרגיל.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->