### PR TITLE
feat: תמיכה בכמה טוקני GitHub לפי ארגון (GITHUB_TOKENS)

### DIFF
--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -166,6 +166,12 @@
      - -
      - ``ghp_xxx...``
      - Bot/WebApp
+   * - ``GITHUB_TOKENS``
+     - מיפוי בעלים(owner/org)→טוקן לסנכרון ריפואים ממספר ארגונים, כשטוקן יחיד לא מכסה את כולם. פורמט JSON (``{"Org": "ghp_..."}``) או פשוט (``Org1=ghp_...,Org2=github_pat_...``). נבחר לפי הבעלים של הריפו; אם אין התאמה נופלים ל-``GITHUB_TOKEN``.
+     - לא
+     - -
+     - ``Org1=ghp_xxx,Org2=github_pat_yyy``
+     - Bot/WebApp
    * - ``GITHUB_WEBHOOK_SECRET``
      - סוד לאימות GitHub Webhook (HMAC SHA256) עבור ``POST /api/webhooks/github``. אם לא מוגדר, ה-webhook ייחסם (401) ולא יתבצע Sync אוטומטי.
      - כן (Repo Sync)

--- a/services/config_inspector_service.py
+++ b/services/config_inspector_service.py
@@ -540,6 +540,17 @@ class ConfigService:
             category="repo_sync",
             sensitive=True,
         ),
+        "GITHUB_TOKENS": ConfigDefinition(
+            key="GITHUB_TOKENS",
+            default="",
+            description=(
+                "מיפוי בעלים(owner/org)→טוקן לסנכרון ריפואים ממספר ארגונים, כשטוקן יחיד לא מכסה את כולם. "
+                "פורמט JSON: {\"Org\": \"ghp_...\"} או פשוט: Org1=ghp_...,Org2=github_pat_.... "
+                "נבחר לפי הבעלים של הריפו; אם אין התאמה נופלים ל-GITHUB_TOKEN."
+            ),
+            category="repo_sync",
+            sensitive=True,
+        ),
         "BOT_JOBS_API_BASE_URL": ConfigDefinition(
             key="BOT_JOBS_API_BASE_URL",
             default="",

--- a/services/git_mirror_service.py
+++ b/services/git_mirror_service.py
@@ -11,6 +11,7 @@ Git Mirror Service - ניהול מראה Git מקומי על Render Disk
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -94,6 +95,10 @@ class GitMirrorService:
     _GITHUB_HTTPS_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+(?:\.git)?/?$", re.IGNORECASE)
     _GITHUB_SSH_RE = re.compile(r"^git@github\.com:[^/\s]+/[^/\s]+(?:\.git)?$", re.IGNORECASE)
 
+    # חילוץ בעלים (owner/org) מתוך URL של GitHub – לבחירת טוקן פר-ארגון
+    _OWNER_HTTPS_RE = re.compile(r"^https://github\.com/([^/\s]+)/", re.IGNORECASE)
+    _OWNER_SSH_RE = re.compile(r"^git@github\.com:([^/\s]+)/", re.IGNORECASE)
+
     def __init__(
         self,
         base_path: Optional[str] = None,
@@ -148,6 +153,80 @@ class GitMirrorService:
             return False
         return bool(self._GITHUB_HTTPS_RE.fullmatch(url) or self._GITHUB_SSH_RE.fullmatch(url))
 
+    @staticmethod
+    def _load_github_token_map() -> Dict[str, str]:
+        """
+        טוען מיפוי בעלים(owner/org)→טוקן מתוך משתנה הסביבה ``GITHUB_TOKENS``.
+
+        זה מאפשר לסנכרן ריפואים ממספר ארגונים שונים, כל אחד עם טוקן משלו,
+        כשטוקן classic יחיד לא יכול לכסות את כולם.
+
+        פורמטים נתמכים:
+        - JSON:  ``{"Campaign-AI4U": "ghp_xxx", "OtherOrg": "github_pat_yyy"}``
+        - פשוט:  ``Campaign-AI4U=ghp_xxx,OtherOrg=github_pat_yyy``
+          (מפריד בין זוגות: פסיק/נקודה-פסיק/שורה חדשה; מפריד owner/token: ``=`` או ``:``)
+
+        המפתחות מוחזרים ב-lowercase (בעלים ב-GitHub הם case-insensitive).
+        """
+        raw = (os.getenv("GITHUB_TOKENS", "") or "").strip()
+        if not raw:
+            return {}
+
+        result: Dict[str, str] = {}
+
+        # פורמט JSON
+        if raw.startswith("{"):
+            try:
+                data = json.loads(raw)
+            except Exception:
+                logger.warning("GITHUB_TOKENS is set but is not valid JSON; ignoring it")
+                return {}
+            if isinstance(data, dict):
+                for owner, token in data.items():
+                    owner_s = str(owner).strip().lower()
+                    token_s = str(token).strip()
+                    if owner_s and token_s:
+                        result[owner_s] = token_s
+            return result
+
+        # פורמט פשוט: owner=token,owner2=token2
+        for pair in re.split(r"[,\n;]+", raw):
+            m = re.match(r"^\s*([^=:\s]+)\s*[=:]\s*(.+?)\s*$", pair)
+            if not m:
+                continue
+            owner_s = m.group(1).strip().lower()
+            token_s = m.group(2).strip()
+            if owner_s and token_s:
+                result[owner_s] = token_s
+        return result
+
+    def _extract_owner(self, url: str) -> str:
+        """מחלץ את שם הבעלים/הארגון מ-URL של GitHub (HTTPS או SSH)."""
+        if not isinstance(url, str):
+            return ""
+        u = url.strip()
+        m = self._OWNER_HTTPS_RE.match(u) or self._OWNER_SSH_RE.match(u)
+        return m.group(1) if m else ""
+
+    def _token_for_url(self, url: str) -> Optional[str]:
+        """
+        בוחר את הטוקן המתאים ל-URL לפי סדר עדיפויות:
+        1. טוקן שהוזרק במפורש ל-constructor (override).
+        2. טוקן פר-בעלים מתוך ``GITHUB_TOKENS`` (לפי הארגון של הריפו).
+        3. ``GITHUB_TOKEN`` הגלובלי כברירת מחדל.
+        """
+        if self.github_token:
+            return self.github_token
+
+        owner = self._extract_owner(url)
+        if owner:
+            token_map = self._load_github_token_map()
+            token = token_map.get(owner.lower())
+            if token:
+                return token
+
+        return os.getenv("GITHUB_TOKEN") or None
+
     def _get_authenticated_url(self, url: str) -> str:
         """
         הזרקת GitHub Token ל-URL לתמיכה ב-Private Repos
@@ -160,8 +239,10 @@ class GitMirrorService:
 
         Note:
             לא לרשום את ה-URL המאומת ללוגים!
+            בחירת הטוקן נעשית לפי הבעלים של הריפו (ראו _token_for_url),
+            כדי לתמוך בסנכרון ריפואים ממספר ארגונים עם טוקנים שונים.
         """
-        token = self.github_token or os.getenv("GITHUB_TOKEN")
+        token = self._token_for_url(url)
 
         if not token:
             return url

--- a/tests/test_git_mirror_service.py
+++ b/tests/test_git_mirror_service.py
@@ -136,3 +136,66 @@ def test_get_mirror_info_ignores_deleted_files_during_size_calc(service, monkeyp
     assert info is not None
     assert info["size_bytes"] == 15
 
+
+
+# ============================================
+# ריבוי טוקנים לפי ארגון (GITHUB_TOKENS)
+# ============================================
+
+def test_extract_owner_https_and_ssh(service):
+    assert service._extract_owner("https://github.com/Campaign-AI4U/campaign-ai.git") == "Campaign-AI4U"
+    assert service._extract_owner("https://github.com/octocat/Hello-World") == "octocat"
+    assert service._extract_owner("git@github.com:MyOrg/repo.git") == "MyOrg"
+    assert service._extract_owner("not-a-url") == ""
+
+
+def test_token_map_simple_format_selects_per_owner(service, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKENS", "Campaign-AI4U=ghp_AAA,OtherOrg=github_pat_BBB")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_GLOBAL")
+
+    # ארגון ממופה → הטוקן שלו
+    assert service._token_for_url("https://github.com/Campaign-AI4U/campaign-ai.git") == "ghp_AAA"
+    # התאמת בעלים היא case-insensitive
+    assert service._token_for_url("https://github.com/otherorg/foo.git") == "github_pat_BBB"
+    # ארגון לא ממופה → נפילה ל-GITHUB_TOKEN הגלובלי
+    assert service._token_for_url("https://github.com/ThirdOrg/bar.git") == "ghp_GLOBAL"
+
+
+def test_token_map_json_format(service, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKENS", '{"Campaign-AI4U": "ghp_JSON_A", "OtherOrg": "ghp_JSON_B"}')
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert service._token_for_url("https://github.com/Campaign-AI4U/campaign-ai.git") == "ghp_JSON_A"
+    assert service._token_for_url("https://github.com/OtherOrg/x.git") == "ghp_JSON_B"
+    # ארגון לא ממופה ואין GITHUB_TOKEN → None (לא מזריקים טוקן)
+    assert service._token_for_url("https://github.com/Nobody/y.git") is None
+
+
+def test_token_fallback_to_global_when_no_map(service, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKENS", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_GLOBAL")
+    assert service._token_for_url("https://github.com/anyone/x.git") == "ghp_GLOBAL"
+
+
+def test_invalid_json_token_map_is_ignored(service, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKENS", "{not valid json")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_GLOBAL")
+    # JSON שבור → מתעלמים מהמפה ונופלים ל-GITHUB_TOKEN
+    assert service._token_for_url("https://github.com/Campaign-AI4U/campaign-ai.git") == "ghp_GLOBAL"
+
+
+def test_authenticated_url_injects_per_owner_token(service, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKENS", "Campaign-AI4U=ghp_AAA")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_GLOBAL")
+    url = service._get_authenticated_url("https://github.com/Campaign-AI4U/campaign-ai.git")
+    assert url == "https://oauth2:ghp_AAA@github.com/Campaign-AI4U/campaign-ai.git"
+    # ארגון לא ממופה → הטוקן הגלובלי
+    url2 = service._get_authenticated_url("https://github.com/Zzz/repo.git")
+    assert url2 == "https://oauth2:ghp_GLOBAL@github.com/Zzz/repo.git"
+
+
+def test_constructor_token_overrides_map(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKENS", "Campaign-AI4U=ghp_AAA")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_GLOBAL")
+    svc = GitMirrorService(base_path=str(tmp_path), github_token="ghp_EXPLICIT")
+    # טוקן שהוזרק במפורש ל-constructor גובר על הכל
+    assert svc._token_for_url("https://github.com/Campaign-AI4U/campaign-ai.git") == "ghp_EXPLICIT"


### PR DESCRIPTION
## ✨ תיאור קצר
עד עכשיו הסנכרון השתמש ב-`GITHUB_TOKEN` גלובלי יחיד, ולכן אי אפשר היה לסנכרן ריפואים משני **ארגונים שונים** כשאין טוקן classic אחד שמכסה את שניהם. נוסף משתנה env אופציונלי **`GITHUB_TOKENS`** שממפה בעלים(owner/org)→טוקן, כך שכל ריפו מסונכרן עם הטוקן הנכון לו.

## 📦 שינויים עיקריים
- [x] קוד (Backend)
- [ ] בוט טלגרם
- [ ] מסד נתונים/מיגרציות
- [x] תיעוד (docs/)
- [ ] DevOps/CI/CD

פירוט נקודות:
- `services/git_mirror_service.py`: בחירת טוקן לפי הבעלים של הריפו (`_token_for_url`), עם חילוץ owner מה-URL (HTTPS/SSH) וטעינת מיפוי מ-`GITHUB_TOKENS`.
- סדר עדיפויות: טוקן מפורש ב-constructor ⟶ מיפוי פר-ארגון (`GITHUB_TOKENS`) ⟶ `GITHUB_TOKEN` הגלובלי.
- שני פורמטים ל-`GITHUB_TOKENS`: JSON (`{"Org": "ghp_..."}`) או פשוט (`Org1=ghp_...,Org2=github_pat_...`). התאמת בעלים case-insensitive; JSON שבור — מתעלמים ממנו בבטחה.
- הטוקן נצרב ל-mirror בזמן ה-clone, כך שכל ריפו שומר את הטוקן הנכון גם ל-fetch-ים העתידיים (webhook delta sync).

## 🧪 בדיקות
- `pytest tests/test_git_mirror_service.py` — 15/15 עוברים.
- [x] Unit
- [ ] Integration
- [ ] Manual

בדיקות חדשות: חילוץ owner (HTTPS/SSH), בחירת טוקן פר-ארגון (JSON ופשוט), case-insensitive, נפילה ל-`GITHUB_TOKEN`, JSON שבור מתעלמים, הזרקת הטוקן הנכון ל-URL, ו-override של constructor.

## 🧪 בדיקות נדרשות ב‑PR
- 🔍 Code Quality & Security
- Unit Tests (3.11)
- Unit Tests (3.12)

## 📝 סוג שינוי
- [x] feat: פיצ'ר חדש

## ✅ צ'קליסט
- [x] הקוד עוקב אחרי הסגנון (Black/isort/flake8/mypy)
- [x] בדיקות רצות ועוברות
- [x] תיעוד עודכן — `docs/environment-variables.rst`
- [x] אם נוספו/שונו משתני סביבה – עודכן `docs/environment-variables.rst` **וגם** `services/config_inspector_service.py`
- [x] אין סודות/מפתחות בקוד
- [x] אין מחיקות מסוכנות/פעולות על root
- [x] הודעת הקומיט תואמת Conventional Commits

עיינתי בתיעוד הפרויקט ([CodeBot Docs](https://amirbiron.github.io/CodeBot/)) בהתאם למדיניות.

## 🧩 אבטחה / השפעה
- `GITHUB_TOKENS` מסומן sensitive ב-config inspector, ונחשף ב-URL רק בזמן clone/fetch (עם redaction בלוגים כמו קודם).
- **תאימות לאחור מלאה:** אם `GITHUB_TOKENS` לא מוגדר — ההתנהגות זהה לחלוטין לקודם (נפילה ל-`GITHUB_TOKEN`).

## 🔁 שימוש
```
GITHUB_TOKENS=Campaign-AI4U=ghp_xxx,OtherOrg=github_pat_yyy
```
או JSON:
```
GITHUB_TOKENS={"Campaign-AI4U": "ghp_xxx", "OtherOrg": "github_pat_yyy"}
```
הערה: ל-mirror שכבר קיים הטוקן כבר צרוב מה-clone הקודם; המיפוי משפיע על clone חדש (ריפו חדש / re-clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sz2Di3c2tfCyCbsSSdXHn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sz2Di3c2tfCyCbsSSdXHn4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * נוספה תמיכה בהגדרת כמה טוקנים ל-GitHub לפי ארגון/בעלים, כך שסנכרון ריפואים פרטיים ממספר מקורות נעשה גמיש יותר.

* **Bug Fixes**
  * שופר זיהוי הבעלים מכתובות HTTPS ו-SSH.
  * במקרים ללא התאמה למיפוי, המערכת נופלת אוטומטית לטוקן הכללי.
  * טוקן שהוזן ישירות עדיין גובר על הגדרות אחרות.

* **Documentation**
  * עודכן התיעוד עם פירוט על פורמטי ההגדרה האפשריים וההתנהגות במקרה של חוסר התאמה.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->